### PR TITLE
fix adhoc signing

### DIFF
--- a/docker.d/init.sh
+++ b/docker.d/init.sh
@@ -70,6 +70,9 @@ case $COT_PRODUCT in
   mpd001)
     export TRUST_DOMAIN=mpd001
     ;;
+  adhoc)
+    export TRUST_DOMAIN=adhoc
+    ;;
   *)
     exit 1
     ;;

--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -59,6 +59,9 @@ case $COT_PRODUCT in
     fi
     ;;
   adhoc)
+    test_var_set 'WIDEVINE_CERT'
+
+    echo $WIDEVINE_CERT | base64 -d > $WIDEVINE_CERT_PATH
     ;;
   *)
     exit 1


### PR DESCRIPTION
The `docker.d/init.sh` patch fixes dev-signingscript. The widevine block isn't needed to fix, but we'll need it down the line, and I had that change locally, so I let it ride along. We can separate the two if wanted.