### PR TITLE
Bug 1617128 - part 2: Add fennec-profile-manager signing config

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -74,6 +74,13 @@ in:
              {"$eval": "AUTOGRAPH_FENIX_PASSWORD"},
              ["autograph_apk"]
             ]
+        project:mobile:fennec-profile-manager:releng:signing:cert:dep-signing:
+          # Reuse the same Fenix key since it's a fenix-related project
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_FENIX_USERNAME"},
+             {"$eval": "AUTOGRAPH_FENIX_PASSWORD"},
+             ["autograph_apk"]
+            ]
         project:mobile:reference-browser:releng:signing:cert:dep-signing:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_USERNAME"},
@@ -242,6 +249,18 @@ in:
              ["autograph_apk_fennec_sha1"]
             ]
         project:mobile:fenix:releng:signing:cert:fennec-production-signing:
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},
+             {"$eval": "AUTOGRAPH_FENNEC_RELEASE_PASSWORD"},
+             ["autograph_apk"]
+            ]
+        project:mobile:fennec-profile-manager:releng:signing:cert:fennec-nightly-signing:
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_FENNEC_NIGHTLY_USERNAME"},
+             {"$eval": "AUTOGRAPH_FENNEC_NIGHTLY_PASSWORD"},
+             ["autograph_apk_fennec_sha1"]
+            ]
+        project:mobile:fennec-profile-manager:releng:signing:cert:fennec-production-signing:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},
              {"$eval": "AUTOGRAPH_FENNEC_RELEASE_PASSWORD"},


### PR DESCRIPTION
Follows #149 up. 

Fixes https://firefox-ci-tc.services.mozilla.com/tasks/eDyVFx5BQ46bEOx6wPuA7A/runs/3/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FeDyVFx5BQ46bEOx6wPuA7A%2Fruns%2F3%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log#L32