### PR TITLE
poller - catch TimeoutError during claimWork

### DIFF
--- a/notarization_poller/src/notarization_poller/worker.py
+++ b/notarization_poller/src/notarization_poller/worker.py
@@ -42,7 +42,7 @@ async def claim_work(config, worker_queue, num_tasks=1):
     payload = {"workerGroup": config["worker_group"], "workerId": config["worker_id"], "tasks": num_tasks}
     try:
         return await worker_queue.claimWork(config["provisioner_id"], config["worker_type"], payload)
-    except (taskcluster.exceptions.TaskclusterFailure, aiohttp.ClientError) as exc:
+    except (taskcluster.exceptions.TaskclusterFailure, aiohttp.ClientError, asyncio.TimeoutError) as exc:
         log.warning("{} {}".format(exc.__class__, exc))
 
 


### PR DESCRIPTION
I was thinking about landing this with the rest of the lost UUID changes. Now that we know the root cause of at least some of the lost UUIDs, we may not need those changes, so let's land this earlier.