### PR TITLE
Bug 1588590 - fix GCP mobile worker configs for prod/dev

### DIFF
--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -8,6 +8,7 @@ taskcluster_scope_prefixes:
     - "project:mobile:focus:releng:googleplay:product:"
     - "project:mobile:reference-browser:releng:googleplay:product:"
     - "project:mobile:fenix:releng:googleplay:product:"
+    - "project:mobile:firefox-tv:releng:googleplay:product:"
   else:
     - "project:releng:googleplay:"
 products:
@@ -47,6 +48,7 @@ products:
           apps:
             dep:
               service_account: dummy
+              default_track: beta
               package_names:
                 - "org.mozilla.fennec_aurora"
               credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FIREFOX_DEP_PATH" }
@@ -61,22 +63,25 @@ products:
           apps:
             nightly:
               package_names: [ "org.mozilla.fenix.nightly" ]
-              default_track: 'beta'
-              service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FENIX_NIGHTLY" }
-              credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_NIGHTLY_PATH" }
               certificate_alias: 'fenix-nightly'
+              google:
+                default_track: 'beta'
+                service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FENIX_NIGHTLY" }
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_NIGHTLY_PATH" }
             beta:
               package_names: [ "org.mozilla.fenix.beta" ]
-              default_track: 'internal'
-              service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FENIX_BETA" }
-              credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_BETA_PATH"}
               certificate_alias: "fenix-beta"
+              google:
+                default_track: 'internal'
+                service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FENIX_BETA" }
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_BETA_PATH"}
             production:
               package_names: [ "org.mozilla.fenix" ]
-              default_track: 'internal'
-              service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FENIX_PROD" }
-              credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_PROD_PATH" }
               certificate_alias: 'fenix-production'
+              google:
+                default_track: 'internal'
+                service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FENIX_PROD" }
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_PROD_PATH" }
         - product_names: [ "focus" ]
           digest_algorithm: 'SHA-256'
           skip_check_ordered_version_codes: true
@@ -84,7 +89,7 @@ products:
           skip_check_same_locales: true
           skip_checks_fennec: true
           override_channel_model: "single_google_app"
-          single_app_config:
+          app:
             service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FOCUS" }
             credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_PATH" }
             package_names:
@@ -97,13 +102,26 @@ products:
           skip_check_same_locales: true
           skip_checks_fennec: true
           override_channel_model: "single_google_app"
-          single_app_config:
+          app:
             service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_REFERENCE_BROWSER" }
             credentials_file: { "$eval": "GOOGLE_CREDENTIALS_REFERENCE_BROWSER_PATH" }
             package_names:
               - "org.mozilla.reference.browser"
             certificate_alias: "reference-browser"
-
+        - product_names: [ "firefox-tv" ]
+          skip_check_multiple_locales: true
+          skip_check_same_locales: true
+          skip_checks_fennec: true
+          skip_check_signature: true
+          skip_check_ordered_version_codes: true
+          override_channel_model: "single_google_app"
+          apps:
+            production:
+              package_names:
+                - "org.mozilla.tv.firefox"
+              amazon:
+                client_id: 'dummy'
+                client_secret: 'dummy'
       'COT_PRODUCT == "mobile" && ENV == "fake-prod"':
         - product_names: [ "fenix" ]
           digest_algorithm: "SHA-256"
@@ -111,7 +129,7 @@ products:
           skip_check_same_locales: true
           skip_checks_fennec: true
           override_channel_model: "single_google_app"
-          single_app_config:
+          app:
             package_names:
               - "org.mozilla.fenix"
               - "org.mozilla.fenix.beta"
@@ -126,20 +144,33 @@ products:
           skip_check_same_locales: true
           skip_checks_fennec: true
           override_channel_model: "single_google_app"
-          single_app_config:
+          app:
             package_names:
               - "org.mozilla.focus"
               - "org.mozilla.klar"
             service_account: "dummy"
             credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_DEP_PATH" }
             certificate_alias: "focus"
+        - product_names: [ "firefox-tv" ]
+          skip_check_multiple_locales: true
+          skip_check_same_locales: true
+          skip_checks_fennec: true
+          skip_check_signature: true
+          skip_check_ordered_version_codes: true
+          apps:
+            production:
+              package_names:
+                - "org.mozilla.tv.firefox"
+              amazon:
+                client_id: 'dummy'
+                client_secret: 'dummy'
         - product_names: [ "reference-browser" ]
           digest_algorithm: "SHA-256"
           skip_check_multiple_locales: true
           skip_check_same_locales: true
           skip_checks_fennec: true
           override_channel_model: "single_google_app"
-          single_app_config:
+          app:
             package_names:
               - "org.mozilla.reference.browser"
             service_account: "dummy"

--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -114,7 +114,6 @@ products:
           skip_checks_fennec: true
           skip_check_signature: true
           skip_check_ordered_version_codes: true
-          override_channel_model: "single_google_app"
           apps:
             production:
               package_names:


### PR DESCRIPTION
This is to match the `script_config.json` we generate on puppet [here](https://github.com/mozilla-releng/build-puppet/blob/master/modules/pushapk_scriptworker/manifests/settings.pp)