### PR TITLE
Bug 1598525 - [treescript] Set upstream_repo from variable.

### DIFF
--- a/treescript/docker.d/init_worker.sh
+++ b/treescript/docker.d/init_worker.sh
@@ -19,12 +19,15 @@ test_var_set 'PROJECT_NAME'
 test_var_set 'SSH_KEY'
 test_var_set 'SSH_USER'
 
+export UPSTREAM_REPO="https://hg.mozilla.org/mozilla-unified"
+
 case $COT_PRODUCT in
   firefox)
     export TASKCLUSTER_SCOPE_PREFIX="project:releng:${PROJECT_NAME}script:"
     ;;
   thunderbird)
     export TASKCLUSTER_SCOPE_PREFIX="project:comm:thunderbird:releng:${PROJECT_NAME}script:"
+    export UPSTREAM_REPO="https://hg.mozilla.org/comm-central"
     ;;
   *)
     exit 1

--- a/treescript/docker.d/worker.yml
+++ b/treescript/docker.d/worker.yml
@@ -5,6 +5,6 @@ taskcluster_scope_prefix: { "$eval": "TASKCLUSTER_SCOPE_PREFIX" }
 treestatus_base_url: https://treestatus.mozilla-releng.net
 hg: 'hg'
 hg_share_base_dir: { "$eval": "HG_SHARE_BASE_DIR" }
-upstream_repo: 'https://hg.mozilla.org/mozilla-unified'
+upstream_repo: { "$eval": "UPSTREAM_REPO" }
 hg_ssh_user: { "$eval": "SSH_USER" }
 hg_ssh_keyfile: { "$eval": "SSH_KEY_PATH" }


### PR DESCRIPTION
The Verbump task fails during Thunderbird releases with "repository is
unreleated".
Set config['upstream_repo'] to comm-central for Thundrbird treescript
tasks.