### PR TITLE
Bug 1600978 - Use TASKCLUSTER_SCOPE_PREFIX to set TASKCLUSTER_SCOPE.

### DIFF
--- a/shipitscript/docker.d/init_worker.sh
+++ b/shipitscript/docker.d/init_worker.sh
@@ -10,20 +10,6 @@ test_var_set() {
   fi
 }
 
-case $ENV in
-  dev|fake-prod)
-    export API_ROOT_V2="https://api.shipit.staging.mozilla-releng.net"
-    export TASKCLUSTER_SCOPE="project:releng:ship-it:server:staging"
-    ;;
-  prod)
-    export API_ROOT_V2="https://shipit-api.mozilla-releng.net"
-    export TASKCLUSTER_SCOPE="project:releng:ship-it:server:production"
-    ;;
-  *)
-    exit 1
-    ;;
-esac
-
 case $COT_PRODUCT in
   firefox)
     export TASKCLUSTER_SCOPE_PREFIX="project:releng:ship-it:"
@@ -35,6 +21,22 @@ case $COT_PRODUCT in
     exit 1
     ;;
 esac
+
+
+case $ENV in
+  dev|fake-prod)
+    export API_ROOT_V2="https://api.shipit.staging.mozilla-releng.net"
+    export TASKCLUSTER_SCOPE="${TASKCLUSTER_SCOPE_PREFIX}server:staging"
+    ;;
+  prod)
+    export API_ROOT_V2="https://shipit-api.mozilla-releng.net"
+    export TASKCLUSTER_SCOPE="${TASKCLUSTER_SCOPE_PREFIX}server:production"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+
 
 export MARK_AS_SHIPPED_SCHEMA_FILE="/app/shipitscript/shipitscript/data/mark_as_shipped_task_schema.json"
 export CREATE_NEW_RELEASE_SCHEMA_FILE="/app/shipitscript/shipitscript/data/create_new_release_task_schema.json"


### PR DESCRIPTION
This is is fix an issue with incorrect scopes when Thunderbird
runs the release-mark-as-shipped task.