### PR TITLE
[treescript] Don't strip after running robustcheckout.

### DIFF
--- a/treescript/src/treescript/mercurial.py
+++ b/treescript/src/treescript/mercurial.py
@@ -202,7 +202,6 @@ async def checkout_repo(config, task, repo_path):
         branch,
         exception=CheckoutError,
     )
-    await strip_outgoing(config, task, repo_path)
 
 
 # do_tagging {{{1


### PR DESCRIPTION
robustcheckout is desigend to be a resilient tool for ensuring that a checkout
matches exactly what is in an upstream repo, in a cache friendly way. We
don't need to duplicate that worker by strip+update+purge.