### PR TITLE
Treescript: Use config["upstream_repo"] instead of hardcoded URL in d…

### DIFF
--- a/treescript/src/treescript/merges.py
+++ b/treescript/src/treescript/merges.py
@@ -176,10 +176,11 @@ async def do_merge(config, task, repo_path):
     """
     merge_config = get_merge_config(task)
 
+    upstream_repo = config["upstream_repo"]
     from_branch = merge_config.get("from_branch")
     to_branch = merge_config.get("to_branch")
 
-    await run_hg_command(config, "pull", "https://hg.mozilla.org/mozilla-unified", repo_path=repo_path)
+    await run_hg_command(config, "pull", upstream_repo, repo_path=repo_path)
 
     # Used if end_tag is set.
     await run_hg_command(config, "up", "-C", to_branch, repo_path=repo_path)

--- a/treescript/tests/test_merges.py
+++ b/treescript/tests/test_merges.py
@@ -297,3 +297,16 @@ async def test_bump_central(mocker, config, task, repo_context, merge_bump_info)
     for expected in expected_calls:
         assert expected in called_args
     assert result == [("https://hg.mozilla.org/mozilla-central", "some_revision")]
+
+
+@pytest.mark.parametrize(
+    "merge_config,expected", (({}, "browser/config/version.txt"), ({"fetch_version_from": "some/other/version.txt"}, "some/other/version.txt"))
+)
+def test_core_version_file(merge_config, expected):
+    assert merges.core_version_file(merge_config) == expected
+
+
+def test_formatter():
+    fmt = merges.BashFormatter()
+    assert fmt.format("Foo ${bar} {baz}", baz="BAZ") == "Foo ${bar} BAZ"
+    assert fmt.format("Foo ${bar} {}", "BAZ") == "Foo ${bar} BAZ"

--- a/treescript/tests/test_merges.py
+++ b/treescript/tests/test_merges.py
@@ -71,6 +71,7 @@ def config(tmpdir):
     config_["artifact_dir"] = os.path.join(tmpdir, "artifacts")
     config_["hg_ssh_user"] = "sshuser"
     config_["merge_day_clobber_file"] = "CLOBBER"
+    config_["upstream_repo"] = "https://hg.mozilla.org/repo/fake_upstream"
     yield config_
 
 
@@ -278,7 +279,7 @@ async def test_bump_central(mocker, config, task, repo_context, merge_bump_info)
     result = await merges.do_merge(config, task, repo_context.repo)
 
     expected_calls = [
-        ("pull", "https://hg.mozilla.org/mozilla-unified"),
+        ("pull", "https://hg.mozilla.org/repo/fake_upstream"),
         ("up", "-C", "central"),
         (
             "tag",
@@ -296,16 +297,3 @@ async def test_bump_central(mocker, config, task, repo_context, merge_bump_info)
     for expected in expected_calls:
         assert expected in called_args
     assert result == [("https://hg.mozilla.org/mozilla-central", "some_revision")]
-
-
-@pytest.mark.parametrize(
-    "merge_config,expected", (({}, "browser/config/version.txt"), ({"fetch_version_from": "some/other/version.txt"}, "some/other/version.txt"))
-)
-def test_core_version_file(merge_config, expected):
-    assert merges.core_version_file(merge_config) == expected
-
-
-def test_formatter():
-    fmt = merges.BashFormatter()
-    assert fmt.format("Foo ${bar} {baz}", baz="BAZ") == "Foo ${bar} BAZ"
-    assert fmt.format("Foo ${bar} {}", "BAZ") == "Foo ${bar} BAZ"


### PR DESCRIPTION
…o_merge

This is needed for Thunderbird support. config["upstream_repo"] is already set appropriately and is used in checkout_repo.