### PR TITLE
Speedup pinning

### DIFF
--- a/maintenance/pin.sh
+++ b/maintenance/pin.sh
@@ -22,7 +22,5 @@ else
     "
 fi
 
-for dir in $DIRS; do
-    docker run -t -v $PWD:/src -w /src python:3.7 maintenance/pin-helper.sh "$dir"
-    docker run -t -v $PWD:/src -e SUFFIX=py38.txt -w /src python:3.8 maintenance/pin-helper.sh "$dir"
-done
+docker run -t -v $PWD:/src -w /src python:3.7 maintenance/pin-helper.sh $DIRS
+docker run -t -v $PWD:/src -e SUFFIX=py38.txt -w /src python:3.8 maintenance/pin-helper.sh $DIRS


### PR DESCRIPTION
Run the helper 2 times instead of 2 times per directory. This way we
don't run the initial package installation step multiple times. This
speeds up the process a bit, especially when you are tethering. :)