### PR TITLE
Bug 1596470 - add missing Fennec prod signing for Fenix

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -146,6 +146,8 @@ case $ENV in
         test_var_set 'AUTOGRAPH_WIDEVINE_USERNAME'
         ;;
       mobile)
+        test_var_set 'AUTOGRAPH_FENNEC_RELEASE_PASSWORD'
+        test_var_set 'AUTOGRAPH_FENNEC_RELEASE_USERNAME'
         test_var_set 'AUTOGRAPH_FENIX_BETA_PASSWORD'
         test_var_set 'AUTOGRAPH_FENIX_BETA_USERNAME'
         test_var_set 'AUTOGRAPH_FENIX_NIGHTLY_PASSWORD'

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -233,6 +233,13 @@ in:
              ["autograph_apk"],
              "autograph"
             ]
+        project:mobile:fenix:releng:signing:cert:fennec-production-signing:
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},
+             {"$eval": "AUTOGRAPH_FENNEC_RELEASE_PASSWORD"},
+             ["autograph_apk"],
+             "autograph"
+            ]
         project:mobile:reference-browser:releng:signing:cert:release-signing:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_USERNAME"},


### PR DESCRIPTION
Turns out we missed porting https://github.com/mozilla-releng/build-puppet/blob/master/modules/signing_scriptworker/templates/passwords-mobile.json.erb#L14 over.