### PR TITLE
allow for source_repo and target_repo in payload

### DIFF
--- a/treescript/src/treescript/data/treescript_task_schema.json
+++ b/treescript/src/treescript/data/treescript_task_schema.json
@@ -93,9 +93,6 @@
                 "source_repo": {
                     "type": "string"
                 },
-                "target_repo": {
-                    "type": "string"
-                },
                 "dry_run": {
                     "type": "boolean"
                 },

--- a/treescript/src/treescript/data/treescript_task_schema.json
+++ b/treescript/src/treescript/data/treescript_task_schema.json
@@ -90,6 +90,12 @@
                 "branch": {
                     "type": "string"
                 },
+                "source_repo": {
+                    "type": "string"
+                },
+                "target_repo": {
+                    "type": "string"
+                },
                 "dry_run": {
                     "type": "boolean"
                 },

--- a/treescript/src/treescript/mercurial.py
+++ b/treescript/src/treescript/mercurial.py
@@ -7,11 +7,12 @@ import tempfile
 from scriptworker_client.utils import run_command, makedirs, load_json_or_yaml
 from treescript.exceptions import CheckoutError, FailedSubprocess, PushError
 from treescript.task import (
+    DONTBUILD_MSG,
     get_branch,
+    get_dontbuild,
     get_source_repo,
     get_tag_info,
-    get_dontbuild,
-    DONTBUILD_MSG,
+    get_target_repo,
 )
 
 # https://www.mercurial-scm.org/repo/hg/file/tip/tests/run-tests.py#l1040
@@ -186,13 +187,13 @@ async def checkout_repo(config, task, repo_path):
     """
     share_base = config["hg_share_base_dir"]
     upstream_repo = config["upstream_repo"]
-    dest_repo = get_source_repo(task)
+    source_repo = get_source_repo(task)
     # branch default is used to pull tip of the repo at checkout time
     branch = get_branch(task, "default")
     await run_hg_command(
         config,
         "robustcheckout",
-        dest_repo,
+        source_repo,
         repo_path,
         "--sharebase",
         share_base,
@@ -295,17 +296,17 @@ async def do_tagging(config, task, repo_path):
         return 0
     desired_rev = tag_info["revision"]
     dontbuild = get_dontbuild(task)
-    dest_repo = get_source_repo(task)
+    source_repo = get_source_repo(task)
     commit_msg = TAG_MSG.format(revision=desired_rev, tags=", ".join(desired_tags))
     if dontbuild:
         commit_msg += DONTBUILD_MSG
     log.info(
         "Pulling {revision} from {repo} explicitly.".format(
-            revision=desired_rev, repo=dest_repo
+            revision=desired_rev, repo=source_repo
         )
     )
     await run_hg_command(
-        config, "pull", "-r", desired_rev, dest_repo, repo_path=repo_path
+        config, "pull", "-r", desired_rev, source_repo, repo_path=repo_path
     )
     log.info(commit_msg)
     await run_hg_command(
@@ -355,7 +356,7 @@ async def log_outgoing(config, task, repo_path):
         int: the number of outgoing changesets
 
     """
-    dest_repo = get_source_repo(task)
+    target_repo = get_target_repo(task)
     log.info("outgoing changesets..")
     num_changesets = 0
     output = await run_hg_command(
@@ -364,7 +365,7 @@ async def log_outgoing(config, task, repo_path):
         "-vp",
         "-r",
         ".",
-        dest_repo,
+        target_repo,
         repo_path=repo_path,
         return_output=True,
         expected_exit_codes=(0, 1),
@@ -382,8 +383,7 @@ async def log_outgoing(config, task, repo_path):
 async def strip_outgoing(config, task, repo_path):
     """Strip all unpushed outgoing revisions and purge the changes.
 
-    This is something we should do at the beginning of tasks, as well as
-    on failed pushes.
+    This is something we should do on failed pushes.
 
     Args:
         config (dict): the running config
@@ -422,8 +422,8 @@ async def push(config, task, repo_path):
         PushError: on failure
 
     """
-    dest_repo = get_source_repo(task)
-    dest_repo_ssh = dest_repo.replace("https://", "ssh://")
+    target_repo = get_target_repo(task)
+    target_repo_ssh = target_repo.replace("https://", "ssh://")
     ssh_username = config.get("hg_ssh_user")
     ssh_key = config.get("hg_ssh_keyfile")
     ssh_opt = []
@@ -433,7 +433,7 @@ async def push(config, task, repo_path):
             ssh_opt[1] += " -l %s" % ssh_username
         if ssh_key:
             ssh_opt[1] += " -i %s" % ssh_key
-    log.info("Pushing local changes to {}".format(dest_repo_ssh))
+    log.info("Pushing local changes to {}".format(target_repo_ssh))
     try:
         await run_hg_command(
             config,
@@ -442,7 +442,7 @@ async def push(config, task, repo_path):
             "-r",
             ".",
             "-v",
-            dest_repo_ssh,
+            target_repo_ssh,
             repo_path=repo_path,
             exception=PushError,
         )

--- a/treescript/src/treescript/mercurial.py
+++ b/treescript/src/treescript/mercurial.py
@@ -12,7 +12,6 @@ from treescript.task import (
     get_dontbuild,
     get_source_repo,
     get_tag_info,
-    get_target_repo,
 )
 
 # https://www.mercurial-scm.org/repo/hg/file/tip/tests/run-tests.py#l1040
@@ -356,7 +355,7 @@ async def log_outgoing(config, task, repo_path):
         int: the number of outgoing changesets
 
     """
-    target_repo = get_target_repo(task)
+    source_repo = get_source_repo(task)
     log.info("outgoing changesets..")
     num_changesets = 0
     output = await run_hg_command(
@@ -365,7 +364,7 @@ async def log_outgoing(config, task, repo_path):
         "-vp",
         "-r",
         ".",
-        target_repo,
+        source_repo,
         repo_path=repo_path,
         return_output=True,
         expected_exit_codes=(0, 1),
@@ -422,8 +421,8 @@ async def push(config, task, repo_path):
         PushError: on failure
 
     """
-    target_repo = get_target_repo(task)
-    target_repo_ssh = target_repo.replace("https://", "ssh://")
+    source_repo = get_source_repo(task)
+    source_repo_ssh = source_repo.replace("https://", "ssh://")
     ssh_username = config.get("hg_ssh_user")
     ssh_key = config.get("hg_ssh_keyfile")
     ssh_opt = []
@@ -433,7 +432,7 @@ async def push(config, task, repo_path):
             ssh_opt[1] += " -l %s" % ssh_username
         if ssh_key:
             ssh_opt[1] += " -i %s" % ssh_key
-    log.info("Pushing local changes to {}".format(target_repo_ssh))
+    log.info("Pushing local changes to {}".format(source_repo_ssh))
     try:
         await run_hg_command(
             config,
@@ -442,7 +441,7 @@ async def push(config, task, repo_path):
             "-r",
             ".",
             "-v",
-            target_repo_ssh,
+            source_repo_ssh,
             repo_path=repo_path,
             exception=PushError,
         )

--- a/treescript/src/treescript/task.py
+++ b/treescript/src/treescript/task.py
@@ -21,10 +21,10 @@ def _sort_actions(actions):
 
 
 # get_source_repo {{{1
-def get_source_repo(task):
+def get_metadata_source_repo(task):
     """Get the source repo from the task metadata.
 
-    Assumes task['metadata']['source'] exists and is a link to a mercurial file on
+    Assumes `task['metadata']['source']` exists and is a link to a mercurial file on
     hg.mozilla.org (over https)
 
     Args:
@@ -50,6 +50,27 @@ def get_source_repo(task):
     return parts[0]
 
 
+def get_source_repo(task):
+    """Get the source repo from the task payload, falling back to the metadata.
+
+    First looks for `task['payload']['source_repo']`, then falls back to
+    ``get_metadata_source_repo``.
+
+    Args:
+        task: the task definition.
+
+    Returns:
+        str: url, including https scheme, to mercurial repository of the source repo.
+
+    Raises:
+        TaskVerificationError: on unexpected input.
+
+    """
+    if task["payload"].get("source_repo"):
+        return task["payload"]["source_repo"]
+    return get_metadata_source_repo(task)
+
+
 def get_short_source_repo(task):
     """Get the name of the source repo, e.g. mozilla-central.
 
@@ -63,6 +84,27 @@ def get_short_source_repo(task):
     source_repo = get_source_repo(task)
     parts = source_repo.split("/")
     return parts[-1]
+
+
+def get_target_repo(task):
+    """Get the target repo from the task payload, falling back to the metadata.
+
+    First looks for `task['payload']['target_repo']`, then falls back to
+    ``get_metadata_source_repo``.
+
+    Args:
+        task: the task definition.
+
+    Returns:
+        str: url, including https scheme, to mercurial repository of the target repo.
+
+    Raises:
+        TaskVerificationError: on unexpected input.
+
+    """
+    if task["payload"].get("target_repo"):
+        return task["payload"]["target_repo"]
+    return get_metadata_source_repo(task)
 
 
 # get_branch {{{1

--- a/treescript/src/treescript/task.py
+++ b/treescript/src/treescript/task.py
@@ -86,27 +86,6 @@ def get_short_source_repo(task):
     return parts[-1]
 
 
-def get_target_repo(task):
-    """Get the target repo from the task payload, falling back to the metadata.
-
-    First looks for `task['payload']['target_repo']`, then falls back to
-    ``get_metadata_source_repo``.
-
-    Args:
-        task: the task definition.
-
-    Returns:
-        str: url, including https scheme, to mercurial repository of the target repo.
-
-    Raises:
-        TaskVerificationError: on unexpected input.
-
-    """
-    if task["payload"].get("target_repo"):
-        return task["payload"]["target_repo"]
-    return get_metadata_source_repo(task)
-
-
 # get_branch {{{1
 def get_branch(task, default=None):
     """Get the optional branch from the task payload.

--- a/treescript/tests/test_mercurial.py
+++ b/treescript/tests/test_mercurial.py
@@ -400,8 +400,8 @@ async def test_log_outgoing(config, task, mocker, output):
             return output
 
     mocker.patch.object(mercurial, "run_hg_command", new=run_command)
-    mocked_source_repo = mocker.patch.object(mercurial, "get_source_repo")
-    mocked_source_repo.return_value = "https://hg.mozilla.org/treescript-test"
+    mocked_target_repo = mocker.patch.object(mercurial, "get_target_repo")
+    mocked_target_repo.return_value = "https://hg.mozilla.org/treescript-test"
     await mercurial.log_outgoing(config, task, config["work_dir"])
 
     assert len(called_args) == 1
@@ -416,6 +416,22 @@ async def test_log_outgoing(config, task, mocker, output):
             assert fh.read().rstrip() == output
 
 
+# strip_outgoing {{{1
+@pytest.mark.asyncio
+async def test_strip_outgoing(config, task, mocker):
+    called_args = []
+
+    async def run_command(config, *arguments, repo_path=None, **kwargs):
+        called_args.append([tuple([config]) + arguments, {"repo_path": repo_path}])
+
+    mocker.patch.object(mercurial, "run_hg_command", new=run_command)
+    await mercurial.strip_outgoing(config, task, config["work_dir"])
+
+    assert len(called_args) == 3
+    assert "repo_path" in called_args[0][1]
+    assert is_slice_in_list(("strip", "--no-backup", "outgoing()"), called_args[0][0])
+
+
 # push {{{1
 @pytest.mark.asyncio
 async def test_push(config, task, mocker, tmpdir):
@@ -425,8 +441,8 @@ async def test_push(config, task, mocker, tmpdir):
         called_args.append([tuple([config]) + arguments, {"repo_path": repo_path}])
 
     mocker.patch.object(mercurial, "run_hg_command", new=run_command)
-    mocked_source_repo = mocker.patch.object(mercurial, "get_source_repo")
-    mocked_source_repo.return_value = "https://hg.mozilla.org/treescript-test"
+    mocked_target_repo = mocker.patch.object(mercurial, "get_target_repo")
+    mocked_target_repo.return_value = "https://hg.mozilla.org/treescript-test"
     await mercurial.push(config, task, tmpdir)
 
     assert len(called_args) == 1
@@ -457,8 +473,8 @@ async def test_push_ssh(config, task, mocker, options, expect, tmpdir):
     print()
     config.update(options)
     mocker.patch.object(mercurial, "run_hg_command", new=run_command)
-    mocked_source_repo = mocker.patch.object(mercurial, "get_source_repo")
-    mocked_source_repo.return_value = "https://hg.mozilla.org/treescript-test"
+    mocked_target_repo = mocker.patch.object(mercurial, "get_target_repo")
+    mocked_target_repo.return_value = "https://hg.mozilla.org/treescript-test"
     await mercurial.push(config, task, tmpdir)
 
     assert len(called_args) == 1

--- a/treescript/tests/test_mercurial.py
+++ b/treescript/tests/test_mercurial.py
@@ -400,8 +400,8 @@ async def test_log_outgoing(config, task, mocker, output):
             return output
 
     mocker.patch.object(mercurial, "run_hg_command", new=run_command)
-    mocked_target_repo = mocker.patch.object(mercurial, "get_target_repo")
-    mocked_target_repo.return_value = "https://hg.mozilla.org/treescript-test"
+    mocked_source_repo = mocker.patch.object(mercurial, "get_source_repo")
+    mocked_source_repo.return_value = "https://hg.mozilla.org/treescript-test"
     await mercurial.log_outgoing(config, task, config["work_dir"])
 
     assert len(called_args) == 1
@@ -441,8 +441,8 @@ async def test_push(config, task, mocker, tmpdir):
         called_args.append([tuple([config]) + arguments, {"repo_path": repo_path}])
 
     mocker.patch.object(mercurial, "run_hg_command", new=run_command)
-    mocked_target_repo = mocker.patch.object(mercurial, "get_target_repo")
-    mocked_target_repo.return_value = "https://hg.mozilla.org/treescript-test"
+    mocked_source_repo = mocker.patch.object(mercurial, "get_source_repo")
+    mocked_source_repo.return_value = "https://hg.mozilla.org/treescript-test"
     await mercurial.push(config, task, tmpdir)
 
     assert len(called_args) == 1
@@ -473,8 +473,8 @@ async def test_push_ssh(config, task, mocker, options, expect, tmpdir):
     print()
     config.update(options)
     mocker.patch.object(mercurial, "run_hg_command", new=run_command)
-    mocked_target_repo = mocker.patch.object(mercurial, "get_target_repo")
-    mocked_target_repo.return_value = "https://hg.mozilla.org/treescript-test"
+    mocked_source_repo = mocker.patch.object(mercurial, "get_source_repo")
+    mocked_source_repo.return_value = "https://hg.mozilla.org/treescript-test"
     await mercurial.push(config, task, tmpdir)
 
     assert len(called_args) == 1

--- a/treescript/tests/test_task.py
+++ b/treescript/tests/test_task.py
@@ -122,7 +122,6 @@ def test_get_metadata_source_repo(task_defn, source_repo):
         source_repo
     )
     assert source_repo == ttask.get_source_repo(task_defn)
-    assert source_repo == ttask.get_target_repo(task_defn)
 
 
 def test_get_source_repo_no_source(task_defn):
@@ -147,12 +146,9 @@ def test_get_short_source_repo(task_defn):
         "https://hg.mozilla.org/projects/mozilla-test-bed",
     ),
 )
-def test_get_source_and_target_repo(task_defn, source_repo):
+def test_get_payload_source_repo(task_defn, source_repo):
     task_defn["payload"]["source_repo"] = source_repo
     assert source_repo == ttask.get_source_repo(task_defn)
-    task_defn["payload"].pop("source_repo")
-    task_defn["payload"]["target_repo"] = source_repo
-    assert source_repo == ttask.get_target_repo(task_defn)
 
 
 @pytest.mark.parametrize("branch", ("foo", None))

--- a/treescript/tests/test_task.py
+++ b/treescript/tests/test_task.py
@@ -117,11 +117,12 @@ def test_get_source_repo_raises(task_defn, source_url, raises):
         "https://hg.mozilla.org/projects/mozilla-test-bed",
     ),
 )
-def test_get_source_repo(task_defn, source_repo):
+def test_get_metadata_source_repo(task_defn, source_repo):
     task_defn["metadata"]["source"] = "{}/file/default/taskcluster/ci/foobar".format(
         source_repo
     )
     assert source_repo == ttask.get_source_repo(task_defn)
+    assert source_repo == ttask.get_target_repo(task_defn)
 
 
 def test_get_source_repo_no_source(task_defn):
@@ -135,6 +136,23 @@ def test_get_source_repo_no_source(task_defn):
 
 def test_get_short_source_repo(task_defn):
     assert ttask.get_short_source_repo(task_defn) == "mozilla-test-source"
+
+
+@pytest.mark.parametrize(
+    "source_repo",
+    (
+        "https://hg.mozilla.org/mozilla-central",
+        "https://hg.mozilla.org/releases/mozilla-release",
+        "https://hg.mozilla.org/releases/mozilla-esr120",
+        "https://hg.mozilla.org/projects/mozilla-test-bed",
+    ),
+)
+def test_get_source_and_target_repo(task_defn, source_repo):
+    task_defn["payload"]["source_repo"] = source_repo
+    assert source_repo == ttask.get_source_repo(task_defn)
+    task_defn["payload"].pop("source_repo")
+    task_defn["payload"]["target_repo"] = source_repo
+    assert source_repo == ttask.get_target_repo(task_defn)
 
 
 @pytest.mark.parametrize("branch", ("foo", None))


### PR DESCRIPTION
This improves our try situation. We still die if, say, new revisions are pushed to esr68 that aren't in Try; then our outgoing changes != our expected changes. We could adjust the `log_outgoing` number comparison to only warn if we're pushing to Try, or something similar.

Fixes #88.