### PR TITLE
bug 1573529 - send a generic keyid for autograph widevine signing

### DIFF
--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -402,7 +402,6 @@ async def sign_widevine(context, orig_path, fmt):
     """
     file_base, file_extension = os.path.splitext(orig_path)
     cert_type = task.task_cert_type(context)
-    is_autograph = utils.is_autograph_signing_format(fmt)
     keyid = utils.get_widevine_keyid(cert_type)
     # Convert dmg to tarball
     if file_extension == ".dmg":

--- a/signingscript/src/signingscript/utils.py
+++ b/signingscript/src/signingscript/utils.py
@@ -9,7 +9,11 @@ import os
 from shutil import copyfile
 from collections import namedtuple
 
-from signingscript.exceptions import FailedSubprocess, SigningServerError
+from signingscript.exceptions import (
+    FailedSubprocess,
+    SigningScriptError,
+    SigningServerError,
+)
 
 log = logging.getLogger(__name__)
 
@@ -209,3 +213,25 @@ def split_autograph_format(format_):
         return format_.split(":", 1)
     else:
         return format_, None
+
+
+def get_widevine_keyid(cert_type):
+    """Get the keyid for the autograph widevine signer.
+
+    Args:
+        cert_type (str): the cert type
+
+    Raises:
+        SigningScriptError: on unknown cert_type
+
+    Returns:
+        str: the keyid to use
+
+    """
+    cert_type = cert_type.split(":")[-1]
+    if cert_type == "dep-signing":
+        return "widevine_dep1_genericrsa"
+    elif cert_type in ("nightly-signing", "release-signing"):
+        return "widevine_rel1_genericrsa"
+    else:
+        raise SigningScriptError("Unknown cert_type {}!".format(cert_type))

--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -17,6 +17,7 @@ from scriptworker.utils import makedirs
 from signingscript.exceptions import SigningScriptError
 from signingscript.utils import get_hash, SigningServer
 import signingscript.sign as sign
+import signingscript.task as task
 import signingscript.utils as utils
 from conftest import (
     noop_sync,
@@ -733,6 +734,8 @@ async def test_sign_widevine(
     mocker.patch.object(sign, "_create_tarfile", new=noop_async)
     mocker.patch.object(sign, "_create_zipfile", new=noop_async)
     mocker.patch.object(sign, "_run_generate_precomplete", new=noop_sync)
+    mocker.patch.object(task, "task_cert_type", new=noop_sync)
+    mocker.patch.object(utils, "get_widevine_keyid", new=noop_sync)
     mocker.patch.object(os.path, "isfile", new=fake_isfile)
 
     if raises:
@@ -1097,7 +1100,7 @@ async def test_widevine_autograph(context, mocker, tmp_path, blessed):
     wv.generate_widevine_signature.return_value = b"sigwidevinesig"
     called_format = None
 
-    async def fake_sign_hash(context, h, fmt):
+    async def fake_sign_hash(context, h, fmt, keyid=None):
         nonlocal called_format
         called_format = fmt
         return b"sigautographsig"

--- a/signingscript/tests/test_utils.py
+++ b/signingscript/tests/test_utils.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 from scriptworker.context import Context
-from signingscript.exceptions import FailedSubprocess, SigningServerError
+from signingscript.exceptions import FailedSubprocess, SigningServerError, SigningScriptError
 from conftest import read_file
 import signingscript.utils as utils
 from conftest import PUB_KEY_PATH
@@ -160,3 +160,21 @@ async def test_execute_subprocess(exit_code):
 )
 def test_is_sha1_apk_autograph_signing_format(format, expected):
     assert utils.is_sha1_apk_autograph_signing_format(format) == expected
+
+
+# get_widevine_keyid {{{1
+@pytest.mark.parametrize(
+    "cert_type,expected,raises",
+    (
+        ("foo:bar:dep-signing", "widevine_dep1_genericrsa", False),
+        ("foo:bar:nightly-signing", "widevine_rel1_genericrsa", False),
+        ("release-signing", "widevine_rel1_genericrsa", False),
+        ("foo:bar:unknown", None, SigningScriptError),
+    ),
+)
+def test_get_widevine_keyid(cert_type, expected, raises):
+    if raises:
+        with pytest.raises(raises):
+            utils.get_widevine_keyid(cert_type)
+    else:
+        assert utils.get_widevine_keyid(cert_type) == expected


### PR DESCRIPTION
Looks like using `widevine_dep1_genericrsa` worked.