### PR TITLE
Bug 1610291 - skip commits outside of default for automated betas.

### DIFF
--- a/shipitscript/src/shipitscript/pushlog_scan.py
+++ b/shipitscript/src/shipitscript/pushlog_scan.py
@@ -33,7 +33,9 @@ def get_shippable_revision_build(branch, last_shipped_rev, cron_rev):
     # TODO use redo here to automatically retry
     resp = requests.get(URL.format(branch=branch), params={"full": "1", "fromchange": last_shipped_rev, "tochange": cron_rev})
     pushlog = resp.json()
-    reversed_pushes = [pushlog[k] for k in sorted(pushlog.keys(), reverse=True)]
+    # we strip out all the pushes that contain other branches' commits (e.g. relbranch)
+    reversed_pushes = [pushlog[k] for k in sorted(pushlog.keys(), reverse=True)
+                        if pushlog[k]['changesets'][0]['branch'] == 'default']
     for push in reversed_pushes:
         push_importance = is_push_important(push)
         if push_importance == Importance.IMPORTANT:

--- a/shipitscript/src/shipitscript/pushlog_scan.py
+++ b/shipitscript/src/shipitscript/pushlog_scan.py
@@ -34,8 +34,7 @@ def get_shippable_revision_build(branch, last_shipped_rev, cron_rev):
     resp = requests.get(URL.format(branch=branch), params={"full": "1", "fromchange": last_shipped_rev, "tochange": cron_rev})
     pushlog = resp.json()
     # we strip out all the pushes that contain other branches' commits (e.g. relbranch)
-    reversed_pushes = [pushlog[k] for k in sorted(pushlog.keys(), reverse=True)
-                        if pushlog[k]['changesets'][0]['branch'] == 'default']
+    reversed_pushes = [pushlog[k] for k in sorted(pushlog.keys(), reverse=True) if pushlog[k]["changesets"][0]["branch"] == "default"]
     for push in reversed_pushes:
         push_importance = is_push_important(push)
         if push_importance == Importance.IMPORTANT:


### PR DESCRIPTION
hg.mozilla.org retrieves commits from all branches when queried `from` - `to`. For some repositories (such as esr68) that includes relbranches commits which "pollute" what shipitscript should analyze in order to start a proper beta.

Earlier today we accidentally promoted a Fennec beta release based off a wrong revision. This is to fix this for future.