### PR TITLE
XPI + MPD001 deploy

### DIFF
--- a/docker.d/init.sh
+++ b/docker.d/init.sh
@@ -64,6 +64,12 @@ case $COT_PRODUCT in
   application-services)
     export TRUST_DOMAIN=appservices
     ;;
+  xpi)
+    export TRUST_DOMAIN=xpi
+    ;;
+  mpd001)
+    export TRUST_DOMAIN=mpd001
+    ;;
   *)
     exit 1
     ;;

--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -50,34 +50,17 @@ case $COT_PRODUCT in
     ;;
   application-services)
     ;;
+  xpi)
+    ;;
+  mpd001)
+    ;;
   *)
     exit 1
     ;;
 esac
 
 case $ENV in
-  dev)
-    test_var_set 'AUTOGRAPH_AUTHENTICODE_PASSWORD'
-    test_var_set 'AUTOGRAPH_AUTHENTICODE_USERNAME'
-    test_var_set 'AUTHENTICODE_CERT_PATH'
-    test_var_set 'AUTHENTICODE_CROSS_CERT_PATH'
-    test_var_set 'AUTHENTICODE_TIMESTAMP_STYLE'
-    test_var_set 'AUTOGRAPH_FENNEC_PASSWORD'
-    test_var_set 'AUTOGRAPH_FENNEC_USERNAME'
-    test_var_set 'AUTOGRAPH_GPG_PASSWORD'
-    test_var_set 'AUTOGRAPH_GPG_USERNAME'
-    test_var_set 'AUTOGRAPH_LANGPACK_PASSWORD'
-    test_var_set 'AUTOGRAPH_LANGPACK_USERNAME'
-    test_var_set 'AUTOGRAPH_MAR_PASSWORD'
-    test_var_set 'AUTOGRAPH_MAR_STAGE_PASSWORD'
-    test_var_set 'AUTOGRAPH_MAR_STAGE_USERNAME'
-    test_var_set 'AUTOGRAPH_MAR_USERNAME'
-    test_var_set 'AUTOGRAPH_OMNIJA_PASSWORD'
-    test_var_set 'AUTOGRAPH_OMNIJA_USERNAME'
-    test_var_set 'AUTOGRAPH_WIDEVINE_PASSWORD'
-    test_var_set 'AUTOGRAPH_WIDEVINE_USERNAME'
-    ;;
-  fake-prod)
+  dev|fake-prod)
     case $COT_PRODUCT in
       firefox|thunderbird)
         test_var_set 'AUTOGRAPH_AUTHENTICODE_PASSWORD'
@@ -113,6 +96,17 @@ case $ENV in
       application-services)
         test_var_set 'AUTOGRAPH_GPG_PASSWORD'
         test_var_set 'AUTOGRAPH_GPG_USERNAME'
+        ;;
+      xpi)
+        test_var_set 'AUTOGRAPH_XPI_PASSWORD'
+        test_var_set 'AUTOGRAPH_XPI_USERNAME'
+        ;;
+      mpd001)
+        test_var_set 'AUTOGRAPH_AUTHENTICODE_PASSWORD'
+        test_var_set 'AUTOGRAPH_AUTHENTICODE_USERNAME'
+        test_var_set 'AUTHENTICODE_CERT_PATH'
+        test_var_set 'AUTHENTICODE_CROSS_CERT_PATH'
+        test_var_set 'AUTHENTICODE_TIMESTAMP_STYLE'
         ;;
     esac
     ;;
@@ -166,6 +160,17 @@ case $ENV in
       application-services)
         test_var_set 'AUTOGRAPH_GPG_USERNAME'
         test_var_set 'AUTOGRAPH_GPG_PASSWORD'
+        ;;
+      xpi)
+        test_var_set 'AUTOGRAPH_XPI_PASSWORD'
+        test_var_set 'AUTOGRAPH_XPI_USERNAME'
+        ;;
+      mpd001)
+        test_var_set 'AUTOGRAPH_AUTHENTICODE_PASSWORD'
+        test_var_set 'AUTOGRAPH_AUTHENTICODE_USERNAME'
+        test_var_set 'AUTHENTICODE_CERT_PATH'
+        test_var_set 'AUTHENTICODE_CROSS_CERT_PATH'
+        test_var_set 'AUTHENTICODE_TIMESTAMP_STYLE'
         ;;
     esac
     ;;

--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -168,6 +168,8 @@ case $ENV in
       mpd001)
         test_var_set 'AUTOGRAPH_AUTHENTICODE_PASSWORD'
         test_var_set 'AUTOGRAPH_AUTHENTICODE_USERNAME'
+        test_var_set 'AUTOGRAPH_AUTHENTICODE_EV_PASSWORD'
+        test_var_set 'AUTOGRAPH_AUTHENTICODE_EV_USERNAME'
         test_var_set 'AUTHENTICODE_CERT_PATH'
         test_var_set 'AUTHENTICODE_CROSS_CERT_PATH'
         test_var_set 'AUTHENTICODE_TIMESTAMP_STYLE'

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -5,12 +5,14 @@ $let:
       'COT_PRODUCT == "thunderbird"': 'project:comm:thunderbird:releng:signing:'
       'COT_PRODUCT == "mobile"': 'project:mobile:focus:releng:signing:'
       'COT_PRODUCT == "application-services"': 'project:mozilla:application-services:releng:signing'
+      'COT_PRODUCT == "xpi"': 'project:xpi:releng:signing:'
+      'COT_PRODUCT == "mpd001"': 'project:mpd001:releng:signing:'
 in:
   $merge:
     $match:
 
       # dep-passwords.json
-      'ENV == "dev" || (ENV == "fake-prod" && (COT_PRODUCT == "firefox" || COT_PRODUCT == "thunderbird"))':
+      '(ENV == "dev" || ENV == "fake-prod") && (COT_PRODUCT == "firefox" || COT_PRODUCT == "thunderbird")':
         $let:
           firefox_and_thunderbird_nonprod_autograph:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
@@ -93,6 +95,25 @@ in:
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["autograph_gpg"]
             ]
+
+      # dep-passwords-xpi.json
+      '(ENV == "dev" || ENV == "fake-prod") && COT_PRODUCT == "xpi"':
+        '${scope_prefix[0]}cert:dep-signing':
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_XPI_USERNAME"},
+             {"$eval": "AUTOGRAPH_XPI_PASSWORD"},
+             ["extension_rsa_dep", "systemaddon_rsa_dep"]
+            ]
+
+      # dep-passwords-mpd001.json
+      '(ENV == "dev" || ENV == "fake-prod") && COT_PRODUCT == "mpd001"':
+        '${scope_prefix[0]}cert:dep-signing':
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_USERNAME"},
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_PASSWORD"},
+             ["autograph_authenticode", "autograph_authenticode_stub"]
+            ]
+
       # passwords.json
       'ENV == "prod" && (COT_PRODUCT == "firefox" || COT_PRODUCT == "thunderbird")':
         $let:
@@ -240,4 +261,22 @@ in:
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["autograph_gpg"]
+            ]
+
+      # passwords-xpi.json
+      'ENV == "prod" && COT_PRODUCT == "xpi"':
+        '${scope_prefix[0]}cert:release-signing':
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_XPI_USERNAME"},
+             {"$eval": "AUTOGRAPH_XPI_PASSWORD"},
+             ["extension_rsa", "systemaddon_rsa_rel"]
+            ]
+
+      # passwords-mpd001.json
+      'ENV == "prod" && COT_PRODUCT == "mpd001"':
+        '${scope_prefix[0]}cert:release-signing':
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_USERNAME"},
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_PASSWORD"},
+             ["autograph_authenticode", "autograph_authenticode_stub"]
             ]

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -113,6 +113,11 @@ in:
              {"$eval": "AUTOGRAPH_AUTHENTICODE_PASSWORD"},
              ["autograph_authenticode", "autograph_authenticode_stub"]
             ]
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_EV_USERNAME"},
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_EV_PASSWORD"},
+             ["autograph_authenticode_ev"]
+            ]
 
       # passwords.json
       'ENV == "prod" && (COT_PRODUCT == "firefox" || COT_PRODUCT == "thunderbird")':
@@ -279,4 +284,9 @@ in:
              {"$eval": "AUTOGRAPH_AUTHENTICODE_USERNAME"},
              {"$eval": "AUTOGRAPH_AUTHENTICODE_PASSWORD"},
              ["autograph_authenticode", "autograph_authenticode_stub"]
+            ]
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_EV_USERNAME"},
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_EV_PASSWORD"},
+             ["autograph_authenticode_ev"]
             ]

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -102,7 +102,14 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_XPI_USERNAME"},
              {"$eval": "AUTOGRAPH_XPI_PASSWORD"},
-             ["extension_rsa_dep", "systemaddon_rsa_dep"]
+             ["privileged_webextension"],
+             "extension_rsa_dep"
+            ]
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_XPI_USERNAME"},
+             {"$eval": "AUTOGRAPH_XPI_PASSWORD"},
+             ["system_addon"],
+             "systemaddon_rsa_dep"
             ]
 
       # dep-passwords-mpd001.json
@@ -274,7 +281,14 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_XPI_USERNAME"},
              {"$eval": "AUTOGRAPH_XPI_PASSWORD"},
-             ["extension_rsa", "systemaddon_rsa_rel"]
+             ["privileged_webextension"],
+             "extension_rsa"
+            ]
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_XPI_USERNAME"},
+             {"$eval": "AUTOGRAPH_XPI_PASSWORD"},
+             ["system_addon"],
+             "systemaddon_rsa_rel"
             ]
 
       # passwords-mpd001.json

--- a/signingscript/docker.d/worker.yml
+++ b/signingscript/docker.d/worker.yml
@@ -17,7 +17,7 @@ taskcluster_scope_prefixes:
         - 'project:mobile:reference-browser:releng:signing:'
         - 'project:mobile:firefox-tv:releng:signing:'
       'COT_PRODUCT == "application-services"':
-        - 'project:mozilla:application-services:releng:signing'
+        - 'project:mozilla:application-services:releng:signing:'
 token_duration_seconds: 7200
 dmg: { "$eval": "DMG_PATH" }
 hfsplus: { "$eval": "HFSPLUS_PATH" }

--- a/signingscript/docker.d/worker.yml
+++ b/signingscript/docker.d/worker.yml
@@ -18,6 +18,10 @@ taskcluster_scope_prefixes:
         - 'project:mobile:firefox-tv:releng:signing:'
       'COT_PRODUCT == "application-services"':
         - 'project:mozilla:application-services:releng:signing:'
+      'COT_PRODUCT == "xpi"':
+        - 'project:xpi:releng:signing:'
+      'COT_PRODUCT == "mpd001"':
+        - 'project:mpd001:releng:signing:'
 token_duration_seconds: 7200
 dmg: { "$eval": "DMG_PATH" }
 hfsplus: { "$eval": "HFSPLUS_PATH" }


### PR DESCRIPTION
This only has a partial mpd001 config currently. We still need SOPS secrets. (I created the taskcluster clients already; those are landed in the secrets repo.)

Related:
- https://github.com/mozilla-releng/scriptworker-scripts/pull/65 (not sure if I'm supposed to test this on the yet-to-be-created dev pod first, or if we're going to land this and then create the dev pod)
- https://github.com/mozilla-releng/k8s-autoscale/pull/67
- https://github.com/mozilla-services/cloudops-infra/pull/1647

Getting preliminary review, but we should probably get everything ready to go before we land.