### PR TITLE
Bug 1617128 - part 1: Allow fennec-profile-manager signing scopes

### DIFF
--- a/signingscript/docker.d/worker.yml
+++ b/signingscript/docker.d/worker.yml
@@ -11,11 +11,12 @@ taskcluster_scope_prefixes:
       'COT_PRODUCT == "thunderbird"':
         - 'project:comm:thunderbird:releng:signing:'
       'COT_PRODUCT == "mobile"':
-        - 'project:mobile:focus:releng:signing:'
         - 'project:mobile:android-components:releng:signing:'
         - 'project:mobile:fenix:releng:signing:'
-        - 'project:mobile:reference-browser:releng:signing:'
+        - 'project:mobile:fennec-profile-manager:releng:signing:'
         - 'project:mobile:firefox-tv:releng:signing:'
+        - 'project:mobile:focus:releng:signing:'
+        - 'project:mobile:reference-browser:releng:signing:'
       'COT_PRODUCT == "application-services"':
         - 'project:mozilla:application-services:releng:signing:'
       'COT_PRODUCT == "xpi"':


### PR DESCRIPTION
Part ~~2~~ 3 will bump scriptworker so we include https://github.com/mozilla-releng/scriptworker/pull/433, which is needed in prod. I don't want prod to be bumped yet because if so, python 3.8 will be deployed. I'd prefer to hold the py3.8 deployment after Fenix Beta is started cc @rail 

As of now, I just need the dep workers to go past this point https://firefox-ci-tc.services.mozilla.com/tasks/eDyVFx5BQ46bEOx6wPuA7A/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FeDyVFx5BQ46bEOx6wPuA7A%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log#L29