### PR TITLE
Bug 1600104 - Expose `fennec-nightly-signing` scope to fenix

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -144,6 +144,8 @@ case $ENV in
         test_var_set 'AUTOGRAPH_WIDEVINE_USERNAME'
         ;;
       mobile)
+        test_var_set 'AUTOGRAPH_FENNEC_NIGHTLY_PASSWORD'
+        test_var_set 'AUTOGRAPH_FENNEC_NIGHTLY_USERNAME'
         test_var_set 'AUTOGRAPH_FENNEC_RELEASE_PASSWORD'
         test_var_set 'AUTOGRAPH_FENNEC_RELEASE_USERNAME'
         test_var_set 'AUTOGRAPH_FIREFOX_TV_USERNAME'

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -202,6 +202,12 @@ in:
              {"$eval": "AUTOGRAPH_FENIX_PASSWORD"},
              ["autograph_apk"]
             ]
+        project:mobile:fenix:releng:signing:cert:fennec-nightly-signing:
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_FENNEC_NIGHTLY_USERNAME"},
+             {"$eval": "AUTOGRAPH_FENNEC_NIGHTLY_PASSWORD"},
+             ["autograph_apk"]
+            ]
         project:mobile:fenix:releng:signing:cert:fennec-production-signing:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},


### PR DESCRIPTION
`AUTOGRAPH_FENNEC_NIGHTLY_*` is available per https://github.com/mozilla-releng/scriptworker-scripts/blob/d64a7f9120f63ae534ec143b1484fc2e53fe5452/signingscript/docker.d/passwords.yml#L147-L148

We use `autograph_apk` instead `autograph_apk_fennec_sha1` of because of https://github.com/mozilla-releng/build-puppet/pull/591#discussion_r320742427