### PR TITLE
Bug 1600916 - Check versions in payload and maven artifact maps

### DIFF
--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -13,6 +13,8 @@ import aiohttp
 import boto3
 from botocore.exceptions import ClientError
 from redo import retry
+from mozilla_version.maven import MavenVersion
+from mozilla_version.errors import PatternNotMatchedError
 from scriptworker import client
 from scriptworker.exceptions import ScriptWorkerRetryException, ScriptWorkerTaskException
 from scriptworker.utils import raise_future_exceptions, retry_async
@@ -198,9 +200,27 @@ async def push_to_maven(context):
     context.checksums = dict()  # Needed by downstream calls
     context.raw_balrog_manifest = dict()  # Needed by downstream calls
 
+    check_maven_artifact_map(context)
+
     # overwrite artifacts_to_beetmove with the declarative artifacts ones
     context.artifacts_to_beetmove = task.get_upstream_artifacts(context, preserve_full_paths=True)
     await move_beets(context, context.artifacts_to_beetmove, artifact_map=context.task["payload"]["artifactMap"])
+
+
+def check_maven_artifact_map(context):
+    """Check that versions in artifact map to be valid Maven versions"""
+    version = context.task["payload"]["version"]
+    try:
+        MavenVersion.parse(version)
+    except PatternNotMatchedError:
+        raise ScriptWorkerTaskException(f"bad version '{version}'")
+
+    for artifact_dict in context.task["payload"]["artifactMap"]:
+        for dest_dict in artifact_dict["paths"].values():
+            for dest in dest_dict["destinations"]:
+                dest_file = os.path.basename(dest)
+                if version not in dest_file:
+                    raise ScriptWorkerTaskException(f"version in artifact doesn't match expected version '{version}'")
 
 
 # copy_beets {{{1

--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -209,7 +209,7 @@ async def push_to_maven(context):
     context.raw_balrog_manifest = dict()  # Needed by downstream calls
 
     # Version validation
-    version = task.check_maven_version(context)
+    version = task.get_maven_version(context)
     task.check_maven_artifact_map(context, version)
 
     # overwrite artifacts_to_beetmove with the declarative artifacts ones

--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -12,9 +12,9 @@ from multiprocessing.pool import ThreadPool
 import aiohttp
 import boto3
 from botocore.exceptions import ClientError
-from redo import retry
-from mozilla_version.maven import MavenVersion
 from mozilla_version.errors import PatternNotMatchedError
+from mozilla_version.maven import MavenVersion
+from redo import retry
 from scriptworker import client
 from scriptworker.exceptions import ScriptWorkerRetryException, ScriptWorkerTaskException
 from scriptworker.utils import raise_future_exceptions, retry_async

--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -198,7 +198,9 @@ async def push_to_maven(context):
     context.checksums = dict()  # Needed by downstream calls
     context.raw_balrog_manifest = dict()  # Needed by downstream calls
 
-    task.check_maven_artifact_map(context)
+    # Version validation
+    version = task.check_maven_version(context)
+    task.check_maven_artifact_map(context, version)
 
     # overwrite artifacts_to_beetmove with the declarative artifacts ones
     context.artifacts_to_beetmove = task.get_upstream_artifacts(context, preserve_full_paths=True)

--- a/beetmoverscript/src/beetmoverscript/task.py
+++ b/beetmoverscript/src/beetmoverscript/task.py
@@ -88,7 +88,9 @@ def get_maven_version(context):
     """Extract and validate a valid Maven version"""
     version = context.task["payload"]["version"]
     release_props = context.release_props
-    # Version follows the FirefoxVersion pattern for Geckoview < 84.0
+    # TODO The following 'if' should be removed once GeckoView >= 84 is in mozilla-release.
+    # This is a temporary solution to maintain compatibility while the 'version' field in
+    # GeckoView's payload transitions from FirefoxVersion format to MavenVersion.
     if release_props.get("appName") == "geckoview":
         app_version = FirefoxVersion.parse(release_props["appVersion"])
         if int(app_version.major_number) < 84:

--- a/beetmoverscript/src/beetmoverscript/task.py
+++ b/beetmoverscript/src/beetmoverscript/task.py
@@ -84,7 +84,7 @@ def validate_bucket_paths(bucket, s3_bucket_path):
 
 
 def check_maven_artifact_map(context):
-    """Check that versions in artifact map to be valid Maven versions"""
+    """Check that versions in artifact map are valid Maven versions"""
     version = context.task["payload"]["version"]
     try:
         MavenVersion.parse(version)

--- a/beetmoverscript/src/beetmoverscript/task.py
+++ b/beetmoverscript/src/beetmoverscript/task.py
@@ -97,7 +97,7 @@ def check_maven_artifact_map(context):
                 dest_folder, dest_file = os.path.split(dest)
                 last_folder = os.path.basename(dest_folder)
                 if version != last_folder:
-                    raise ScriptWorkerTaskException(f"Name of last folder '{last_folder}' in path '{dest_file}' does not match payload version '{version}'")
+                    raise ScriptWorkerTaskException(f"Name of last folder '{last_folder}' in path '{dest}' does not match payload version '{version}'")
                 if version not in dest_file:
                     raise ScriptWorkerTaskException(f"Cannot find version '{version}' in file name '{dest_file}'. Path under test: {dest}")
 

--- a/beetmoverscript/tests/test_script.py
+++ b/beetmoverscript/tests/test_script.py
@@ -13,7 +13,6 @@ import beetmoverscript.script
 from beetmoverscript.constants import PARTNER_REPACK_PRIVATE_REGEXES, PARTNER_REPACK_PUBLIC_REGEXES
 from beetmoverscript.script import (
     async_main,
-    check_maven_artifact_map,
     copy_beets,
     enrich_balrog_manifest,
     get_destination_for_partner_repack_path,
@@ -68,45 +67,6 @@ async def test_push_to_releases(context, mocker, candidates_keys, releases_keys,
             await push_to_releases(context)
     else:
         await push_to_releases(context)
-
-
-def test_check_maven_artifact_map(context):
-    context.action = "push-to-maven"
-
-    fake_correct_version = "12.3.20200920201111"
-    source = "fake_path/fake-artifact-{version}.jar"
-
-    def artifact_map_entry_with_version(version):
-        return {
-            "locale": "en-US",
-            "paths": {
-                source: {
-                    "checksums_path": "",
-                    "destinations": [f"fake/destination/{version}/fake-artifact-{version}.jar"],
-                }
-            },
-            "taskId": "fake-task-id",
-        }
-
-    context.task = {
-        "payload": {
-            "artifactMap": [],
-            "releaseProperties": {"appName": "nightly_components"},
-            "upstreamArtifacts": [{"paths": [source], "taskId": "fake-task-id", "taskType": "build"}],
-            "version": "bad.version",
-        }
-    }
-
-    with pytest.raises(ScriptWorkerTaskException):
-        check_maven_artifact_map(context)
-
-    context.task["payload"]["version"] = fake_correct_version
-    context.task["payload"]["artifactMap"] = [artifact_map_entry_with_version(fake_correct_version)]
-    check_maven_artifact_map(context)
-
-    context.task["payload"]["artifactMap"] = [artifact_map_entry_with_version("a.bad.version")]
-    with pytest.raises(ScriptWorkerTaskException):
-        check_maven_artifact_map(context)
 
 
 # copy_beets {{{1

--- a/beetmoverscript/tests/test_script.py
+++ b/beetmoverscript/tests/test_script.py
@@ -13,6 +13,7 @@ import beetmoverscript.script
 from beetmoverscript.constants import PARTNER_REPACK_PRIVATE_REGEXES, PARTNER_REPACK_PUBLIC_REGEXES
 from beetmoverscript.script import (
     async_main,
+    check_maven_artifact_map,
     copy_beets,
     enrich_balrog_manifest,
     get_destination_for_partner_repack_path,
@@ -67,6 +68,45 @@ async def test_push_to_releases(context, mocker, candidates_keys, releases_keys,
             await push_to_releases(context)
     else:
         await push_to_releases(context)
+
+
+def test_check_maven_artifact_map(context):
+    context.action = "push-to-maven"
+
+    fake_correct_version = "12.3.20200920201111"
+    source = "fake_path/fake-artifact-{version}.jar"
+
+    def artifact_map_entry_with_version(version):
+        return {
+            "locale": "en-US",
+            "paths": {
+                source: {
+                    "checksums_path": "",
+                    "destinations": [f"fake/destination/{version}/fake-artifact-{version}.jar"],
+                }
+            },
+            "taskId": "fake-task-id",
+        }
+
+    context.task = {
+        "payload": {
+            "artifactMap": [],
+            "releaseProperties": {"appName": "nightly_components"},
+            "upstreamArtifacts": [{"paths": [source], "taskId": "fake-task-id", "taskType": "build"}],
+            "version": "bad.version",
+        }
+    }
+
+    with pytest.raises(ScriptWorkerTaskException):
+        check_maven_artifact_map(context)
+
+    context.task["payload"]["version"] = fake_correct_version
+    context.task["payload"]["artifactMap"] = [artifact_map_entry_with_version(fake_correct_version)]
+    check_maven_artifact_map(context)
+
+    context.task["payload"]["artifactMap"] = [artifact_map_entry_with_version("a.bad.version")]
+    with pytest.raises(ScriptWorkerTaskException):
+        check_maven_artifact_map(context)
 
 
 # copy_beets {{{1

--- a/beetmoverscript/tests/test_task.py
+++ b/beetmoverscript/tests/test_task.py
@@ -155,21 +155,15 @@ def test_validate_bucket_paths(bucket, path, raises):
 @pytest.mark.parametrize(
     "payload_version,filename_version,folder_version,expectation",
     (
-        (None, None, None, does_not_raise()),
-        ("a.bad.version", None, None, pytest.raises(ScriptWorkerTaskException)),
-        (None, "a.bad.version", None, pytest.raises(ScriptWorkerTaskException)),
-        (None, None, "a.bad.version", pytest.raises(ScriptWorkerTaskException)),
+        ("12.3.20200920201111", "12.3.20200920201111", "12.3.20200920201111", does_not_raise()),
+        ("a.bad.version", "12.3.20200920201111", "12.3.20200920201111", pytest.raises(ScriptWorkerTaskException)),
+        ("12.3.20200920201111", "a.bad.version", "12.3.20200920201111", pytest.raises(ScriptWorkerTaskException)),
+        ("12.3.20200920201111", "12.3.20200920201111", "a.bad.version", pytest.raises(ScriptWorkerTaskException)),
     ),
 )
 def test_check_maven_artifact_map(context, payload_version, filename_version, folder_version, expectation):
     context.action = "push-to-maven"
-
-    fake_correct_version = "12.3.20200920201111"
     source = "fake_path/fake-artifact-{version}.jar"
-
-    payload_version = payload_version or fake_correct_version
-    filename_version = filename_version or fake_correct_version
-    folder_version = folder_version or fake_correct_version
 
     artifact_map_entry = {
         "locale": "en-US",

--- a/beetmoverscript/tests/test_task.py
+++ b/beetmoverscript/tests/test_task.py
@@ -157,13 +157,14 @@ def test_check_maven_artifact_map(context):
     fake_correct_version = "12.3.20200920201111"
     source = "fake_path/fake-artifact-{version}.jar"
 
-    def artifact_map_entry_with_version(version):
+    def artifact_map_entry_with_version(version, folder_version=None):
+        folder_version = folder_version or version
         return {
             "locale": "en-US",
             "paths": {
                 source: {
                     "checksums_path": "",
-                    "destinations": [f"fake/destination/{version}/fake-artifact-{version}.jar"],
+                    "destinations": [f"fake/destination/{folder_version}/fake-artifact-{version}.jar"],
                 }
             },
             "taskId": "fake-task-id",
@@ -186,6 +187,10 @@ def test_check_maven_artifact_map(context):
     check_maven_artifact_map(context)
 
     context.task["payload"]["artifactMap"] = [artifact_map_entry_with_version("a.bad.version")]
+    with pytest.raises(ScriptWorkerTaskException):
+        check_maven_artifact_map(context)
+
+    context.task["payload"]["artifactMap"] = [artifact_map_entry_with_version(fake_correct_version, "a.bad.version")]
     with pytest.raises(ScriptWorkerTaskException):
         check_maven_artifact_map(context)
 


### PR DESCRIPTION
This tries to fix the problems that #277 introduced when dealing with geckoview versions.

The plan is to also modify how the version is set in the payload for geckoview beetmover jobs. However, we still have to support the current geckoview version format here as a special case until the changes we make in mozilla-central get to beta and release. 

@JohanLorenzo I split the logic into two functions so that it's easier to unit-test, but I may have gone overboard with switching on the specific major version, so I'd understand if you find this is not a satisfactory solution.