### PR TITLE
Bug 1607266 - set backgroundRate and forceFallBack as optional

### DIFF
--- a/balrogscript/src/balrogscript/script.py
+++ b/balrogscript/src/balrogscript/script.py
@@ -98,8 +98,8 @@ def schedule(task, config, auth0_secrets):
         task["payload"]["version"],
         task["payload"]["build_number"],
         task["payload"]["publish_rules"],
-        task["payload"]["release_eta"] or None,  # Send None if release_eta is ''
         task["payload"].get("force_fallback_mapping_update", False),
+        task["payload"]["release_eta"] or None,  # Send None if release_eta is ''
         task["payload"].get("background_rate"),
     ]
     # XXX optionally append background_rate if/when we want to support it

--- a/balrogscript/src/balrogscript/script.py
+++ b/balrogscript/src/balrogscript/script.py
@@ -98,9 +98,9 @@ def schedule(task, config, auth0_secrets):
         task["payload"]["version"],
         task["payload"]["build_number"],
         task["payload"]["publish_rules"],
-        task["payload"]["force_fallback_mapping_update"] or False,
         task["payload"]["release_eta"] or None,  # Send None if release_eta is ''
-        task["payload"]["background_rate"] or None,
+        task["payload"].get("force_fallback_mapping_update", False),
+        task["payload"].get("background_rate"),
     ]
     # XXX optionally append background_rate if/when we want to support it
 


### PR DESCRIPTION
We make the new payload vars optional: https://hg.mozilla.org/releases/mozilla-beta/rev/0b1cde02d80a#l2.71

But we expect them to exist: https://github.com/mozilla-releng/scriptworker-scripts/pull/116/files#diff-c94ab011a5da8654fdb1da7508514dbdR101