### PR TITLE
Bug 1600104 - part 2: Change "Fenix as Fennec" nightly digest to SHA1

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -206,7 +206,7 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_FENNEC_NIGHTLY_USERNAME"},
              {"$eval": "AUTOGRAPH_FENNEC_NIGHTLY_PASSWORD"},
-             ["autograph_apk"]
+             ["autograph_apk_fennec_sha1"]
             ]
         project:mobile:fenix:releng:signing:cert:fennec-production-signing:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",


### PR DESCRIPTION
See https://mozilla.slack.com/archives/CKM7DLL67/p1575476629022200?thread_ts=1575453733.016500&cid=CKM7DLL67 and following messages.

Basically Fenix signed as Fennec nightly cannot be installed:

```
adb: failed to install nightly.apk: Failure [INSTALL_PARSE_FAILED_NO_CERTIFICATES: Failed to collect certificates from /data/app/vmdl1882734546.tmp/base.apk: /data/app/vmdl1882734546.tmp/base.apk failed verification of META-INF/SIGNATURE.SF: Failed to verify signature: no verified SignerInfos]
```

`apksigner` is more verbose about the error:
```
$ apksigner verify --verbose target.apk
DOES NOT VERIFY
ERROR: JAR signer SIGNATURE.DSA: JAR signature META-INF/SIGNATURE.DSA uses digest algorithm SHA-256 and signature algorithm DSA which is not supported on API Level(s) 21 for which this APK is being verified
```

We're not exactly facing [bug 1332916](https://bugzilla.mozilla.org/show_bug.cgi?id=1332916) again, but it's about the same thing.

Fenix targets [Android 5.0+](https://github.com/mozilla-mobile/fenix/blob/fdd7400ccce73cb4912ca766a03b26eed283c692/architecture/build.gradle#L13), which is [API 21](https://developer.android.com/guide/topics/manifest/uses-sdk-element.html#ApiLevels).

I looked at the code of Android, and actually DSA + sha256 was [introduced in API 22](https://android.googlesource.com/platform/tools/apksig/+/refs/tags/android-9.0.0_r51/src/main/java/com/android/apksig/internal/apk/v1/V1SchemeVerifier.java#1030).

We don't want to bump Fenix from API 21 to API 22, just for migrating Fennec Nightly users. Therefore, let's change its digest to be back at sha1 again. 