### PR TITLE
Do not modify passed headers

### DIFF
--- a/shipitscript/shipitscript/shipitapi.py
+++ b/shipitscript/shipitscript/shipitapi.py
@@ -54,6 +54,7 @@ class Release_V2(object):
 
     def _request(self, api_endpoint, data=None, method='GET', headers={}):
         url = '{}{}'.format(self.api_root, api_endpoint)
+        headers = headers.copy()
         if method.upper() not in ('GET', 'HEAD'):
             headers.update(
                 self._get_taskcluster_headers(

--- a/shipitscript/shipitscript/test/test_shipitapi.py
+++ b/shipitscript/shipitscript/test/test_shipitapi.py
@@ -72,8 +72,12 @@ def test_release_v2_class(mocker):
     api_call_count += 1
 
     # test that update call correct URL
+    headers = {'X-Test': 'yes'}
     ret = release.update_status(
-        release_name, status='success test', rebuild_product_details=False
+        release_name,
+        status='success test',
+        rebuild_product_details=False,
+        headers=headers,
     )
     ret_json = json.loads(ret)
     assert ret_json['test'] is True
@@ -88,6 +92,8 @@ def test_release_v2_class(mocker):
     )
     api_call_count += 1
     assert release.session.request.call_count == api_call_count
+    # make sure we don't modify the passed headers dictionary in the methods
+    assert headers == {'X-Test': 'yes'}
 
     # test that update triggers product details
     ret = release.update_status(


### PR DESCRIPTION
We shouldn't mutate the passed `headers` dictionary, because the Hawk
header depends on the URL and the payload. Also we shouldn't mutate them
in any case. :)

I found this inspecting the shipitapi logs and realized that we send Hawk headers for GET requests, while we shouldn't.