### PR TITLE
[treescript] Change how actions are handled.

### DIFF
--- a/treescript/src/treescript/data/treescript_task_schema.json
+++ b/treescript/src/treescript/data/treescript_task_schema.json
@@ -96,6 +96,9 @@
                 "dry_run": {
                     "type": "boolean"
                 },
+                "push": {
+                    "type": "boolean"
+                },
                 "dontbuild": {
                     "type": "boolean"
                 },

--- a/treescript/src/treescript/script.py
+++ b/treescript/src/treescript/script.py
@@ -30,17 +30,12 @@ async def do_actions(config, task, actions, repo_path):
     """
     await checkout_repo(config, task, repo_path)
     num_changes = 0
-    for action in actions:
-        if action in ["tagging", "tag"]:
-            num_changes += await do_tagging(config, task, repo_path)
-        elif "version_bump" == action:
-            num_changes += await bump_version(config, task, repo_path)
-        elif "l10n_bump" == action:
-            num_changes += await l10n_bump(config, task, repo_path)
-        elif "push" == action:
-            pass  # handled after log_outgoing
-        else:
-            raise NotImplementedError("Unexpected action")
+    if "tag" in actions:
+        num_changes += await do_tagging(config, task, repo_path)
+    if "version_bump" in actions:
+        num_changes += await bump_version(config, task, repo_path)
+    if "l10n_bump" in actions:
+        num_changes += await l10n_bump(config, task, repo_path)
     num_outgoing = await log_outgoing(config, task, repo_path)
     if num_outgoing != num_changes:
         raise TreeScriptError("Outgoing changesets don't match number of expected changesets!" " {} vs {}".format(num_outgoing, num_changes))

--- a/treescript/src/treescript/script.py
+++ b/treescript/src/treescript/script.py
@@ -8,7 +8,7 @@ from scriptworker_client.client import sync_main
 from treescript.exceptions import CheckoutError, PushError, TreeScriptError
 from treescript.l10n import l10n_bump
 from treescript.mercurial import checkout_repo, do_tagging, log_mercurial_version, log_outgoing, push, strip_outgoing, validate_robustcheckout_works
-from treescript.task import is_dry_run, task_action_types
+from treescript.task import should_push, task_action_types
 from treescript.versionmanip import bump_version
 
 log = logging.getLogger(__name__)
@@ -44,15 +44,11 @@ async def do_actions(config, task, actions, repo_path):
     num_outgoing = await log_outgoing(config, task, repo_path)
     if num_outgoing != num_changes:
         raise TreeScriptError("Outgoing changesets don't match number of expected changesets!" " {} vs {}".format(num_outgoing, num_changes))
-    if is_dry_run(task):
-        log.info("Not pushing changes, dry_run was forced")
-    elif "push" in actions:
+    if should_push(task, actions):
         if num_changes:
             await push(config, task, repo_path)
         else:
             log.info("No changes; skipping push.")
-    else:
-        log.info("Not pushing changes, lacking scopes")
     await strip_outgoing(config, task, repo_path)
 
 

--- a/treescript/src/treescript/task.py
+++ b/treescript/src/treescript/task.py
@@ -186,17 +186,17 @@ def get_ignore_closed_tree(task):
 
 # task_action_types {{{1
 def task_action_types(config, task):
-    """Extract task actions as scope definitions.
+    """Extract task actions from task payload.
 
     Args:
         config (dict): the running config.
         task (dict): the task definition.
 
     Raises:
-        TaskVerificationError: if the number of cert scopes is not 1.
+        TaskVerificationError: if unknown actions are specified.
 
     Returns:
-        str: the cert type.
+        set: the set of specified actions
 
     """
     actions = set(task["payload"].get("actions", []))
@@ -210,9 +210,11 @@ def task_action_types(config, task):
 
 # is_dry_run {{{1
 def should_push(task, actions):
-    """Extract task force_dry_run feature.
+    """Determine whether this task should push the changes it makes.
 
-    This is meant as a means to do a dry-run even if the task has the push action scope.
+    If `dry_run` is true on the task, there will not be a push.
+    Otherwise, if `push` is specified, that determines if there should be a push.
+    Otherwise, there is a push if the `push` action is specified.
 
     Args:
         task (dict): the task definition.
@@ -221,7 +223,7 @@ def should_push(task, actions):
         TaskVerificationError: if the number of cert scopes is not 1.
 
     Returns:
-        str: the cert type.
+        bool: whether this task should push
 
     """
     dry_run = task["payload"].get("dry_run", False)

--- a/treescript/src/treescript/task.py
+++ b/treescript/src/treescript/task.py
@@ -7,14 +7,10 @@ from treescript.exceptions import TaskVerificationError
 log = logging.getLogger(__name__)
 
 
-VALID_ACTIONS = ("tag", "version_bump", "l10n_bump", "push")
+VALID_ACTIONS = {"tag", "version_bump", "l10n_bump", "push"}
 
 DONTBUILD_MSG = " DONTBUILD"
 CLOSED_TREE_MSG = " CLOSED TREE"
-
-
-def _sort_actions(actions):
-    return sorted(actions, key=VALID_ACTIONS.index)
 
 
 # get_source_repo {{{1
@@ -203,13 +199,13 @@ def task_action_types(config, task):
         str: the cert type.
 
     """
-    actions = task["payload"].get("actions", [])
+    actions = set(task["payload"].get("actions", []))
     log.info("Action requests: %s", actions)
-    invalid_actions = set(actions) - set(VALID_ACTIONS)
+    invalid_actions = actions - VALID_ACTIONS
     if len(invalid_actions) > 0:
         raise TaskVerificationError("Task specified invalid actions: {}".format(invalid_actions))
 
-    return _sort_actions(actions)
+    return actions
 
 
 # is_dry_run {{{1

--- a/treescript/src/treescript/task.py
+++ b/treescript/src/treescript/task.py
@@ -7,10 +7,7 @@ from treescript.exceptions import TaskVerificationError
 log = logging.getLogger(__name__)
 
 
-# This list should be sorted in the order the actions should be taken
-# XXX remove `tagging` when we remove scope support for actions
-#     (payload-based actions will use `tag`)
-VALID_ACTIONS = ("tag", "tagging", "version_bump", "l10n_bump", "push")
+VALID_ACTIONS = ("tag", "version_bump", "l10n_bump", "push")
 
 DONTBUILD_MSG = " DONTBUILD"
 CLOSED_TREE_MSG = " CLOSED TREE"
@@ -206,13 +203,7 @@ def task_action_types(config, task):
         str: the cert type.
 
     """
-    if task.get("payload", {}).get("actions"):
-        actions = task["payload"]["actions"]
-    else:
-        log.warning("Scopes-based actions are deprecated! Use task.payload.actions instead.")
-        actions = [s.split(":")[-1] for s in task["scopes"] if s.startswith(config["taskcluster_scope_prefix"] + "action:")]
-        if len(actions) < 1:
-            raise TaskVerificationError("Need at least one valid action specified in scopes")
+    actions = task["payload"].get("actions", [])
     log.info("Action requests: %s", actions)
     invalid_actions = set(actions) - set(VALID_ACTIONS)
     if len(invalid_actions) > 0:

--- a/treescript/tests/test_mercurial.py
+++ b/treescript/tests/test_mercurial.py
@@ -20,6 +20,7 @@ from treescript.task import DONTBUILD_MSG
 ROBUSTCHECKOUT_FILES = (
     os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "build", "lib", "treescript", "py2", "robustcheckout.py")),
     os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src", "treescript", "py2", "robustcheckout.py")),
+    os.path.abspath(os.path.join(os.path.dirname(mercurial.__file__), "py2", "robustcheckout.py")),
 )
 UNEXPECTED_ENV_KEYS = "HG HGPROF CDPATH GREP_OPTIONS http_proxy no_proxy " "HGPLAINEXCEPT EDITOR VISUAL PAGER NO_PROXY CHGDEBUG".split()
 

--- a/treescript/tests/test_task.py
+++ b/treescript/tests/test_task.py
@@ -252,7 +252,7 @@ def test_get_ignore_closed_tree(task_defn, closed_tree):
 @pytest.mark.parametrize("actions", (["tag"], ["version_bump"], ["tag", "version_bump", "push"]))
 def test_task_action_types_actions(actions):
     task = {"payload": {"actions": actions}}
-    assert actions == ttask.task_action_types(SCRIPT_CONFIG, task)
+    assert set(actions) == ttask.task_action_types(SCRIPT_CONFIG, task)
 
 
 # task_task_action_types {{{1

--- a/treescript/tests/test_task.py
+++ b/treescript/tests/test_task.py
@@ -7,10 +7,6 @@ from scriptworker_client.client import verify_task_schema
 from scriptworker_client.exceptions import TaskVerificationError
 from treescript.script import get_default_config
 
-TEST_ACTION_TAG = "project:releng:treescript:action:tagging"
-TEST_ACTION_BUMP = "project:releng:treescript:action:version_bump"
-TEST_ACTION_INVALID = "project:releng:treescript:action:invalid"
-
 SCRIPT_CONFIG = {"taskcluster_scope_prefix": "project:releng:treescript:"}
 
 
@@ -259,27 +255,13 @@ def test_task_action_types_actions(actions):
     assert actions == ttask.task_action_types(SCRIPT_CONFIG, task)
 
 
-@pytest.mark.parametrize(
-    "actions,scopes",
-    ((["tagging"], [TEST_ACTION_TAG]), (["version_bump"], [TEST_ACTION_BUMP]), (["tagging", "version_bump"], [TEST_ACTION_BUMP, TEST_ACTION_TAG])),
-)
-def test_task_action_types_valid_scopes(actions, scopes):
-    task = {"scopes": scopes}
-    assert actions == ttask.task_action_types(SCRIPT_CONFIG, task)
-
-
-@pytest.mark.parametrize("scopes", ([TEST_ACTION_INVALID], [TEST_ACTION_TAG, TEST_ACTION_INVALID]))
-def test_task_action_types_invalid_action(scopes):
-    task = {"scopes": scopes}
+# task_task_action_types {{{1
+@pytest.mark.parametrize("actions", (["tag", "invalid"], ["invaid"]))
+def test_task_action_types_actions_invalid(actions):
+    task = {"payload": {"actions": actions}}
     with pytest.raises(TaskVerificationError):
         ttask.task_action_types(SCRIPT_CONFIG, task)
 
-
-@pytest.mark.parametrize("scopes", ([], ["project:releng:foo:not:for:here"]))
-def test_task_action_types_missing_action(scopes):
-    task = {"scopes": scopes}
-    with pytest.raises(TaskVerificationError):
-        ttask.task_action_types(SCRIPT_CONFIG, task)
 
 
 @pytest.mark.parametrize("task", ({"payload": {}}, {"payload": {"dry_run": False}}, {"scopes": ["foo"]}))

--- a/treescript/tests/test_task.py
+++ b/treescript/tests/test_task.py
@@ -263,12 +263,22 @@ def test_task_action_types_actions_invalid(actions):
         ttask.task_action_types(SCRIPT_CONFIG, task)
 
 
+@pytest.mark.parametrize("task", ({"payload": {"push": True}}, {"payload": {"dry_run": False, "push": True}}, {"payload": {"actions": ["push"]}}))
+def test_should_push_true(task):
+    actions = ttask.task_action_types(SCRIPT_CONFIG, task)
+    assert True is ttask.should_push(task, actions)
 
-@pytest.mark.parametrize("task", ({"payload": {}}, {"payload": {"dry_run": False}}, {"scopes": ["foo"]}))
-def test_is_dry_run(task):
-    assert False is ttask.is_dry_run(task)
 
-
-def test_is_dry_run_true():
-    task = {"payload": {"dry_run": True}}
-    assert True is ttask.is_dry_run(task)
+@pytest.mark.parametrize(
+    "task",
+    (
+        {"payload": {"dry_run": True}},
+        {"payload": {"dry_run": True, "actions": ["push"]}},
+        {"payload": {"dry_run": True, "push": True}},
+        {"payload": {"push": False, "actions": ["push"]}},
+        {"payload": {}},
+    ),
+)
+def test_should_push_false(task):
+    actions = ttask.task_action_types(SCRIPT_CONFIG, task)
+    assert False is ttask.should_push(task, actions)


### PR DESCRIPTION
- Remove the deprecated support for specifying actions by scope. This is not used on esr68, so can be removed.
- Don't treat `push` as an action. See [the commit message](https://github.com/mozilla-releng/scriptworker-scripts/commit/ec98cf61d4146653b63100e5952f92b64fa8580d) for the rational.
- Treat actions as a set rather than a list; we currently sort the actions in a specific order, so that when we loop over the list of actions, they run in the right order. This changes it to just run each action in the right order, if the action is specified in the set of actions.