### PR TITLE
Bug 1608103 - Expose fennec sha1 format to dep-signing

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -72,14 +72,14 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_FENIX_USERNAME"},
              {"$eval": "AUTOGRAPH_FENIX_PASSWORD"},
-             ["autograph_apk"]
+             ["autograph_apk", "autograph_apk_fennec_sha1"]
             ]
         project:mobile:fennec-profile-manager:releng:signing:cert:dep-signing:
           # Reuse the same Fenix key since it's a fenix-related project
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_FENIX_USERNAME"},
              {"$eval": "AUTOGRAPH_FENIX_PASSWORD"},
-             ["autograph_apk"]
+             ["autograph_apk", "autograph_apk_fennec_sha1"]
             ]
         project:mobile:reference-browser:releng:signing:cert:dep-signing:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",


### PR DESCRIPTION
Fixes https://firefox-ci-tc.services.mozilla.com/tasks/KhYOQ0z2SxG1Bo-OP2NI-g/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FKhYOQ0z2SxG1Bo-OP2NI-g%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log#L29