### PR TITLE
Cleanup version handling.

### DIFF
--- a/docker.d/generate_version_json.sh
+++ b/docker.d/generate_version_json.sh
@@ -1,15 +1,15 @@
 #/bin/sh
 set -e
 
-test $HEAD_REV
+test $SCRIPTWORKER_HEAD_REV
 test $TASK_ID
 test $TASKCLUSTER_ROOT_URL
-test $REPO_URL
+test $SCRIPTWORKER_HEAD_REPOSITORY
 
 cat > version.json <<EOF
 {
-    "commit": "${GIT_HEAD_REV}",
-    "source": "${REPO_URL}",
+    "commit": "${SCRIPTWORKER_HEAD_REV}",
+    "source": "${SCRIPTWORKER_HEAD_REPOSITORY}",
     "build": "${TASKCLUSTER_ROOT_URL}/tasks/${TASK_ID}"
 }
 EOF

--- a/docker.d/generate_version_json.sh
+++ b/docker.d/generate_version_json.sh
@@ -5,12 +5,10 @@ test $HEAD_REV
 test $TASK_ID
 test $TASKCLUSTER_ROOT_URL
 test $REPO_URL
-test $PROJECT_NAME
 
 cat > version.json <<EOF
 {
     "commit": "${GIT_HEAD_REV}",
-    "version": "$(cat ${PROJECT_NAME}/version.txt)",
     "source": "${REPO_URL}",
     "build": "${TASKCLUSTER_ROOT_URL}/tasks/${TASK_ID}"
 }

--- a/docker.d/push_image.sh
+++ b/docker.d/push_image.sh
@@ -14,7 +14,7 @@ test $PROJECT_NAME
 apk -U add jq
 
 echo "=== Re-tagging docker image ==="
-export DOCKER_ARCHIVE_TAG="${DOCKER_TAG}-$(cat ./${PROJECT_NAME}/version.txt)-$(date +%Y%m%d%H%M%S)-${SCRIPTWORKER_HEAD_REV}"
+export DOCKER_ARCHIVE_TAG="${DOCKER_TAG}-$(date +%Y%m%d%H%M%S)-${SCRIPTWORKER_HEAD_REV}"
 docker tag $DOCKER_REPO:$DOCKER_TAG $DOCKER_REPO:$DOCKER_ARCHIVE_TAG
 
 echo "=== Generating dockercfg ==="

--- a/docker.d/push_image.sh
+++ b/docker.d/push_image.sh
@@ -5,7 +5,7 @@ test $DOCKERHUB_EMAIL
 test $DOCKERHUB_USER
 test $DOCKER_REPO
 test $DOCKER_TAG
-test $HEAD_REV
+test $SCRIPTWORKER_HEAD_REV
 test $HOME
 test $PUSH_DOCKER_IMAGE
 test $SECRET_URL
@@ -14,7 +14,7 @@ test $PROJECT_NAME
 apk -U add jq
 
 echo "=== Re-tagging docker image ==="
-export DOCKER_ARCHIVE_TAG="${DOCKER_TAG}-$(cat ./${PROJECT_NAME}/version.txt)-$(date +%Y%m%d%H%M%S)-${GIT_HEAD_REV}"
+export DOCKER_ARCHIVE_TAG="${DOCKER_TAG}-$(cat ./${PROJECT_NAME}/version.txt)-$(date +%Y%m%d%H%M%S)-${SCRIPTWORKER_HEAD_REV}"
 docker tag $DOCKER_REPO:$DOCKER_TAG $DOCKER_REPO:$DOCKER_ARCHIVE_TAG
 
 echo "=== Generating dockercfg ==="

--- a/taskcluster/docker/k8s-image/build_and_push.sh
+++ b/taskcluster/docker/k8s-image/build_and_push.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 # TODO: move docker.d/ files into the image?
 set -e
-test REPO_URL
-test HEAD_REV
+test SCRIPTWORKER_HEAD_REPOSITORY
+test SCRIPTWORKER_HEAD_REV
 test PROJECT_NAME
 test PUSH_DOCKER_IMAGE
 
 mkdir -p /builds/worker/checkouts
 cd /builds/worker/checkouts
-wget ${REPO_URL}/archive/${HEAD_REV}.tar.gz
-tar zxf ${HEAD_REV}.tar.gz
-mv *-${HEAD_REV} src
+wget ${SCRIPTWORKER_HEAD_REPOSITORY}/archive/${SCRIPTWORKER_HEAD_REV}.tar.gz
+tar zxf ${SCRIPTWORKER_HEAD_REV}.tar.gz
+mv *-${SCRIPTWORKER_HEAD_REV} src
 cd src
 cp ${PROJECT_NAME}/docker.d/* docker.d/
 cp ${PROJECT_NAME}/Dockerfile .

--- a/taskcluster/scriptworker_taskgraph/transforms/k8s_image.py
+++ b/taskcluster/scriptworker_taskgraph/transforms/k8s_image.py
@@ -62,11 +62,11 @@ def set_environment(config, jobs):
         attributes = job["attributes"]
         env = job["worker"].setdefault("env", {})
         env.update({
-            "HEAD_REV": config.params['head_rev'],
+            "SCRIPTWORKER_HEAD_REV": config.params['head_rev'],
             "DOCKER_REPO": job.pop("docker-repo"),
             "DOCKER_TAG": config.params.get('docker_tag', 'unknown'),
             "PROJECT_NAME": project_name,
-            "REPO_URL": config.params['head_repository'],
+            "SCRIPTWORKER_HEAD_REPOSITORY": config.params['head_repository'],
             "TASKCLUSTER_ROOT_URL": "$TASKCLUSTER_ROOT_URL",
         })
         push_docker_image = config.params.get("push_docker_image")


### PR DESCRIPTION
- Don't include scriptworker version in dockerflow metadata.
- Use run-task compatible environment variables for building images.
- Stop including script version in archive docker tag. 