### PR TITLE
Fix tox

### DIFF
--- a/iscript/src/iscript/mac.py
+++ b/iscript/src/iscript/mac.py
@@ -500,7 +500,7 @@ def get_app_paths(config, task):
 
 
 def filter_apps(all_paths, fmt, inverted=False):
-    """Filters through a list of apps and returns a list of apps back based on filter.
+    """Filter all_apps by format.
 
     Args:
         all_paths: list of App objects

--- a/iscript/tox.ini
+++ b/iscript/tox.ini
@@ -36,7 +36,7 @@ whitelist_externals =
     test
 
 commands=
-    bash -c 'test "{env:TRAVIS:missing}" != "missing" && coveralls || echo "Skipping coveralls outside of travis"'
+    - coveralls
 
 [testenv:mypy]
 usedevelop = true

--- a/scriptworker_client/tox.ini
+++ b/scriptworker_client/tox.ini
@@ -32,7 +32,7 @@ whitelist_externals =
     test
 
 commands =
-    bash -c 'test "{env:TRAVIS:missing}" != "missing" && coveralls || echo "Skipping coveralls outside of travis"'
+    - coveralls
 
 [testenv:mypy]
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -24,32 +24,32 @@ passenv =
 [testenv:client-py36]
 changedir = {toxinidir}/scriptworker_client
 commands =
-    - tox -e py36
+    tox -e py36
 
 [testenv:client-py37]
 changedir = {toxinidir}/scriptworker_client
 commands =
-    - tox -e py37,mypy
+    tox -e py37,mypy
     - tox -e coveralls
 
 [testenv:iscript-py36]
 changedir = {toxinidir}/iscript
 commands =
-    - tox -e py36
+    tox -e py36
 
 [testenv:iscript-py37]
 changedir = {toxinidir}/iscript
 commands =
-    - tox -e py37,mypy
+    tox -e py37,mypy
     - tox -e coveralls
 
 [testenv:treescript-py36]
 changedir = {toxinidir}/treescript
 commands =
-    - tox -e py36
+    tox -e py36
 
 [testenv:treescript-py37]
 changedir = {toxinidir}/treescript
 commands =
-    - tox -e py37,mypy
+    tox -e py37,mypy
     - tox -e coveralls

--- a/treescript/tests/test_versionmanip.py
+++ b/treescript/tests/test_versionmanip.py
@@ -115,7 +115,7 @@ def test_find_what_version_parser_to_use(file, expectation, expected_result):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "new_version, should_append_esr", (("87.0", True), ("87.0b3", False))
+    "new_version, should_append_esr", (("68.0", True), ("68.0b3", False))
 )
 async def test_bump_version(mocker, repo_context, new_version, should_append_esr):
     called_args = []
@@ -140,7 +140,7 @@ async def test_bump_version(mocker, repo_context, new_version, should_append_esr
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("new_version", ("87.0", "87.0b3"))
+@pytest.mark.parametrize("new_version", ("68.0", "68.0b3"))
 async def test_bump_version_DONTBUILD_true(mocker, repo_context, new_version):
     called_args = []
 
@@ -161,7 +161,7 @@ async def test_bump_version_DONTBUILD_true(mocker, repo_context, new_version):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("new_version", ("87.0", "87.0b3"))
+@pytest.mark.parametrize("new_version", ("68.0", "68.0b3"))
 async def test_bump_version_DONTBUILD_false(mocker, repo_context, new_version):
     called_args = []
 
@@ -235,7 +235,7 @@ async def test_bump_version_missing_file(mocker, repo_context, new_version):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("new_version", ("27.0", "26.0b3", "45.0esr"))
+@pytest.mark.parametrize("new_version", ("24.0", "31.0b3", "45.0esr"))
 async def test_bump_version_smaller_version(mocker, repo_context, new_version):
     called_args = []
 
@@ -257,7 +257,7 @@ async def test_bump_version_smaller_version(mocker, repo_context, new_version):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "new_version,expect_version",
-    (("87.0", "87.0esr"), ("92.0.1", "92.0.1esr"), ("76.9.10esr", "76.9.10esr")),
+    (("60.2.0", "60.2.0esr"), ("68.0.1", "68.0.1esr"), ("68.9.10esr", "68.9.10esr")),
 )
 async def test_bump_version_esr(mocker, repo_context, new_version, expect_version):
     if not repo_context.xtest_version.endswith("esr"):
@@ -283,12 +283,12 @@ async def test_bump_version_esr(mocker, repo_context, new_version, expect_versio
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "new_version,expect_esr_version", (("87.0", "87.0esr"), ("92.0.1", "92.0.1esr"))
+    "new_version,expect_esr_version", (("60.0", "60.0esr"), ("68.0.1", "68.0.1esr"))
 )
 async def test_bump_version_esr_dont_bump_non_esr(
     mocker, config, tmpdir, new_version, expect_esr_version
 ):
-    version = "56.0.1"
+    version = "52.0.1"
     repo = os.path.join(tmpdir, "repo")
     os.mkdir(repo)
     os.mkdir(os.path.join(repo, "config"))

--- a/treescript/tox.ini
+++ b/treescript/tox.ini
@@ -33,7 +33,7 @@ whitelist_externals =
     test
 
 commands =
-    bash -c 'test "{env:TRAVIS:missing}" != "missing" && coveralls || echo "Skipping coveralls outside of travis"'
+    - coveralls
 
 [testenv:mypy]
 usedevelop = true


### PR DESCRIPTION
This patch:

- fixes tox. In #13, we saw that tox run from the top level of the repo ignores errors. This is from the prepended `-` in the command. Fixed.
- fixes iscript flake8
- fixes treescript tests from the new, stricter mozilla-version (#14).