### PR TITLE
Do not override python dependencies

### DIFF
--- a/addonscript/Dockerfile
+++ b/addonscript/Dockerfile
@@ -16,7 +16,6 @@ RUN python -m venv /app \
  && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/configloader \
- && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app
 

--- a/balrogscript/Dockerfile
+++ b/balrogscript/Dockerfile
@@ -16,7 +16,6 @@ RUN python -m venv /app \
  && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/configloader \
- && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app
 

--- a/beetmoverscript/Dockerfile
+++ b/beetmoverscript/Dockerfile
@@ -15,7 +15,6 @@ RUN python -m venv /app \
  && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/configloader \
- && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app
 

--- a/bouncerscript/Dockerfile
+++ b/bouncerscript/Dockerfile
@@ -15,7 +15,6 @@ RUN python -m venv /app \
  && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/configloader \
- && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app
 

--- a/pushapkscript/Dockerfile
+++ b/pushapkscript/Dockerfile
@@ -18,7 +18,6 @@ RUN python -m venv /app \
  && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/configloader \
- && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app
 

--- a/pushsnapscript/Dockerfile
+++ b/pushsnapscript/Dockerfile
@@ -23,7 +23,6 @@ RUN python -m venv /app \
  && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/configloader \
- && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app
 

--- a/shipitscript/Dockerfile
+++ b/shipitscript/Dockerfile
@@ -16,7 +16,6 @@ RUN python -m venv /app \
  && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/configloader \
- && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app
 

--- a/signingscript/Dockerfile
+++ b/signingscript/Dockerfile
@@ -19,7 +19,6 @@ RUN python -m venv /app \
  && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/configloader \
- && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app
 

--- a/treescript/Dockerfile
+++ b/treescript/Dockerfile
@@ -21,7 +21,6 @@ RUN python -m venv /app \
  && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/configloader \
- && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app
 


### PR DESCRIPTION
Ideally we should install configloader isolated, I'll tackle this in another PR. This PR uses the approach we used before I added the problematic `pip install -r requirements/base.txt`