### PR TITLE
go back to 5 attempts per notarization call

### DIFF
--- a/iscript/src/iscript/mac.py
+++ b/iscript/src/iscript/mac.py
@@ -806,7 +806,6 @@ async def wrap_notarization_with_sudo(
                             "exception": IScriptError,
                         },
                         retry_exceptions=(IScriptError,),
-                        attempts=10,
                     )
                 )
             )
@@ -901,7 +900,6 @@ async def poll_notarization_uuid(
                 "exception": IScriptError,
             },
             retry_exceptions=(IScriptError,),
-            attempts=10,
         )
         status = get_notarization_status_from_log(log_path)
         if status == "success":
@@ -975,7 +973,6 @@ async def staple_notarization(all_paths, path_attr="app_path"):
                         "log_level": logging.DEBUG,
                     },
                     retry_exceptions=(IScriptError,),
-                    attempts=10,
                 )
             )
         )


### PR DESCRIPTION
I added 10 attempts to give Apple more time to get things working on the
back end. However, today it seems to just delay when we get the error
messages, rather than resulting in a slower but green task.

If we decide we want to go back to 5 retry attempts, this is how we'd do
it.