### PR TITLE
Skip listing directories in tarballs

### DIFF
--- a/docker.d/init.sh
+++ b/docker.d/init.sh
@@ -40,6 +40,10 @@ case $ENV in
     ;;
   dev)
     export TRUST_LEVEL=1
+    # special case for signing, using -t- instead
+    if [ $PROJECT_NAME = "signing" ]; then
+        export TRUST_LEVEL=t
+    fi
     export WORKER_SUFFIX="-dev"
     ;;
   *)

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -887,8 +887,8 @@ def _get_tarfile_compression(compression):
 async def _get_tarfile_files(from_, compression):
     compression = _get_tarfile_compression(compression)
     with tarfile.open(from_, mode="r:{}".format(compression)) as t:
-        files = t.getnames()
-        return files
+        files = t.getmembers()
+        return [f.name for f in files if f.isfile()]
 
 
 # _extract_tarfile {{{1

--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -963,12 +963,9 @@ async def test_zipfile_append_write(context):
 )
 async def test_get_tarfile_files(path, compression):
     assert sorted(await sign._get_tarfile_files(path, compression)) == [
-        ".",
         "./a",
         "./b",
-        "./c",
         "./c/d",
-        "./c/e",
         "./c/e/f",
     ]
 


### PR DESCRIPTION
This prevents needlessly unpacking tarballs for widevine signing in l10n
signing jobs.