### PR TITLE
Bug 1626933 Add support for bump_esr action in treescript

### DIFF
--- a/treescript/src/treescript/data/treescript_task_schema.json
+++ b/treescript/src/treescript/data/treescript_task_schema.json
@@ -16,9 +16,6 @@
             "type": "object",
             "required": [
                 "version_files",
-                "version_files_suffix",
-                "version_suffix",
-                "copy_files",
                 "replacements",
                 "to_branch",
                 "to_repo",
@@ -28,47 +25,30 @@
                 "version_files": {
                     "type": "array",
                     "items": {
-                        "type": "string",
-                        "examples": [
-                            "browser/config/version.txt",
-                            "config/milestone.txt"
-                        ]
-                    }
-                },
-                "version_files_suffix": {
-                    "type": "array",
-                    "minItems": 0,
-                    "items": {
-                        "type": "string",
-                        "examples": [
-                            "browser/config/version_display.txt"
-                        ]
-                    }
-                },
-                "version_suffix": {
-                    "type": "string",
-                    "default": "",
-                    "examples": [
-                        "b1"
-                    ],
-                    "pattern": "^([ab][0-9]+|esr|)?$"
-                },
-                "copy_files": {
-                    "type": "array",
-                    "minItems": 0,
-                    "items": {
-                        "type": "array",
-                        "minItems": 2,
-                        "maxItems": 2,
-                        "items": {
-                            "type": "string"
-                        },
-                        "examples": [
-                            [
-                                "browser/config/version.txt",
-                                "browser/config/version_display.txt"
-                            ]
-                        ]
+                        "type": "object",
+                        "required": [
+                            "filename"
+                        ],
+                        "properties": {
+                            "filename": {
+                                "type": "string",
+                                "description": "Path to filename containing a version."
+                            },
+                            "new_suffix": {
+                                "type": "string",
+                                "description": "Replace the current suffix (b1, a1, esr) with this string. Empty is valid."
+                            },
+                            "bump_major_number": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Increment the major version number"
+                            },
+                            "bump_minor_number": {
+                                "type": "boolean",
+                                "default": false,
+                                "description": "Increment the minor version number"
+                            }
+                        }
                     }
                 },
                 "replacements": {

--- a/treescript/src/treescript/data/treescript_task_schema.json
+++ b/treescript/src/treescript/data/treescript_task_schema.json
@@ -38,15 +38,13 @@
                                 "type": "string",
                                 "description": "Replace the current suffix (b1, a1, esr) with this string. Empty is valid."
                             },
-                            "bump_major_number": {
-                                "type": "boolean",
-                                "default": false,
-                                "description": "Increment the major version number"
-                            },
-                            "bump_minor_number": {
-                                "type": "boolean",
-                                "default": false,
-                                "description": "Increment the minor version number"
+                            "version_bump": {
+                                "type": "string",
+                                "enum": [
+                                    "major",
+                                    "minor"
+                                ],
+                                "description": "Increment either the major or minor version number, or neither if empty"
                             }
                         }
                     }

--- a/treescript/src/treescript/merges.py
+++ b/treescript/src/treescript/merges.py
@@ -64,32 +64,54 @@ def touch_clobber_file(config, repo_path):
             f.write(new_contents)
 
 
+def create_new_version(version_config, repo_path):
+    """Create the new version string used in file manipulation.
+
+    Arguments:
+        version_config (dict):
+            {
+                "filename": mandatory path,
+                "new_suffix": string, default is to keep original.
+                "bump_major_number": bool, optional, default false
+                "bump_minor_number": bool, optional, default false
+            }
+
+    Returns:
+        string: new version string for file contents.
+    """
+    version = get_version(version_config["filename"], repo_path)
+    if version_config.get("bump_major_number"):
+        version = version.bump("major_number")
+    if version_config.get("bump_minor_number"):
+        version = version.bump("minor_number")
+    if "new_suffix" in version_config:  # '' is a valid entry
+        version = attr.evolve(version, is_esr=False, beta_number=None, is_nightly=False)
+        version = f"{version}{version_config['new_suffix']}"
+    else:
+        version = f"{version}"
+    log.info("New version is %s", version)
+    return version
+
+
 async def apply_rebranding(config, repo_path, merge_config):
     """Apply changes to repo required for merge/rebranding."""
     log.info("Rebranding %s to %s", merge_config.get("from_branch"), merge_config.get("to_branch"))
 
+    # Must collect this before any bumping.
     version = get_version("browser/config/version.txt", repo_path)
-    current_major_version = version.major_number
-    if merge_config.get("incr_major_version", False):
-        version = version.bump("major_number")
 
     if merge_config.get("version_files"):
-        next_version = f"{version.major_number}.{version.minor_number}"
-        await do_bump_version(config, repo_path, merge_config["version_files"], next_version)
-
-    if merge_config.get("version_files_suffix"):
-        version = attr.evolve(version, is_esr=False, beta_number=None, is_nightly=False)
-        next_version = f"{version}{merge_config.get('version_suffix')}"
-        await do_bump_version(config, repo_path, merge_config["version_files_suffix"], next_version)
+        for version_config in merge_config["version_files"]:
+            await do_bump_version(config, repo_path, [version_config["filename"]], create_new_version(version_config, repo_path))
 
     for f in merge_config.get("copy_files", list()):
         shutil.copyfile(os.path.join(repo_path, f[0]), os.path.join(repo_path, f[1]))
 
     format_options = {
-        "current_major_version": current_major_version,
-        "next_major_version": version.major_number,
-        "current_weave_version": current_major_version + 2,
-        "next_weave_version": current_major_version + 3,  # current_weave_version + 1
+        "current_major_version": version.major_number,
+        "next_major_version": version.major_number + 1,
+        "current_weave_version": version.major_number + 2,
+        "next_weave_version": version.major_number + 3,  # current_weave_version + 1
     }
 
     # Cope with bash variables in strings that we don't want to

--- a/treescript/src/treescript/versionmanip.py
+++ b/treescript/src/treescript/versionmanip.py
@@ -23,6 +23,8 @@ ALLOWED_BUMP_FILES = (
     "mobile/android/config/version-files/beta/version_display.txt",
     "mobile/android/config/version-files/release/version.txt",
     "mobile/android/config/version-files/release/version_display.txt",
+    "mobile/android/config/version-files/nightly/version.txt",
+    "mobile/android/config/version-files/nightly/version_display.txt",
 )
 
 _VERSION_CLASS_PER_BEGINNING_OF_PATH = {

--- a/treescript/tests/test_merges.py
+++ b/treescript/tests/test_merges.py
@@ -192,15 +192,15 @@ async def test_apply_rebranding(config, repo_context, mocker, merge_config, expe
         # beta-to-release
         ({"filename": "browser/config/version_display.txt", "new_suffix": ""}, FirefoxVersion.parse("75.0b9"), "75.0"),
         # bump_central
-        ({"filename": "config/milestone.txt", "bump_major_number": True}, FirefoxVersion.parse("75.0a1"), "76.0a1"),
-        ({"filename": "config/milestone.txt", "bump_major_number": True}, FirefoxVersion.parse("75.0"), "76.0"),
+        ({"filename": "config/milestone.txt", "version_bump": "major"}, FirefoxVersion.parse("75.0a1"), "76.0a1"),
+        ({"filename": "config/milestone.txt", "version_bump": "major"}, FirefoxVersion.parse("75.0"), "76.0"),
         # bump_esr
-        ({"filename": "browser/config/version.txt", "bump_minor_number": True}, FirefoxVersion.parse("68.1.0"), "68.2.0"),
-        ({"filename": "browser/config/version_display.txt", "bump_minor_number": True}, FirefoxVersion.parse("68.1.0esr"), "68.2.0esr"),
-        ({"filename": "mobile/android/config/version-files/beta/version.txt", "bump_minor_number": True}, FennecVersion.parse("68.1"), "68.2"),
-        ({"filename": "mobile/android/config/version-files/beta/version_display.txt", "bump_minor_number": True}, FennecVersion.parse("68.1b9"), "68.2b1"),
-        ({"filename": "mobile/android/config/version-files/nightly/version.txt", "bump_minor_number": True}, FennecVersion.parse("68.1a1"), "68.2a1"),
-        ({"filename": "mobile/android/config/version-files/release/version.txt", "bump_minor_number": True}, FennecVersion.parse("68.6.1"), "68.7.0"),
+        ({"filename": "browser/config/version.txt", "version_bump": "minor"}, FirefoxVersion.parse("68.1.0"), "68.2.0"),
+        ({"filename": "browser/config/version_display.txt", "version_bump": "minor"}, FirefoxVersion.parse("68.1.0esr"), "68.2.0esr"),
+        ({"filename": "mobile/android/config/version-files/beta/version.txt", "version_bump": "minor"}, FennecVersion.parse("68.1"), "68.2"),
+        ({"filename": "mobile/android/config/version-files/beta/version_display.txt", "version_bump": "minor"}, FennecVersion.parse("68.1b9"), "68.2b1"),
+        ({"filename": "mobile/android/config/version-files/nightly/version.txt", "version_bump": "minor"}, FennecVersion.parse("68.1a1"), "68.2a1"),
+        ({"filename": "mobile/android/config/version-files/release/version.txt", "version_bump": "minor"}, FennecVersion.parse("68.6.1"), "68.7.0"),
     ),
 )
 async def test_create_new_version(config, mocker, version_config, current_version, expected):


### PR DESCRIPTION
Have refactored the payload so it can cope with the various different styles of version replacement, and this let us remove copy_files, as that only existed to cope with a version number update.

`merge_flavor` is now called `behavior` in the action, as ideally the action parameter should have been `merge-flavor` but this caused errors in taskcluster.