### PR TITLE
Relax the beetmover schema for ignored entries.

### DIFF
--- a/beetmoverscript/src/beetmoverscript/data/artifactMap_beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/artifactMap_beetmover_task_schema.json
@@ -142,14 +142,6 @@
                 "upstreamArtifacts",
                 "releaseProperties",
                 "artifactMap"
-            ],
-            "optional": [
-                "build_number",
-                "version",
-                "locale",
-                "maxRunTime",
-                "appVersion",
-                "next_version"
             ]
         }
     },

--- a/beetmoverscript/src/beetmoverscript/data/artifactMap_beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/artifactMap_beetmover_task_schema.json
@@ -29,10 +29,10 @@
                     "type": "string"
                 },
                 "next_version": {
-                    "type": "string"
+                    "$comment": "ignored"
                 },
                 "appVersion": {
-                    "type": "string"
+                    "$comment": "ignored"
                 },
                 "releaseProperties": {
                     "type": "object",

--- a/beetmoverscript/src/beetmoverscript/data/beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/beetmover_task_schema.json
@@ -29,10 +29,10 @@
                     "type": "string"
                 },
                 "next_version" : {
-                     "type" : "string"
+                    "$comment": "ignored"
                 },
                 "appVersion": {
-                    "type": "string"
+                    "$comment": "ignored"
                 },
                 "releaseProperties" : {
                     "type" : "object",

--- a/beetmoverscript/src/beetmoverscript/data/beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/beetmover_task_schema.json
@@ -87,9 +87,7 @@
                     "uniqueItems": true
                 }
             },
-            "required": ["upload_date", "upstreamArtifacts", "releaseProperties"],
-            "optional": ["build_number", "version", "locale", "maxRunTime", "appVersion", "next_version"]
-
+            "required": ["upload_date", "upstreamArtifacts", "releaseProperties"]
         }
     },
     "required": ["payload", "dependencies"]

--- a/beetmoverscript/src/beetmoverscript/data/maven_beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/maven_beetmover_task_schema.json
@@ -29,10 +29,10 @@
                     "type": "string"
                 },
                 "next_version" : {
-                     "type" : "string"
+                    "$comment": "ignored"
                 },
                 "appVersion": {
-                    "type": "string"
+                    "$comment": "ignored"
                 },
                 "releaseProperties" : {
                     "type" : "object",

--- a/beetmoverscript/src/beetmoverscript/data/release_beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/release_beetmover_task_schema.json
@@ -62,9 +62,7 @@
                     }
                 }
             },
-            "required": ["product", "build_number", "version"],
-            "optional": ["upstreamArtifacts", "maxRunTime", "partners"]
-
+            "required": ["product", "build_number", "version"]
         }
     },
     "required": ["payload", "dependencies"]


### PR DESCRIPTION
Beetmover ignores `appVersion` and `next_version`. [Bug 1524639](https://bugzilla.mozilla.org/show_bug.cgi?id=1524639) change the value of `next_version` from `"None"` to `null`, which caused beetmover to reject the tasks, even though it doesn't use those values.