### PR TITLE
Bug 1608882 - Fix mobile staging instance and enable fennec-nightly

### DIFF
--- a/pushapkscript/docker.d/init_worker.sh
+++ b/pushapkscript/docker.d/init_worker.sh
@@ -96,6 +96,8 @@ case $COT_PRODUCT in
         test_var_set 'GOOGLE_CREDENTIALS_FOCUS'
         test_var_set 'GOOGLE_PLAY_SERVICE_ACCOUNT_REFERENCE_BROWSER'
         test_var_set 'GOOGLE_CREDENTIALS_REFERENCE_BROWSER'
+        test_var_set 'GOOGLE_PLAY_SERVICE_ACCOUNT_FIREFOX_AURORA'
+        test_var_set 'GOOGLE_CREDENTIALS_FIREFOX_AURORA_PATH'
         test_var_set 'AMAZON_CLIENT_ID'
         test_var_set 'AMAZON_CLIENT_SECRET'
 
@@ -111,6 +113,7 @@ case $COT_PRODUCT in
         echo $GOOGLE_CREDENTIALS_FOCUS | base64 -d >             $GOOGLE_CREDENTIALS_FOCUS_PATH
         echo $GOOGLE_CREDENTIALS_REFERENCE_BROWSER | base64 -d > $GOOGLE_CREDENTIALS_REFERENCE_BROWSER_PATH
 
+        import_cert fennec-nightly $CERT_DIR/nightly.pem
         import_cert fenix-nightly $CERT_DIR/fenix_nightly.pem
         import_cert fenix-beta $CERT_DIR/fenix_beta.pem
         import_cert fenix-production $CERT_DIR/fenix_production.pem

--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -55,12 +55,19 @@ products:
               certificate_alias: dep
 
       'COT_PRODUCT == "mobile" && ENV == "prod"':
-        - product_names: [ "fenix"]
+        - product_names: [ "fenix" ]
           digest_algorithm: 'SHA-256'
           skip_check_multiple_locales: true
           skip_check_same_locales: true
           skip_checks_fennec: true
           apps:
+            fennec-nightly:
+              package_names: [ "org.mozilla.fennec_aurora" ]
+              certificate_alias: 'fennec-nightly'
+              google:
+                default_track: 'alpha'
+                service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FIREFOX_AURORA" }
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FIREFOX_AURORA_PATH" }
             nightly:
               package_names: [ "org.mozilla.fenix.nightly" ]
               certificate_alias: 'fenix-nightly'
@@ -127,15 +134,35 @@ products:
           skip_check_multiple_locales: true
           skip_check_same_locales: true
           skip_checks_fennec: true
-          override_channel_model: "single_google_app"
-          app:
-            package_names:
-              - "org.mozilla.fenix"
-              - "org.mozilla.fenix.beta"
-              - "org.mozilla.fenix.nightly"
-            service_account: "dummy"
-            credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_DEP_PATH" }
-            certificate_alias: "fenix"
+          apps:
+            fennec-nightly:
+              package_names: [ "org.mozilla.fennec_aurora" ]
+              certificate_alias: 'fennec-nightly'
+              google:
+                default_track: 'alpha'
+                service_account: 'dummy'
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_DEP_PATH" }
+            nightly:
+              package_names: [ "org.mozilla.fenix.nightly" ]
+              certificate_alias: 'fenix-nightly'
+              google:
+                default_track: 'beta'
+                service_account: 'dummy'
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_DEP_PATH" }
+            beta:
+              package_names: [ "org.mozilla.fenix.beta" ]
+              certificate_alias: "fenix-beta"
+              google:
+                default_track: 'beta-closed'
+                service_account: 'dummy'
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_DEP_PATH" }
+            production:
+              package_names: [ "org.mozilla.fenix" ]
+              certificate_alias: 'fenix-production'
+              google:
+                default_track: 'internal'
+                service_account: 'dummy'
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_DEP_PATH" }
         - product_names: [ "focus" ]
           digest_algorithm: "SHA-256"
           skip_check_ordered_version_codes: true


### PR DESCRIPTION
Fixes errors like: 

```
2020-01-14 11:07:21,494 - mozapkpublisher.common.exceptions - CRITICAL - Expected package names ['org.mozilla.fenix', 'org.mozilla.fenix.beta', 'org.mozilla.fenix.nightly'], found {'org.mozilla.fenix'}
```

https://firefox-ci-tc.services.mozilla.com/tasks/HRA-tPa_QHeZcVxM6ty88Q/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FHRA-tPa_QHeZcVxM6ty88Q%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log#L35

They've been here since last summer or so, on staging. 

It also exposes the ability to publish `org.mozilla.fennec_aurora` to the mobile workers.