### PR TITLE
Do not explicitly trigger product details rebuild

### DIFF
--- a/shipitscript/src/shipitscript/shipitapi.py
+++ b/shipitscript/src/shipitscript/shipitapi.py
@@ -77,12 +77,10 @@ class Release_V2(object):
                 log.error(f"Response code: {resp.status_code}")
             raise
 
-    def update_status(self, name, status, rebuild_product_details=True, headers={}):
+    def update_status(self, name, status, headers={}):
         """Update release status"""
         data = json.dumps({"status": status})
         resp = self._request(api_endpoint="/releases/{}".format(name), method="PATCH", data=data, headers=headers).content
-        if rebuild_product_details:
-            self._request(api_endpoint="/product-details", method="POST", data="{}", headers=headers)
         return resp
 
     def get_disabled_products(self, headers={}):

--- a/shipitscript/tests/test_shipitapi.py
+++ b/shipitscript/tests/test_shipitapi.py
@@ -54,7 +54,7 @@ def test_release_v2_class(mocker):
 
     # test that update call correct URL
     headers = {"X-Test": "yes"}
-    ret = release.update_status(release_name, status="success test", rebuild_product_details=False, headers=headers)
+    ret = release.update_status(release_name, status="success test", headers=headers)
     ret_json = json.loads(ret)
     assert ret_json["test"] is True
     correct_url = "https://www.apiroot.com/releases/releaseName"
@@ -65,15 +65,6 @@ def test_release_v2_class(mocker):
     assert release.session.request.call_count == api_call_count
     # make sure we don't modify the passed headers dictionary in the methods
     assert headers == {"X-Test": "yes"}
-
-    # test that update triggers product details
-    ret = release.update_status(release_name, status="success test", rebuild_product_details=True)
-    ret_json = json.loads(ret)
-    assert ret_json["test"] is True
-    correct_url = "https://www.apiroot.com/product-details"
-    release.session.request.assert_called_with(data="{}", headers=mock.ANY, method="POST", timeout=mock.ANY, verify=mock.ANY, url=correct_url)
-    api_call_count += 2
-    assert release.session.request.call_count == api_call_count
 
     # test that exception raised if error, and retry api call
     release.session.request.return_value.status_code = 400


### PR DESCRIPTION
In https://github.com/mozilla-releng/shipit/pull/179 we change shipit to
automatically rebuild product details, so there is no need to explicitly
trigger this endpoint anymore.