### PR TITLE
Githubscript should not alter target_commitish on a GitHub release

### DIFF
--- a/githubscript/tests/test_integration.py
+++ b/githubscript/tests/test_integration.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from unittest.mock import MagicMock
 
 import pytest
+from github3.exceptions import NotFoundError
 
 import githubscript.github
 from githubscript.script import main
@@ -50,30 +51,64 @@ def task():
     }
 
 
-def test_main_update_release(monkeypatch, tmp_path, config, task):
-    github3_mock = MagicMock()
-    monkeypatch.setattr(githubscript.github, "github3", github3_mock)
+class _GitHubClient:
+    _repository = MagicMock()
 
-    github_client_mock = MagicMock()
-    github3_mock.GitHub.return_value = github_client_mock
-    github_repository_mock = MagicMock()
-    github_client_mock.repository.return_value = github_repository_mock
+    def __init__(self, *args, **kwargs):
+        pass
 
-    incomplete_release_mock = MagicMock(
-        tag_name="v5.2.0",
-        target_commitish="b94cfdf06be2be4b5a3c83ab4095eb2ecde7ba71",
-        prerelease=False,
-    )
-    incomplete_release_mock.configure_mock(name="Firefox Preview 5.2")
+    @classmethod
+    def repository(cls, *args, **kwargs):
+        return cls._repository
 
-    valid_release_mock = deepcopy(incomplete_release_mock)
+    @classmethod
+    def reset_repository(cls):
+        cls._repository = MagicMock()
+        return cls._repository
+
+
+@pytest.fixture
+def github3_repo_mock(monkeypatch):
+    # _repository is a class attribute because githubscript instanciates it later and we
+    # want to know get the value here. That's also why we reset it in this fixture.
+    # It has to be reset from a test to another but not within a test.
+    repo_mock = _GitHubClient.reset_repository()
+    monkeypatch.setattr(githubscript.github, "GitHub", _GitHubClient)
+    yield repo_mock
+
+
+@asynccontextmanager
+async def _RetryClientMock(*args, **kwargs):
+    client_mock = MagicMock()
+
+    @asynccontextmanager
+    async def get_mock(*args, **kwargs):
+        response_mock = MagicMock(status=200)
+        yield response_mock
+
+    client_mock.get = get_mock
+    yield client_mock
+
+
+@pytest.fixture
+def retry_client_mock(monkeypatch):
+    monkeypatch.setattr(githubscript.github, "RetryClient", _RetryClientMock)
+
+
+@pytest.fixture
+def valid_release_mock():
     valid_release_mock = MagicMock(
         tag_name="v5.2.0",
-        target_commitish="b94cfdf06be2be4b5a3c83ab4095eb2ecde7ba71",
+        target_commitish="release/v5.2.0",
         prerelease=False,
     )
     valid_release_mock.configure_mock(name="Firefox 5.2")
 
+    yield valid_release_mock
+
+
+@pytest.fixture
+def valid_release_with_assets_mock(valid_release_mock):
     valid_release_with_assets_mock = deepcopy(valid_release_mock)
     first_asset_mock = MagicMock(content_type="application/vnd.android.package-archive", size=9)
     first_asset_mock.configure_mock(name="firefox_preview_v5.2_arm64.apk")
@@ -81,26 +116,11 @@ def test_main_update_release(monkeypatch, tmp_path, config, task):
     second_asset_mock.configure_mock(name="firefox_preview_v5.2_x86_64.apk")
     valid_release_with_assets_mock.assets.return_value = [first_asset_mock, second_asset_mock]
 
-    github_repository_mock.release_from_tag.side_effect = [
-        incomplete_release_mock,
-        valid_release_mock,
-        valid_release_with_assets_mock,
-    ]
+    yield valid_release_with_assets_mock
 
-    @asynccontextmanager
-    async def RetryClientMock(*args, **kwargs):
-        client_mock = MagicMock()
 
-        @asynccontextmanager
-        async def get_mock(*args, **kwargs):
-            response_mock = MagicMock(status=200)
-            yield response_mock
-
-        client_mock.get = get_mock
-        yield client_mock
-
-    monkeypatch.setattr(githubscript.github, "RetryClient", RetryClientMock)
-
+@pytest.fixture
+def scriptworker_config(tmp_path, config, task):
     work_dir = tmp_path / "work"
     work_dir.mkdir()
     config["work_dir"] = str(work_dir)
@@ -119,10 +139,42 @@ def test_main_update_release(monkeypatch, tmp_path, config, task):
         with open(file_path, "wb") as f:
             f.write(b"some data")
 
-    main(config_path=config_path)
-    incomplete_release_mock.edit.assert_called_with(
+    yield config_path
+
+
+def test_main_create_release(github3_repo_mock, retry_client_mock, valid_release_mock, valid_release_with_assets_mock, scriptworker_config):
+    github3_repo_mock.release_from_tag.side_effect = [
+        NotFoundError(MagicMock()),
+        valid_release_mock,
+        valid_release_with_assets_mock,
+    ]
+
+    main(config_path=scriptworker_config)
+    github3_repo_mock.create_release.assert_called_once_with(
+        tag_name="v5.2.0", name="Firefox 5.2", draft=False, prerelease=False, target_commitish="b94cfdf06be2be4b5a3c83ab4095eb2ecde7ba71"
+    )
+    assert github3_repo_mock.edit.call_count == 0
+    assert valid_release_mock.upload_asset.call_count == 2
+
+
+def test_main_update_release(github3_repo_mock, retry_client_mock, valid_release_mock, valid_release_with_assets_mock, scriptworker_config):
+    incomplete_release_mock = MagicMock(
         tag_name="v5.2.0",
         target_commitish="b94cfdf06be2be4b5a3c83ab4095eb2ecde7ba71",
+        prerelease=False,
+    )
+    incomplete_release_mock.configure_mock(name="Firefox Preview 5.2")
+
+    github3_repo_mock.release_from_tag.side_effect = [
+        incomplete_release_mock,
+        valid_release_mock,
+        valid_release_with_assets_mock,
+    ]
+
+    main(config_path=scriptworker_config)
+    assert github3_repo_mock.create_release.call_count == 0
+    incomplete_release_mock.edit.assert_called_with(
+        tag_name="v5.2.0",
         name="Firefox 5.2",
         draft=False,
         prerelease=False,


### PR DESCRIPTION
Otherwise it breaks Chain of Trust.

Fixes

```
2020-09-29T17:57:51    ERROR - Hit ScriptWorkerException: CoTError('scriptworker:parent el3i3MuyR_CCWVw71AwNdA: the runtime task doesn\'t match any rebuilt definition!\n["[(\'change\',\\n"\n "  \'payload.env.MOBILE_HEAD_REF\',\\n"\n "  (\'88fc5f8a7e1b51e14d1b68f692a629d9144e8e5c\', \'releases/v82.0.0\'))]"]')
```

https://firefox-ci-tc.services.mozilla.com/tasks/Y3nWYC5WRsW0Zf0DYz-E7A/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FY3nWYC5WRsW0Zf0DYz-E7A%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Fchain_of_trust.log#L186

I looked into making Chain of Trust more resilient but we're limited by the Github API. Let me walk you through 2 examples:

Fenix v81.1.1 was shipped via Github releases and never touched by githubscript. See the field `target_commitish`: https://api.github.com/repos/mozilla-mobile/fenix/releases/31503131. On the other hand, Fenix v82.0.0b1 was modified by githubscript: https://api.github.com/repos/mozilla-mobile/fenix/releases/31683165. On the first example, the `target_commitish` is a git branch whereas it's a commit has in the second example.

I could change CoT to get the branch from a hash, but that's not doable. Moreover, a single hash can be on multiple branches, so we have no reliable way of getting the branch of v82b1. The same happens with the event used by `.taskcluster.yml`, you either get a hash or a branch but not both https://docs.github.com/en/free-pro-team@latest/developers/webhooks-and-events/webhook-events-and-payloads#release.

Long story short: the simplest solution is to stop changing the `target_commitish`. This way, the CoT uses the same data all over the graph. That's why I made this very PR.

The `target_commitish` will be passed to Github whenever we fully switch to shipit. Reason is: no github release is created until githubscript starts, so we somehow need to give something (here a hash) to Github in order to display that release.

We will be able to revert https://github.com/mozilla-mobile/fenix/pull/15546, once that change is live.

Let me know if you have any questions! 