### PR TITLE
Symlink widevine.py from /etc to site-packages

### DIFF
--- a/signingscript/Dockerfile
+++ b/signingscript/Dockerfile
@@ -22,6 +22,7 @@ RUN python -m venv /app \
  && cd /app/configloader \
  && /app/configloader_venv/bin/pip install -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
+ && ln -sf /etc/widevine.py $(/app/bin/python -c "import site; print(site.getsitepackages()[0])")/widevine.py \
  && cd /app
 
 CMD ["/app/docker.d/init.sh"]


### PR DESCRIPTION
widevine.py is mounted by Kubernetes as /etc/widevine.py

Depends on https://github.com/mozilla-services/cloudops-infra/pull/1846 merged