### PR TITLE
Bug 1608874 - part 2: Remove Fennec Nightly/Beta/Release production w…

### DIFF
--- a/beetmoverscript/docker.d/worker.yml
+++ b/beetmoverscript/docker.d/worker.yml
@@ -44,7 +44,6 @@ bucket_config:
           buckets:
             devedition: 'net-mozaws-prod-delivery-archive'
             firefox:    'net-mozaws-prod-delivery-firefox'
-            fennec:     'net-mozaws-prod-delivery-archive'
             mobile:     'net-mozaws-prod-delivery-archive'
           url_prefix: 'https://archive.mozilla.org'
         release:
@@ -54,7 +53,6 @@ bucket_config:
           buckets:
             devedition: 'net-mozaws-prod-delivery-archive'
             firefox:    'net-mozaws-prod-delivery-firefox'
-            fennec:     'net-mozaws-prod-delivery-archive'
             mobile:      'net-mozaws-prod-delivery-archive'
           url_prefix: 'https://archive.mozilla.org'
         partner:
@@ -70,7 +68,6 @@ bucket_config:
           buckets:
             devedition: 'net-mozaws-stage-delivery-archive'
             firefox:    'net-mozaws-stage-delivery-firefox'
-            fennec:     'net-mozaws-stage-delivery-archive'
             mobile:     'net-mozaws-stage-delivery-archive'
           url_prefix: 'https://ftp.stage.mozaws.net'
         dep-partner:

--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -14,33 +14,6 @@ taskcluster_scope_prefixes:
 products:
   $flatten:
     $match:
-      'COT_PRODUCT == "firefox" && ENV == "prod"':
-        - product_names: [ "beta", "aurora", "release" ]
-          digest_algorithm: SHA1
-          override_channel_model: 'choose_google_app_with_scope'
-          apps:
-            release:
-              default_track: production
-              service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FIREFOX_RELEASE" }
-              package_names:
-                - "org.mozilla.firefox"
-              credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FIREFOX_RELEASE_PATH" }
-              certificate_alias: release
-            beta:
-              default_track: production
-              service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FIREFOX_BETA" }
-              package_names:
-                - "org.mozilla.firefox_beta"
-              credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FIREFOX_BETA_PATH" }
-              certificate_alias: release
-            aurora:
-              default_track: beta
-              service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FIREFOX_AURORA" }
-              package_names:
-                - "org.mozilla.fennec_aurora"
-              credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FIREFOX_AURORA_PATH" }
-              certificate_alias: nightly
-
       'COT_PRODUCT == "firefox" && ENV != "prod"':
         - product_names: [ "dep" ]
           digest_algorithm: SHA1

--- a/pushapkscript/tests/test_config.py
+++ b/pushapkscript/tests/test_config.py
@@ -30,20 +30,6 @@ def _validate_config(context):
     jsonschema.validate(config, schema)
 
 
-def test_firefox_prod():
-    context = {
-        "COT_PRODUCT": "firefox",
-        "ENV": "prod",
-        "GOOGLE_PLAY_SERVICE_ACCOUNT_FIREFOX_RELEASE": "release",
-        "GOOGLE_CREDENTIALS_FIREFOX_RELEASE_PATH": "release",
-        "GOOGLE_PLAY_SERVICE_ACCOUNT_FIREFOX_BETA": "beta",
-        "GOOGLE_CREDENTIALS_FIREFOX_BETA_PATH": "beta",
-        "GOOGLE_PLAY_SERVICE_ACCOUNT_FIREFOX_AURORA": "aurora",
-        "GOOGLE_CREDENTIALS_FIREFOX_AURORA_PATH": "aurora",
-    }
-    _validate_config(context)
-
-
 def test_firefox_fake_prod():
     context = {"COT_PRODUCT": "firefox", "ENV": "fake-prod", "GOOGLE_CREDENTIALS_FIREFOX_DEP_PATH": "dep"}
     _validate_config(context)

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -194,11 +194,6 @@ in:
                ["autograph_mar384", "autograph_hash_only_mar384"]
               ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
-               {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},
-               {"$eval": "AUTOGRAPH_FENNEC_RELEASE_PASSWORD"},
-               ["autograph_apk_fennec_sha1"]
-               ]
-            - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_GPG_USERNAME"},
                {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
                ["autograph_gpg"]
@@ -230,11 +225,6 @@ in:
                {"$eval": "AUTOGRAPH_MAR_NIGHTLY_PASSWORD"},
                ["autograph_mar384", "autograph_hash_only_mar384"]
               ]
-            - ["https://autograph-external.prod.autograph.services.mozaws.net",
-               {"$eval": "AUTOGRAPH_FENNEC_NIGHTLY_USERNAME"},
-               {"$eval": "AUTOGRAPH_FENNEC_NIGHTLY_PASSWORD"},
-               ["autograph_apk_fennec_sha1"]
-               ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_GPG_USERNAME"},
                {"$eval": "AUTOGRAPH_GPG_PASSWORD"},


### PR DESCRIPTION
…orkers

We shouldn't sign/beetmover/ship any Fennec anymore. This PR removes the ability for gecko folks to use the real keys and the real accounts. I left the staging ones around because I foresee people willing to test something against Fennec. What do you all think?