### PR TITLE
Bug 1624496 - stop pointing at autograph-stage for dep

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -13,6 +13,8 @@ in:
     $match:
 
       # dep-passwords.json
+      # XXX fake-prod, aka dep, shouldn't point at autograph-external.stage
+      # for anything bug autograph_stage_mar384!!
       '(ENV == "dev" || ENV == "fake-prod") && (COT_PRODUCT == "firefox" || COT_PRODUCT == "thunderbird")':
         $let:
           firefox_and_thunderbird_nonprod_autograph:

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -14,7 +14,7 @@ in:
 
       # dep-passwords.json
       # XXX fake-prod, aka dep, shouldn't point at autograph-external.stage
-      # for anything bug autograph_stage_mar384!!
+      # for anything but autograph_stage_mar384!!
       '(ENV == "dev" || ENV == "fake-prod") && (COT_PRODUCT == "firefox" || COT_PRODUCT == "thunderbird")':
         $let:
           firefox_and_thunderbird_nonprod_autograph:

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -46,12 +46,12 @@ in:
                {"$eval": "AUTOGRAPH_WIDEVINE_PASSWORD"},
                ["autograph_widevine"]
               ]
-            - ["https://autograph-external.stage.autograph.services.mozaws.net",
+            - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_OMNIJA_USERNAME"},
                {"$eval": "AUTOGRAPH_OMNIJA_PASSWORD"},
                ["autograph_omnija"]
               ]
-            - ["https://autograph-external.stage.autograph.services.mozaws.net",
+            - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
                {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
                ["autograph_langpack"]


### PR DESCRIPTION
Autograph-external.stage can go down for any reason at any time. Bustage in fake-prod, aka depsigning, is tree-closing. We should point at autograph-external.prod for fake-prod signing.