### PR TITLE
Bug 1590267 - add missing unsquashfs required.r=rail

### DIFF
--- a/pushsnapscript/Dockerfile
+++ b/pushsnapscript/Dockerfile
@@ -5,6 +5,7 @@ RUN groupadd --gid 10001 app && \
 
 RUN apt-get update \
  && apt-get install -y libsodium-dev \
+ && apt-get install -y squashfs-tools \
  && apt-get clean \
  # XXX Avoid snapcraft from loading useless libs when running on Ubuntu
  && truncate -s 0 /etc/os-release \


### PR DESCRIPTION
`snapcraft` needs this under the hood - we've hit this while configuring AWS puppet instances too, two years ago - @JohanLorenzo documented this nicely under https://bugzilla.mozilla.org/show_bug.cgi?id=1447263#c16.

Porting this over in the Dockerfile.