### PR TITLE
Changes Fenix beta target track to "beta-closed"

### DIFF
--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -72,7 +72,7 @@ products:
               package_names: [ "org.mozilla.fenix.beta" ]
               certificate_alias: "fenix-beta"
               google:
-                default_track: 'internal'
+                default_track: 'beta-closed'
                 service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FENIX_BETA" }
                 credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_BETA_PATH"}
             production:


### PR DESCRIPTION
This is for [this Fenix ticket](https://github.com/mozilla-mobile/fenix/issues/6461).
By changing `default_track` to `beta-closed`, releases will be pushed to the `beta-closed` track automatically