### PR TITLE
support xpi signing

### DIFF
--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -287,10 +287,6 @@ async def sign_xpi(context, orig_path, fmt):
     cert_type = task.task_cert_type(context)
     file_base, file_extension = os.path.splitext(orig_path)
 
-    a = get_autograph_config(
-        context.autograph_configs, cert_type, [fmt], raise_on_empty=True
-    )
-
     if file_extension not in (".xpi", ".zip"):
         raise SigningScriptError("Expected a .xpi")
 

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -286,7 +286,7 @@ async def sign_xpi(context, orig_path, fmt):
     """
     file_base, file_extension = os.path.splitext(orig_path)
 
-    if file_extension != ".xpi":
+    if file_extension not in (".xpi", ".zip"):
         raise SigningScriptError("Expected a .xpi")
 
     ext_id = _extension_id(orig_path, fmt)
@@ -617,6 +617,7 @@ def _extension_id(filename, fmt):
         "languages" in manifest
         and "langpack_id" in manifest
         and LANGPACK_RE.match(manifest["applications"]["gecko"]["id"])
+        and filename.endswith(".xpi")
     ):
         raise SigningScriptError("{} is not a valid langpack".format(filename))
     return manifest["applications"]["gecko"]["id"]

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -600,8 +600,17 @@ def _extension_id(filename, fmt):
     Side effect of additionally verifying langpack manifests.
     """
     xpi = zipfile.ZipFile(filename, "r")
-    with xpi.open("manifest.json", "r") as f:
-        manifest = json.load(f)
+    manifest = {}
+    for manifest_name in ("manifest.json", "webextension/manifest.json"):
+        try:
+            with xpi.open(manifest_name, "r") as f:
+                manifest = json.load(f)
+                break
+        except KeyError:
+            log.debug(
+                "{} doesn't exist in {}...".format(manifest_name, filename)
+            )
+            continue
     if not manifest.get("applications", {}).get("gecko", {}).get("id"):
         raise SigningScriptError("{} is not a valid xpi".format(filename))
     if "langpack" in fmt and not (

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -269,8 +269,8 @@ async def sign_macapp(context, from_, fmt):
     return from_
 
 
-# sign_langpack {{{1
-async def sign_langpack(context, orig_path, fmt):
+# sign_xpi {{{1
+async def sign_xpi(context, orig_path, fmt):
     """Sign language packs with autograph.
 
     This validates both the file extension and the language pack ID is sane.
@@ -286,13 +286,16 @@ async def sign_langpack(context, orig_path, fmt):
     """
     file_base, file_extension = os.path.splitext(orig_path)
 
-    if not file_extension == ".xpi":
+    if file_extension != ".xpi":
         raise SigningScriptError("Expected a .xpi")
 
-    id = _langpack_id(orig_path)
+    ext_id = _extension_id(orig_path, fmt)
     log.info("Identified {} as extension id: {}".format(orig_path, id))
+    kwargs = {'extension_id': ext_id}
+    if 'langpack' not in fmt:
+        kwargs['keyid'] = fmt
     # Sign the appropriate inner files
-    await sign_file_with_autograph(context, orig_path, fmt, extension_id=id)
+    await sign_file_with_autograph(context, orig_path, fmt, **kwargs)
     return orig_path
 
 
@@ -591,26 +594,23 @@ def _should_sign_windows(filename):
     return False
 
 
-def _langpack_id(filename):
+def _extension_id(filename, fmt):
     """Return a list of id's for the langpacks.
 
-    Side Affect of checking if filenames are actually langpacks.
+    Side effect of additionally verifying langpack manifests.
     """
-    langpack = zipfile.ZipFile(filename, "r")
-    id = None
-    with langpack.open("manifest.json", "r") as f:
+    xpi = zipfile.ZipFile(filename, "r")
+    with xpi.open("manifest.json", "r") as f:
         manifest = json.load(f)
-        if not (
-            "languages" in manifest
-            and "langpack_id" in manifest
-            and "applications" in manifest
-            and "gecko" in manifest["applications"]
-            and "id" in manifest["applications"]["gecko"]
-            and LANGPACK_RE.match(manifest["applications"]["gecko"]["id"])
-        ):
-            raise SigningScriptError("{} is not a valid langpack".format(filename))
-        id = manifest["applications"]["gecko"]["id"]
-    return id
+    if not manifest.get("applications", {}).get("gecko", {}).get("id"):
+        raise SigningScriptError("{} is not a valid xpi".format(filename))
+    if "langpack" in fmt and not (
+        "languages" in manifest
+        and "langpack_id" in manifest
+        and LANGPACK_RE.match(manifest["applications"]["gecko"]["id"])
+    ):
+        raise SigningScriptError("{} is not a valid langpack".format(filename))
+    return manifest["applications"]["gecko"]["id"]
 
 
 # _get_mac_sigpath {{{1
@@ -1002,6 +1002,13 @@ def b64encode(input_bytes):
     return base64.b64encode(input_bytes).decode("ascii")
 
 
+def _is_xpi_format(fmt):
+    if "omnija" in fmt or "langpack" in fmt:
+        return True
+    if "systemaddon" in fmt or "extension_rsa" in fmt:
+        return True
+
+
 @time_function
 def make_signing_req(input_file, fmt, keyid=None, extension_id=None):
     """Make a signing request object to pass to autograph."""
@@ -1020,7 +1027,7 @@ def make_signing_req(input_file, fmt, keyid=None, extension_id=None):
             # https://github.com/mozilla-services/autograph/pull/166/files
             sign_req["options"]["pkcs7_digest"] = "SHA1"
 
-    if "omnija" in fmt or "langpack" in fmt:
+    if _is_xpi_format(fmt):
         sign_req.setdefault("options", {})
         # https://bugzilla.mozilla.org/show_bug.cgi?id=1533818#c9
         sign_req["options"]["id"] = extension_id

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -292,8 +292,6 @@ async def sign_xpi(context, orig_path, fmt):
     ext_id = _extension_id(orig_path, fmt)
     log.info("Identified {} as extension id: {}".format(orig_path, id))
     kwargs = {'extension_id': ext_id}
-    if 'langpack' not in fmt:
-        kwargs['keyid'] = fmt
     # Sign the appropriate inner files
     await sign_file_with_autograph(context, orig_path, fmt, **kwargs)
     return orig_path

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -610,7 +610,6 @@ def _extension_id(filename, fmt):
             log.debug(
                 "{} doesn't exist in {}...".format(manifest_name, filename)
             )
-            continue
     if not manifest.get("applications", {}).get("gecko", {}).get("id"):
         raise SigningScriptError("{} is not a valid xpi".format(filename))
     if "langpack" in fmt and not (

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -1075,7 +1075,7 @@ async def sign_with_autograph(
 
 
 @time_async_function
-async def sign_file_with_autograph(context, from_, fmt, to=None, extension_id=None):
+async def sign_file_with_autograph(context, from_, fmt, to=None, keyid=None, extension_id=None):
     """Signs file with autograph and writes the results to a file.
 
     Args:
@@ -1102,7 +1102,7 @@ async def sign_file_with_autograph(context, from_, fmt, to=None, extension_id=No
     input_file = open(from_, "rb")
     signed_bytes = base64.b64decode(
         await sign_with_autograph(
-            context.session, a, input_file, fmt, "file", extension_id=extension_id
+            context.session, a, input_file, fmt, "file", keyid=keyid, extension_id=extension_id
         )
     )
     with open(to, "wb") as fout:

--- a/signingscript/src/signingscript/task.py
+++ b/signingscript/src/signingscript/task.py
@@ -26,6 +26,7 @@ from signingscript.sign import (
     sign_omnija,
     sign_langpack,
     sign_authenticode_zip,
+    sign_xpi,
 )
 
 log = logging.getLogger(__name__)
@@ -48,6 +49,8 @@ FORMAT_TO_SIGNING_FUNCTION = frozendict(
         "autograph_langpack": sign_langpack,
         "autograph_authenticode": sign_authenticode_zip,
         "autograph_authenticode_stub": sign_authenticode_zip,
+        "extension_rsa.*": sign_xpi,
+        "systemaddon_rsa_.+": sign_xpi,
         "default": sign_file,
     }
 )

--- a/signingscript/src/signingscript/task.py
+++ b/signingscript/src/signingscript/task.py
@@ -24,7 +24,6 @@ from signingscript.sign import (
     sign_mar384_with_autograph_hash,
     sign_gpg_with_autograph,
     sign_omnija,
-    sign_langpack,
     sign_authenticode_zip,
     sign_xpi,
 )
@@ -46,7 +45,7 @@ FORMAT_TO_SIGNING_FUNCTION = frozendict(
         "widevine": sign_widevine,
         "autograph_widevine": sign_widevine,
         "autograph_omnija": sign_omnija,
-        "autograph_langpack": sign_langpack,
+        "autograph_langpack": sign_xpi,
         "autograph_authenticode": sign_authenticode_zip,
         "autograph_authenticode_stub": sign_authenticode_zip,
         "extension_rsa.*": sign_xpi,

--- a/signingscript/src/signingscript/task.py
+++ b/signingscript/src/signingscript/task.py
@@ -48,8 +48,8 @@ FORMAT_TO_SIGNING_FUNCTION = frozendict(
         "autograph_langpack": sign_xpi,
         "autograph_authenticode": sign_authenticode_zip,
         "autograph_authenticode_stub": sign_authenticode_zip,
-        "extension_rsa.*": sign_xpi,
-        "systemaddon_rsa_.+": sign_xpi,
+        "privileged_webextension": sign_xpi,
+        "system_addon": sign_xpi,
         "default": sign_file,
     }
 )

--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -523,6 +523,16 @@ async def test_sign_macapp(context, mocker, filename, expected):
 
 
 # sign_xpi {{{1
+@pytest.mark.parametrize("fmt, is_xpi", (
+    ("foo_omnija", True),
+    ("langpack_foo", True),
+    ("privileged_webextension", True),
+    ("unknown", False),
+))
+def test_is_xpi_format(fmt, is_xpi):
+    assert sign._is_xpi_format(fmt) is is_xpi
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "filename,id,raises",
@@ -535,7 +545,10 @@ async def test_sign_macapp(context, mocker, filename, expected):
 async def test_sign_xpi(context, mocker, filename, id, raises):
     async def mocked_signer(ctx, fname, fmt, extension_id=None):
         assert extension_id == id
+    context.task = {"scopes": ["project:releng:signing:cert:dep-signing"]}
 
+    mocker.patch.object(sign, "get_autograph_config")
+    mocker.patch.object(sign, "_extension_id", return_value=id)
     mocker.patch.object(sign, "_extension_id", return_value=id)
     mocker.patch.object(sign, "sign_file_with_autograph", new=mocked_signer)
     with raises:

--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -1175,6 +1175,12 @@ def test_extension_id():
     assert sign._extension_id(filename, "autograph_langpack") == "langpack-en-CA@firefox.mozilla.org"
 
 
+def test_extension_id_missing_manifest():
+    filename = os.path.join(TEST_DATA_DIR, "test.zip")
+    with pytest.raises(SigningScriptError):
+        sign._extension_id(filename, "autograph_langpack")
+
+
 @pytest.mark.parametrize(
     "json_,raises",
     (

--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -527,7 +527,7 @@ async def test_sign_macapp(context, mocker, filename, expected):
 @pytest.mark.parametrize(
     "filename,id,raises",
     (
-        ("foo.zip", "foo-id@firefox.mozilla.org", pytest.raises(SigningScriptError)),
+        ("foo.blah", "foo-id@firefox.mozilla.org", pytest.raises(SigningScriptError)),
         ("/path/to/foo.xpi", "foo-id@firefox.mozilla.org", does_not_raise()),
         ("foo.xpi", "foo-id@devedition.mozilla.org", does_not_raise()),
     ),

--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -522,7 +522,7 @@ async def test_sign_macapp(context, mocker, filename, expected):
     assert await sign.sign_macapp(context, filename, "blah") == expected
 
 
-# sign_langpack {{{1
+# sign_xpi {{{1
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "filename,id,raises",
@@ -532,14 +532,14 @@ async def test_sign_macapp(context, mocker, filename, expected):
         ("foo.xpi", "foo-id@devedition.mozilla.org", does_not_raise()),
     ),
 )
-async def test_sign_langpack(context, mocker, filename, id, raises):
+async def test_sign_xpi(context, mocker, filename, id, raises):
     async def mocked_signer(ctx, fname, fmt, extension_id=None):
         assert extension_id == id
 
-    mocker.patch.object(sign, "_langpack_id", return_value=id)
+    mocker.patch.object(sign, "_extension_id", return_value=id)
     mocker.patch.object(sign, "sign_file_with_autograph", new=mocked_signer)
     with raises:
-        assert await sign.sign_langpack(context, filename, "blah") == filename
+        assert await sign.sign_xpi(context, filename, "autograph_langpack") == filename
 
 
 # sign_widevine {{{1
@@ -950,17 +950,17 @@ def test_signreq_task_langpack():
 @pytest.mark.asyncio
 async def test_bad_autograph_method():
     with pytest.raises(SigningScriptError):
-        await sign.sign_with_autograph(None, None, None, None, "badformat")
+        await sign.sign_with_autograph(None, None, None, None, "gpg")
 
 
 @pytest.mark.asyncio
 async def test_bad_autograph_format(context):
     context.task = {"scopes": ["project:releng:signing:cert:dep-signing"]}
     with pytest.raises(SigningScriptError):
-        await sign.sign_file_with_autograph(context, "", "badformat")
+        await sign.sign_file_with_autograph(context, "", "gpg")
 
     with pytest.raises(SigningScriptError):
-        await sign.sign_hash_with_autograph(context, "", "badformat")
+        await sign.sign_hash_with_autograph(context, "", "gpg")
 
 
 @pytest.mark.asyncio
@@ -1170,9 +1170,9 @@ def test_langpack_id_regex():
     assert sign.LANGPACK_RE.match("invalid-langpack-id@example.com") is None
 
 
-def test_langpack_id():
+def test_extension_id():
     filename = os.path.join(TEST_DATA_DIR, "en-CA.xpi")
-    assert sign._langpack_id(filename) == "langpack-en-CA@firefox.mozilla.org"
+    assert sign._extension_id(filename, "autograph_langpack") == "langpack-en-CA@firefox.mozilla.org"
 
 
 @pytest.mark.parametrize(
@@ -1244,7 +1244,7 @@ def test_langpack_id():
         ),
     ),
 )
-def test_langpack_id_raises(json_, raises, mocker):
+def test_extension_id_raises(json_, raises, mocker):
     filename = os.path.join(TEST_DATA_DIR, "en-CA.xpi")
 
     def load_manifest(*args, **kwargs):
@@ -1255,7 +1255,7 @@ def test_langpack_id_raises(json_, raises, mocker):
 
     mocker.patch.object(sign.json, "load", load_manifest)
     with raises:
-        id = sign._langpack_id(filename)
+        id = sign._extension_id(filename, "autograph_langpack")
         assert id == json_["applications"]["gecko"]["id"]
 
 

--- a/signingscript/tests/test_task.py
+++ b/signingscript/tests/test_task.py
@@ -54,6 +54,9 @@ def test_task_cert_type_error(context):
     context.task = {"scopes": [TEST_CERT_TYPE, "project:releng:signing:cert:notdep"]}
     with pytest.raises(ScriptWorkerTaskException):
         stask.task_cert_type(context)
+    context.task = None
+    with pytest.raises(TaskVerificationError):
+        stask.task_cert_type(context)
 
 
 # task_signing_formats {{{1


### PR DESCRIPTION
Rebased on top of master.

This uses the format name as the keyid. I can change it up to use a generalized name as the keyid, and specify the keyid in the passwords file, if that's preferred.

It looks like I can't test this in puppet-land, because we dropped py36 support. I'm guessing we should eyeball it, roll it out to a new k8s pod, and test then.