### PR TITLE
Bug 1635488 - part 1: [treescript] Expose commit() function in mercurial

### DIFF
--- a/treescript/src/treescript/l10n.py
+++ b/treescript/src/treescript/l10n.py
@@ -16,7 +16,7 @@ from scriptworker_client.aio import download_file, retry_async, semaphore_wrappe
 from scriptworker_client.exceptions import DownloadError
 from scriptworker_client.utils import load_json_or_yaml
 
-from treescript.mercurial import run_hg_command
+from treescript.mercurial import commit
 from treescript.task import CLOSED_TREE_MSG, DONTBUILD_MSG, get_dontbuild, get_ignore_closed_tree, get_l10n_bump_info, get_short_source_repo
 
 log = logging.getLogger(__name__)
@@ -252,6 +252,6 @@ async def l10n_bump(config, task, repo_path):
             fh.write(json.dumps(new_contents, sort_keys=True, indent=4, separators=(",", ": ")))
         locale_map = build_locale_map(old_contents, new_contents)
         message = build_commit_message(bump_config["name"], locale_map, dontbuild=dontbuild, ignore_closed_tree=ignore_closed_tree)
-        await run_hg_command(config, "commit", "-m", message, repo_path=repo_path)
+        await commit(config, repo_path, message)
         changes += 1
     return changes

--- a/treescript/src/treescript/mercurial.py
+++ b/treescript/src/treescript/mercurial.py
@@ -332,6 +332,17 @@ async def strip_outgoing(config, task, repo_path):
     await run_hg_command(config, "purge", "--all", repo_path=repo_path)
 
 
+async def commit(config, repo_path, commit_msg):
+    """Run `hg commit` against the current source repo.
+
+    Args:
+        config (dict): the running config
+        repo_path (str): the source repo path
+        commit_msg (str): the commit message
+    """
+    await run_hg_command(config, "commit", "-m", commit_msg, repo_path=repo_path)
+
+
 # push {{{1
 async def push(config, task, repo_path, target_repo, revision=None):
     """Run `hg push` against the current source repo.

--- a/treescript/src/treescript/merges.py
+++ b/treescript/src/treescript/merges.py
@@ -8,7 +8,7 @@ import attr
 from scriptworker_client.utils import makedirs
 
 from treescript.l10n import l10n_bump
-from treescript.mercurial import get_revision, run_hg_command
+from treescript.mercurial import commit, get_revision, run_hg_command
 from treescript.task import get_l10n_bump_info, get_merge_config
 from treescript.versionmanip import do_bump_version, get_version
 
@@ -144,7 +144,7 @@ async def preserve_tags(config, repo_path, to_branch):
             fh.write(f"{line}\n")
     status_out = await run_hg_command(config, "status", os.path.join(repo_path, ".hgtags"), return_output=True, repo_path=repo_path)
     if status_out:
-        await run_hg_command(config, "commit", "-m", "Preserve old tags after debusetparents. CLOSED TREE DONTBUILD a=release", repo_path=repo_path)
+        await commit(config, repo_path, "Preserve old tags after debusetparents. CLOSED TREE DONTBUILD a=release")
 
 
 def core_version_file(merge_config):
@@ -229,7 +229,7 @@ async def do_merge(config, task, repo_path):
     with open(path, "w") as fh:
         fh.write(diff_output)
 
-    await run_hg_command(config, "commit", "-m", "Update configs. IGNORE BROKEN CHANGESETS CLOSED TREE NO BUG a=release ba=release", repo_path=repo_path)
+    await commit(config, repo_path, "Update configs. IGNORE BROKEN CHANGESETS CLOSED TREE NO BUG a=release ba=release")
     push_revision_to = await get_revision(config, repo_path, branch=".")
 
     # Do we need to perform multiple pushes for the push stage? If so, return

--- a/treescript/src/treescript/versionmanip.py
+++ b/treescript/src/treescript/versionmanip.py
@@ -7,7 +7,7 @@ import os
 from mozilla_version.gecko import FennecVersion, FirefoxVersion, GeckoVersion, ThunderbirdVersion
 
 from treescript.exceptions import TaskVerificationError, TreeScriptError
-from treescript.mercurial import run_hg_command
+from treescript.mercurial import commit
 from treescript.task import DONTBUILD_MSG, get_dontbuild, get_version_bump_info
 
 log = logging.getLogger(__name__)
@@ -91,7 +91,7 @@ async def bump_version(config, task, repo_path):
         commit_msg = "Automatic version bump CLOSED TREE NO BUG a=release"
         if get_dontbuild(task):
             commit_msg += DONTBUILD_MSG
-        await run_hg_command(config, "commit", "-m", commit_msg, repo_path=repo_path)
+        await commit(config, repo_path, commit_msg)
         num_commits += 1
     return num_commits
 

--- a/treescript/tests/test_l10n.py
+++ b/treescript/tests/test_l10n.py
@@ -262,7 +262,7 @@ async def test_l10n_bump(mocker, ignore_closed_tree, l10n_bump_info, tmpdir, old
     mocker.patch.object(l10n, "load_json_or_yaml", return_value=old_contents)
     mocker.patch.object(l10n, "get_latest_revision", new=noop_async)
     mocker.patch.object(l10n, "build_revision_dict", new=fake_build_revision_dict)
-    mocker.patch.object(l10n, "run_hg_command", new=fake_hg)
+    mocker.patch.object(l10n, "commit", new=fake_hg)
 
     assert await l10n.l10n_bump({}, {}, tmpdir) == changes
 

--- a/treescript/tests/test_mercurial.py
+++ b/treescript/tests/test_mercurial.py
@@ -410,6 +410,21 @@ async def test_strip_outgoing(config, task, mocker):
     assert is_slice_in_list(("strip", "--no-backup", "outgoing()"), called_args[0][0])
 
 
+@pytest.mark.asyncio
+async def test_commit(config, task, mocker):
+    called_args = []
+
+    async def run_command(config, *arguments, repo_path=None, **kwargs):
+        called_args.append([tuple([config]) + arguments, {"repo_path": repo_path}])
+
+    mocker.patch.object(mercurial, "run_hg_command", new=run_command)
+    await mercurial.commit(config, config["work_dir"], "some commit message")
+
+    assert len(called_args) == 1
+    assert "repo_path" in called_args[0][1]
+    assert is_slice_in_list(("commit", "-m", "some commit message"), called_args[0][0])
+
+
 # push {{{1
 @pytest.mark.asyncio
 @pytest.mark.parametrize("source_repo,revision", ((None, None), ("https://hg.mozilla.org/treescript-test", None), (None, ".")))

--- a/treescript/tests/test_merges.py
+++ b/treescript/tests/test_merges.py
@@ -248,6 +248,9 @@ async def test_do_merge(mocker, config, task, repo_context, merge_info, add_merg
         if "return_output" in kwargs:
             return "headers\n\n\n\n+invalid_changeset tag\n changeset tag\n+valid_changeset_is_forty_characters_long tag"
 
+    async def mocked_commit(*arguments, **kwargs):
+        called_args.append("commit")
+
     async def mocked_get_revision(*args, **kwargs):
         return "some_revision"
 
@@ -258,6 +261,7 @@ async def test_do_merge(mocker, config, task, repo_context, merge_info, add_merg
         called_args.append("apply_rebranding")
 
     mocker.patch.object(merges, "run_hg_command", new=mocked_run_hg_command)
+    mocker.patch.object(merges, "commit", new=mocked_commit)
     mocker.patch.object(merges, "get_revision", new=mocked_get_revision)
     mocker.patch.object(merges, "apply_rebranding", new=noop_apply_rebranding)
     mocker.patch.object(merges, "l10n_bump", new=noop_l10n_bump)
@@ -280,6 +284,9 @@ async def test_bump_central(mocker, config, task, repo_context, merge_bump_info)
         if "return_output" in kwargs:
             return "headers\n\n\n\n+invalid_changeset tag\n changeset tag\n+valid_changeset_is_forty_characters_long tag"
 
+    async def mocked_commit(config, repo_path, commit_msg, **kwargs):
+        called_args.append(("commit", commit_msg))
+
     async def mocked_get_revision(*args, **kwargs):
         return "some_revision"
 
@@ -287,6 +294,7 @@ async def test_bump_central(mocker, config, task, repo_context, merge_bump_info)
         called_args.append(("apply_rebranding"))
 
     mocker.patch.object(merges, "run_hg_command", new=mocked_run_hg_command)
+    mocker.patch.object(merges, "commit", new=mocked_commit)
     mocker.patch.object(merges, "get_revision", new=mocked_get_revision)
     mocker.patch.object(merges, "apply_rebranding", new=noop_apply_rebranding)
 
@@ -306,7 +314,7 @@ async def test_bump_central(mocker, config, task, repo_context, merge_bump_info)
         ),
         ("diff",),
         ("apply_rebranding"),
-        ("commit", "-m", "Update configs. IGNORE BROKEN CHANGESETS CLOSED TREE NO BUG a=release ba=release"),
+        ("commit", "Update configs. IGNORE BROKEN CHANGESETS CLOSED TREE NO BUG a=release ba=release"),
     ]
     for expected in expected_calls:
         assert expected in called_args


### PR DESCRIPTION
This refactor is now useful. I plan to create a `git` module that uses the same API as the `mercurial` one. There are several places where treescript commits something. By centralizing the command in the `mercurial`, we enable simpler modifications to wire calls either to the (upcoming) `git` module or the `mercurial` one.

This call is one of them:
https://github.com/mozilla-releng/scriptworker-scripts/blob/022acabfa8af4e928f27ca6f388d33127f2a4284/treescript/src/treescript/versionmanip.py#L94 

This refactor looks a little bit risky. I'd love to land it without anything related to git, yet. 