### PR TITLE
Fix l10n_bump when the tree is closed (bug 1604476)

### DIFF
--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -6,6 +6,7 @@ import os.path
 import re
 import shutil
 import subprocess
+import sys
 import tarfile
 import zipfile
 from contextlib import contextmanager
@@ -27,6 +28,21 @@ from signingscript.utils import get_hash
 TEST_CERT_TYPE = "{}cert:dep-signing".format(DEFAULT_SCOPE_PREFIX)
 
 INSTALL_DIR = os.path.dirname(sign.__file__)
+
+
+def async_mock_return_value(value):
+    """
+    Return a value appropriate to assign to `mock.return_value` of an async function.
+    Python 3.8 added asyncio support to mock, so setting `mock.return_value` to
+    a `Future` cause the result of awaiting the result a future, rather than a
+    value.
+    """
+    if sys.version_info >= (3, 8):
+        return value
+    else:
+        future = asyncio.Future()
+        future.set_result(value)
+        return future
 
 
 @contextmanager
@@ -821,8 +837,7 @@ async def test_gpg_autograph(context, mocker, tmp_path):
     }
 
     mocked_sign = mocker.patch.object(sign, "sign_with_autograph")
-    mocked_sign.return_value = asyncio.Future()
-    mocked_sign.return_value.set_result("--- FAKE SIG ---")
+    mocked_sign.return_value = async_mock_return_value("--- FAKE SIG ---")
 
     result = await sign.sign_gpg_with_autograph(context, tmp, "autograph_gpg")
 

--- a/treescript/src/treescript/l10n.py
+++ b/treescript/src/treescript/l10n.py
@@ -211,16 +211,18 @@ async def l10n_bump(config, task, repo_path):
 
     """
     log.info("Preparing to bump l10n changesets.")
-    dontbuild = get_dontbuild(task)
-    ignore_closed_tree = get_ignore_closed_tree(task)
-    l10n_bump_info = get_l10n_bump_info(task)
-    revision_info = None
-    changes = 0
 
+    ignore_closed_tree = get_ignore_closed_tree(task)
     if not ignore_closed_tree:
         if not await check_treestatus(config, task):
             log.info("Treestatus is closed; skipping l10n bump.")
             return 0
+
+    dontbuild = get_dontbuild(task)
+    l10n_bump_info = get_l10n_bump_info(task)
+    revision_info = None
+    changes = 0
+
     for bump_config in l10n_bump_info:
         if bump_config.get("revision_url"):
             revision_info = await get_revision_info(bump_config, repo_path)

--- a/treescript/src/treescript/l10n.py
+++ b/treescript/src/treescript/l10n.py
@@ -207,7 +207,7 @@ async def l10n_bump(config, task, repo_path):
                                if the file is not in the target repository.
 
     Returns:
-        bool: True if there are any changes.
+        int: non-zero if there are any changes.
 
     """
     log.info("Preparing to bump l10n changesets.")
@@ -220,7 +220,7 @@ async def l10n_bump(config, task, repo_path):
     if not ignore_closed_tree:
         if not await check_treestatus(config, task):
             log.info("Treestatus is closed; skipping l10n bump.")
-            return
+            return 0
     for bump_config in l10n_bump_info:
         if bump_config.get("revision_url"):
             revision_info = await get_revision_info(bump_config, repo_path)


### PR DESCRIPTION
do_actions expects l10n_bump to return an int, not None.