### PR TITLE
Fix l10n bump

### DIFF
--- a/treescript/src/treescript/l10n.py
+++ b/treescript/src/treescript/l10n.py
@@ -232,7 +232,7 @@ async def l10n_bump(config, task, repo_path):
     ignore_closed_tree = get_ignore_closed_tree(task)
     l10n_bump_info = get_l10n_bump_info(task)
     revision_info = None
-    changes = False
+    changes = 0
 
     if not ignore_closed_tree:
         if not await check_treestatus(config, task):
@@ -260,5 +260,5 @@ async def l10n_bump(config, task, repo_path):
             ignore_closed_tree=ignore_closed_tree,
         )
         await run_hg_command(config, "commit", "-m", message, repo_path=repo_path)
-        changes = True
+        changes += 1
     return changes

--- a/treescript/src/treescript/mercurial.py
+++ b/treescript/src/treescript/mercurial.py
@@ -290,14 +290,14 @@ async def do_tagging(config, task, repo_path):
         FailedSubprocess: if the tag attempt doesn't succeed.
 
     Returns:
-        bool: True if there are any changes.
+        int: the number of tags created.
 
     """
     tag_info = get_tag_info(task)
     desired_tags = await check_tags(config, tag_info, repo_path)
     if not desired_tags:
         log.info("No unique tags to add; skipping tagging.")
-        return
+        return 0
     desired_rev = tag_info["revision"]
     dontbuild = get_dontbuild(task)
     dest_repo = get_source_repo(task)
@@ -324,10 +324,19 @@ async def do_tagging(config, task, repo_path):
         *desired_tags,
         repo_path=repo_path,
     )
-    return True
+    return 1
 
 
 # log_outgoing {{{1
+def _count_outgoing(output):
+    """Count the number of outgoing hg changesets from `hg outgoing`"""
+    count = 0
+    for line in output.splitlines():
+        if line.startswith("changeset: "):
+            count += 1
+    return count
+
+
 async def log_outgoing(config, task, repo_path):
     """Run `hg out` against the current revision in the repository.
 
@@ -341,9 +350,13 @@ async def log_outgoing(config, task, repo_path):
     Raises:
         FailedSubprocess: on failure
 
+    Returns:
+        int: the number of outgoing changesets
+
     """
     dest_repo = get_source_repo(task)
     log.info("outgoing changesets..")
+    num_changesets = 0
     output = await run_hg_command(
         config,
         "out",
@@ -360,6 +373,8 @@ async def log_outgoing(config, task, repo_path):
         makedirs(os.path.dirname(path))
         with open(path, "w") as fh:
             fh.write(output)
+        num_changesets = _count_outgoing(output)
+    return num_changesets
 
 
 # strip_outgoing {{{1

--- a/treescript/src/treescript/mercurial.py
+++ b/treescript/src/treescript/mercurial.py
@@ -331,7 +331,13 @@ async def do_tagging(config, task, repo_path):
 
 # log_outgoing {{{1
 def _count_outgoing(output):
-    """Count the number of outgoing hg changesets from `hg outgoing`"""
+    """Count the number of outgoing hg changesets from `hg outgoing`.
+
+    There's a possibility of over-counting, if someone starts their commit
+    message line with `changeset: `, but since we currently know all of our
+    expected commit messages, we shouldn't have any false positives here.
+
+    """
     count = 0
     for line in output.splitlines():
         if line.startswith("changeset: "):

--- a/treescript/src/treescript/mercurial.py
+++ b/treescript/src/treescript/mercurial.py
@@ -48,6 +48,8 @@ def build_hg_command(config, *args):
         "extensions.robustcheckout={}".format(ROBUSTCHECKOUT_PATH),
         "--config",
         "extensions.purge=",
+        "--config",
+        "extensions.strip=",
     ]
     return hg + [*robustcheckout_args, *args]
 

--- a/treescript/src/treescript/mercurial.py
+++ b/treescript/src/treescript/mercurial.py
@@ -353,6 +353,7 @@ async def log_outgoing(config, task, repo_path):
         dest_repo,
         repo_path=repo_path,
         return_output=True,
+        expected_exit_codes=(0, 1),
     )
     if output:
         path = os.path.join(config["artifact_dir"], "public", "logs", "outgoing.diff")

--- a/treescript/src/treescript/script.py
+++ b/treescript/src/treescript/script.py
@@ -58,7 +58,7 @@ async def do_actions(config, task, actions, repo_path):
     if is_dry_run(task):
         log.info("Not pushing changes, dry_run was forced")
     elif "push" in actions:
-        if changes:
+        if num_changes:
             await push(config, task, repo_path)
         else:
             log.info("No changes; skipping push.")

--- a/treescript/src/treescript/versionmanip.py
+++ b/treescript/src/treescript/versionmanip.py
@@ -93,12 +93,13 @@ async def bump_version(config, task, repo_path):
                                if the file is not in the target repository.
 
     Returns:
-        bool: True if there are changes.
+        int: the number of commits created.
 
     """
     bump_info = get_version_bump_info(task)
     files = bump_info["files"]
     changed = False
+    num_commits = 0
 
     for file_ in files:
         abs_file = os.path.join(repo_path, file_)
@@ -148,7 +149,8 @@ async def bump_version(config, task, repo_path):
         if dontbuild:
             commit_msg += DONTBUILD_MSG
         await run_hg_command(config, "commit", "-m", commit_msg, repo_path=repo_path)
-    return changed
+        num_commits += 1
+    return num_commits
 
 
 def replace_ver_in_file(file_, curr_version, new_version):

--- a/treescript/tests/test_l10n.py
+++ b/treescript/tests/test_l10n.py
@@ -330,7 +330,7 @@ async def test_get_revision_info(mocker):
                 "one": {"revision": "onerev", "platforms": ["platform"]},
                 "two": {"revision": "tworev", "platforms": ["platform"]},
             },
-            False,
+            0,
         ),
         (
             False,
@@ -346,7 +346,7 @@ async def test_get_revision_info(mocker):
                 "one": {"revision": "newonerev", "platforms": ["platform"]},
                 "two": {"revision": "newtworev", "platforms": ["platform"]},
             },
-            True,
+            2,
         ),
     ),
 )

--- a/treescript/tests/test_mercurial.py
+++ b/treescript/tests/test_mercurial.py
@@ -95,6 +95,8 @@ def test_build_hg_cmd(config, hg, args):
                 "extensions.robustcheckout={}".format(path),
                 "--config",
                 "extensions.purge=",
+                "--config",
+                "extensions.strip=",
                 "blah",
                 "blah",
                 "--baz",
@@ -366,6 +368,27 @@ async def test_do_tagging_no_tags(config, task, mocker):
 
 
 # log_outgoing {{{1
+@pytest.mark.parametrize(
+    "output, expected",
+    (
+        ("", 0),
+        (
+            """
+blah
+changeset: x
+blah
+blah
+changeset: 9
+blah
+    """,
+            2,
+        ),
+    ),
+)
+def test_count_outgoing(output, expected):
+    assert mercurial._count_outgoing(output) == expected
+
+
 @pytest.mark.parametrize("output", ("hg output!", None))
 @pytest.mark.asyncio
 async def test_log_outgoing(config, task, mocker, output):


### PR DESCRIPTION
This PR:

- counts the number of changes we expect to push, and the number of changesets that are outgoing, and dies if they don't match. This is important, because on Tuesday we had an issue with l10n-bumper pushing all of autoland to central. I believe I've fixed that issue, but this check helps prevent something similar from happening in case of another bug.
- adds the `strip` extension. I believe we were saved from pushing extraneous revisions by using `mq`'s `strip`, but that would potentially strip way more than expected given all the code in mozilla-unified

The other side of the l10n-bump fix is in-tree.

I'm hoping to land this PR before GTB for Thursday's betas, so Just In Case the tagging or version bumping pushes too many commits, we catch that before we push.