### PR TITLE
bug 1620697 - Raise exception if `ERROR` is in the response; also notarize pkg in single_zip

### DIFF
--- a/iscript/src/iscript/exceptions.py
+++ b/iscript/src/iscript/exceptions.py
@@ -15,7 +15,15 @@ class UnknownAppDir(IScriptError):
 
 
 class InvalidNotarization(IScriptError):
-    """Apple returned an invalid status for notarization."""
+    """Apple returned an invalid status during notarization polling."""
+
+
+class ThrottledNotarization(IScriptError):
+    """Apple returned an error telling us we hit our upload limit."""
+
+
+class UnknownNotarizationError(IScriptError):
+    """Apple returned an unknown error response during notarization submission."""
 
 
 class TimeoutError(IScriptError):

--- a/iscript/tests/test_mac.py
+++ b/iscript/tests/test_mac.py
@@ -13,7 +13,7 @@ import pexpect
 import pytest
 
 import iscript.mac as mac
-from iscript.exceptions import InvalidNotarization, IScriptError, TimeoutError, UnknownAppDir
+from iscript.exceptions import InvalidNotarization, IScriptError, ThrottledNotarization, TimeoutError, UnknownAppDir, UnknownNotarizationError
 from scriptworker_client.utils import makedirs
 
 
@@ -439,15 +439,21 @@ def test_get_bundle_id(mocker, counter):
 
 # get_uuid_from_log {{{1
 @pytest.mark.parametrize(
-    "uuid, raises",
+    "uuid, raises, extra",
     (
-        ("07307e2c-db26-494c-8630-cfa239d4b86b", False),
-        ("d4d31c49-c075-4ea1-bb7f-150c74f608e1", False),
-        ("d4d31c49-c075-4ea1-bb7f-150c74f608e1", "missing file"),
-        ("%%%%\\\\=", "missing uuid"),
+        ("07307e2c-db26-494c-8630-cfa239d4b86b", False, ""),
+        ("d4d31c49-c075-4ea1-bb7f-150c74f608e1", False, "Blah blah blah\nFoo bar baz"),
+        ("d4d31c49-c075-4ea1-bb7f-150c74f608e1", "missing file", ""),
+        ("%%%%\\\\=", "missing uuid", ""),
+        (
+            "07307e2c-db26-494c-8630-cfa239d4b86b",
+            ThrottledNotarization,
+            'altool[15766:50391190] *** Error: ERROR ITMS-10004: "You have reached your upload limit of 20 software packages per minute. Pause your uploads, then reduce the number of software packages you upload per minute.',
+        ),
+        ("d4d31c49-c075-4ea1-bb7f-150c74f608e1", UnknownNotarizationError, "What the! It looks like you've hit an ERROR of some sort"),
     ),
 )
-def test_get_uuid_from_log(tmpdir, uuid, raises):
+def test_get_uuid_from_log(tmpdir, uuid, raises, extra):
     """``get_uuid_from_log`` returns the correct uuid from the logfile if present.
     It raises if it has problems finding the uuid in the log.
 
@@ -455,9 +461,12 @@ def test_get_uuid_from_log(tmpdir, uuid, raises):
     log_path = os.path.join(str(tmpdir), "log")
     if raises != "missing file":
         with open(log_path, "w") as fh:
-            fh.write("foo\nbar\nbaz\n RequestUUID = {} \nblah\n".format(uuid))
+            fh.write(f"foo\nbar\nbaz\n RequestUUID = {uuid} \n{extra}\nblah\n")
     if raises:
-        with pytest.raises(IScriptError):
+        exception = raises
+        if not isinstance(raises, IScriptError):
+            exception = IScriptError
+        with pytest.raises(exception):
             mac.get_uuid_from_log(log_path)
     else:
         assert mac.get_uuid_from_log(log_path) == uuid

--- a/iscript/tests/test_mac.py
+++ b/iscript/tests/test_mac.py
@@ -367,14 +367,14 @@ async def test_create_one_notarization_zipfile(mocker, tmpdir, raises):
     work_dir = str(tmpdir)
 
     async def fake_run_command(*args, **kwargs):
-        assert args[0] == ["zip", "-r", os.path.join(work_dir, "app_path.zip"), "0/0.app", "1/1.app", "2/2.app"]
+        assert args[0] == ["zip", "-r", os.path.join(work_dir, "notarization.zip"), "0/0.app", "0/0.pkg", "1/1.app", "1/1.pkg", "2/2.app", "2/2.pkg"]
         if raises:
             raise IScriptError("foo")
 
     mocker.patch.object(mac, "run_command", new=fake_run_command)
     all_paths = []
     for i in range(3):
-        all_paths.append(mac.App(app_path=os.path.join(work_dir, str(i), "{}.app".format(i))))
+        all_paths.append(mac.App(app_path=os.path.join(work_dir, str(i), "{}.app".format(i)), pkg_path=os.path.join(work_dir, str(i), "{}.pkg".format(i))))
     if raises:
         with pytest.raises(IScriptError):
             await mac.create_one_notarization_zipfile(work_dir, all_paths)


### PR DESCRIPTION
I debated putting in notarization retries around this error, but I
haven't, yet, because:

 - I'm leaning towards moving to `single_zip` notarization rather than
   `multi_account`. Overall `single_zip` is a simpler setup, simpler
   workflow, and should automatically reduce our concurrent notarization
   requests to less than the 20/min max Apple is enforcing. It's
   possible that `single_zip` will resolve bug 1620697 by itself.
   Retrying around `multi_account` will keep the complexity, and hammer
   Apple with even more requests.

- I want these errors to be very visible for a period of time. I believe
  that `single_zip` will resolve the upload limit issue, but it's
  possible they could respond with other `ERROR` messages that we would
  automatically retry without noticing. This patch throws separate
  errors around `ERROR ITMS-10004` (`ThrottledNotarization`) and an
  unknown `ERROR` (`UnknownNotarizationError`) which should let us
  decide how to behave in each case.

https://bugzilla.mozilla.org/show_bug.cgi?id=1620697#c18 has an example
response we need to detect.