### PR TITLE
Bug 1672691 - part 2:  [beetmoverscript] Add integration tests to beetmover (more cases)

### DIFF
--- a/beetmoverscript/tests/task_examples/android_components_nightly.json
+++ b/beetmoverscript/tests/task_examples/android_components_nightly.json
@@ -1,0 +1,120 @@
+{
+    "dependencies": ["dependency-task-id"],
+    "scopes": [
+	"project:mobile:android-components:releng:beetmover:action:push-to-maven",
+	"project:mobile:android-components:releng:beetmover:bucket:maven-nightly-staging"
+    ],
+    "payload": {
+	"version": "63.0.20201013153553",
+	"artifactMap": [
+	    {"paths": {}, "locale": "en-US", "taskId": "AKjtHrqYQ32EDZ3GNzwXGg"},
+	    {
+		"paths": {
+		    "public/build/browser-awesomebar-63.0.20201013153553.aar.asc": {
+			"destinations": [
+			    "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.aar.asc"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/browser-awesomebar-63.0.20201013153553.pom.asc": {
+			"destinations": [
+			    "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.pom.asc"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.asc": {
+			"destinations": [
+			    "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553-sources.jar.asc"
+			],
+			"checksums_path": ""
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "ZYfA8OtXRZuDeF5Xq3ubxg"
+	    },
+	    {
+		"paths": {
+		    "public/build/browser-awesomebar-63.0.20201013153553.aar": {
+			"destinations": ["maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.aar"],
+			"checksums_path": ""
+		    },
+		    "public/build/browser-awesomebar-63.0.20201013153553.pom": {
+			"destinations": ["maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.pom"],
+			"checksums_path": ""
+		    },
+		    "public/build/browser-awesomebar-63.0.20201013153553.aar.md5": {
+			"destinations": [
+			    "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.aar.md5"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/browser-awesomebar-63.0.20201013153553.pom.md5": {
+			"destinations": [
+			    "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.pom.md5"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/browser-awesomebar-63.0.20201013153553.aar.sha1": {
+			"destinations": [
+			    "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.aar.sha1"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/browser-awesomebar-63.0.20201013153553.pom.sha1": {
+			"destinations": [
+			    "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.pom.sha1"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/browser-awesomebar-63.0.20201013153553-sources.jar": {
+			"destinations": [
+			    "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553-sources.jar"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.md5": {
+			"destinations": [
+			    "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553-sources.jar.md5"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.sha1": {
+			"destinations": [
+			    "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553-sources.jar.sha1"
+			],
+			"checksums_path": ""
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "XGsGR0qdRmaWNE9fW5CmKQ"
+	    }
+	],
+	"releaseProperties": {"appName": "nightly_components"},
+	"upstreamArtifacts": [
+	    {
+		"paths": [
+		    "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.asc",
+		    "public/build/browser-awesomebar-63.0.20201013153553.aar.asc",
+		    "public/build/browser-awesomebar-63.0.20201013153553.pom.asc"
+		],
+		"taskId": "ZYfA8OtXRZuDeF5Xq3ubxg",
+		"taskType": "signing"
+	    },
+	    {
+		"paths": [
+		    "public/build/browser-awesomebar-63.0.20201013153553-sources.jar",
+		    "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.md5",
+		    "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.sha1",
+		    "public/build/browser-awesomebar-63.0.20201013153553.aar",
+		    "public/build/browser-awesomebar-63.0.20201013153553.aar.md5",
+		    "public/build/browser-awesomebar-63.0.20201013153553.aar.sha1",
+		    "public/build/browser-awesomebar-63.0.20201013153553.pom",
+		    "public/build/browser-awesomebar-63.0.20201013153553.pom.md5",
+		    "public/build/browser-awesomebar-63.0.20201013153553.pom.sha1"
+		],
+		"taskId": "XGsGR0qdRmaWNE9fW5CmKQ",
+		"taskType": "build"
+	    }
+	]
+    }
+}

--- a/beetmoverscript/tests/task_examples/application_services_release.json
+++ b/beetmoverscript/tests/task_examples/application_services_release.json
@@ -1,0 +1,126 @@
+{
+    "dependencies": ["dependency-task-id"],
+    "scopes": [
+	"project:mozilla:app-services:releng:beetmover:bucket:maven-production",
+	"project:mozilla:app-services:releng:beetmover:action:push-to-maven"
+    ],
+    "payload": {
+	"version": "66.0.0",
+	"maxRunTime": 600,
+	"artifactMap": [
+	    {
+		"paths": {
+		    "public/build/fxaclient-66.0.0.aar": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0.aar"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/fxaclient-66.0.0.pom": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0.pom"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/fxaclient-66.0.0.aar.md5": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0.aar.md5"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/fxaclient-66.0.0.pom.md5": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0.pom.md5"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/fxaclient-66.0.0.aar.sha1": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0.aar.sha1"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/fxaclient-66.0.0.pom.sha1": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0.pom.sha1"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/fxaclient-66.0.0-sources.jar": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0-sources.jar"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/fxaclient-66.0.0-sources.jar.md5": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0-sources.jar.md5"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/fxaclient-66.0.0-sources.jar.sha1": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0-sources.jar.sha1"
+			],
+			"checksums_path": ""
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "JjLHZCxMSWynMdEZw3_4jg"
+	    },
+	    {
+		"paths": {
+		    "public/build/fxaclient-66.0.0.aar.asc": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0.aar.asc"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/fxaclient-66.0.0.pom.asc": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0.pom.asc"
+			],
+			"checksums_path": ""
+		    },
+		    "public/build/fxaclient-66.0.0-sources.jar.asc": {
+			"destinations": [
+			    "maven2/org/mozilla/appservices/fxaclient/66.0.0/fxaclient-66.0.0-sources.jar.asc"
+			],
+			"checksums_path": ""
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "INzRHbs3S3C6JCOgO4gawQ"
+	    }
+	],
+	"releaseProperties": {
+	    "appName": "appservices"
+	},
+	"upstreamArtifacts": [
+	    {
+		"paths": [
+		    "public/build/fxaclient-66.0.0.aar",
+		    "public/build/fxaclient-66.0.0.aar.sha1",
+		    "public/build/fxaclient-66.0.0.aar.md5",
+		    "public/build/fxaclient-66.0.0.pom",
+		    "public/build/fxaclient-66.0.0.pom.sha1",
+		    "public/build/fxaclient-66.0.0.pom.md5",
+		    "public/build/fxaclient-66.0.0-sources.jar",
+		    "public/build/fxaclient-66.0.0-sources.jar.sha1",
+		    "public/build/fxaclient-66.0.0-sources.jar.md5"
+		],
+		"taskId": "JjLHZCxMSWynMdEZw3_4jg",
+		"taskType": "build"
+	    },
+	    {
+		"paths": [
+		    "public/build/fxaclient-66.0.0.aar.asc",
+		    "public/build/fxaclient-66.0.0.pom.asc",
+		    "public/build/fxaclient-66.0.0-sources.jar.asc"
+		],
+		"taskId": "INzRHbs3S3C6JCOgO4gawQ",
+		"taskType": "signing"
+	    }
+	]
+    }
+}

--- a/beetmoverscript/tests/task_examples/geckoview_nightly.json
+++ b/beetmoverscript/tests/task_examples/geckoview_nightly.json
@@ -1,0 +1,162 @@
+{
+    "dependencies": ["dependency-task-id"],
+    "scopes": [
+	"project:releng:beetmover:bucket:maven-production",
+	"project:releng:beetmover:action:push-to-maven"
+    ],
+    "payload": {
+	"version": "84.0.20201027095021",
+	"appVersion": "84.0a1",
+	"maxRunTime": 600,
+	"artifactMap": [
+	    {
+		"paths": {
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021.aar"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021.pom"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar.md5": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar.md5"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021.aar.md5"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom.md5": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom.md5"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021.pom.md5"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar.sha1": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar.sha1"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021.aar.sha1"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom.sha1": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom.sha1"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021.pom.sha1"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021-javadoc.jar"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021-sources.jar"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.md5": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.md5"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.md5"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar.md5": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar.md5"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021-sources.jar.md5"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.sha1": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.sha1"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.sha1"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar.sha1": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar.sha1"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021-sources.jar.sha1"
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "X2txpHOYRGiICb75NC1QCA"
+	    },
+	    {
+		"paths": {
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar.asc": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar.asc"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021.aar.asc"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom.asc": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom.asc"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021.pom.asc"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.asc": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.asc"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.asc"
+		    },
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar.asc": {
+			"destinations": [
+			    "maven2/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar.asc"
+			],
+			"checksums_path": "geckoview-nightly-x86-84.0.20201027095021-sources.jar.asc"
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "Ha-3lq3hTCKThoBUEW1F-Q"
+	    }
+	],
+	"artifact_id": "geckoview-nightly-x86",
+	"upload_date": 1603792221,
+	"build_number": 1,
+	"next_version": null,
+	"releaseProperties": {
+	    "branch": "mozilla-central",
+	    "appName": "geckoview",
+	    "buildid": "20201027095021",
+	    "appVersion": "84.0a1"
+	},
+	"upstreamArtifacts": [
+	    {
+		"paths": [
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.md5",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.sha1",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar.md5",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar.sha1",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar.md5",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar.sha1",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom.md5",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom.sha1"
+		],
+		"taskId": "X2txpHOYRGiICb75NC1QCA",
+		"taskType": "build"
+	    },
+	    {
+		"paths": [
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-javadoc.jar.asc",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021-sources.jar.asc",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.aar.asc",
+		    "public/build/maven/org/mozilla/geckoview/geckoview-nightly-x86/84.0.20201027095021/geckoview-nightly-x86-84.0.20201027095021.pom.asc"
+		],
+		"taskId": "Ha-3lq3hTCKThoBUEW1F-Q",
+		"taskType": "signing"
+	    }
+	]
+    }
+}

--- a/beetmoverscript/tests/task_examples/glean_release.json
+++ b/beetmoverscript/tests/task_examples/glean_release.json
@@ -1,0 +1,182 @@
+{
+    "dependencies": ["dependency-task-id"],
+    "scopes": [
+    "project:mozilla:glean:releng:beetmover:bucket:maven-production",
+    "project:mozilla:glean:releng:beetmover:action:push-to-maven"
+  ],
+  "payload": {
+    "version": "32.4.1",
+    "maxRunTime": 600,
+    "artifactMap": [
+      {
+        "paths": {
+          "public/build/glean-32.4.1.aar": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1.aar"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-32.4.1.pom": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1.pom"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-32.4.1.aar.md5": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1.aar.md5"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-32.4.1.pom.md5": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1.pom.md5"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-32.4.1.aar.sha1": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1.aar.sha1"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-32.4.1.pom.sha1": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1.pom.sha1"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-32.4.1-sources.jar": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1-sources.jar"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-32.4.1-sources.jar.md5": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1-sources.jar.md5"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-32.4.1-sources.jar.sha1": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1-sources.jar.sha1"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-forUnitTests-32.4.1.jar": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean-forUnitTests/32.4.1/glean-forUnitTests-32.4.1.jar"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-forUnitTests-32.4.1.pom": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean-forUnitTests/32.4.1/glean-forUnitTests-32.4.1.pom"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-forUnitTests-32.4.1.jar.md5": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean-forUnitTests/32.4.1/glean-forUnitTests-32.4.1.jar.md5"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-forUnitTests-32.4.1.pom.md5": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean-forUnitTests/32.4.1/glean-forUnitTests-32.4.1.pom.md5"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-forUnitTests-32.4.1.jar.sha1": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean-forUnitTests/32.4.1/glean-forUnitTests-32.4.1.jar.sha1"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-forUnitTests-32.4.1.pom.sha1": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean-forUnitTests/32.4.1/glean-forUnitTests-32.4.1.pom.sha1"
+            ],
+            "checksums_path": ""
+          }
+        },
+        "locale": "en-US",
+        "taskId": "E1__QlpvTle9kvK7QGAXfQ"
+      },
+      {
+        "paths": {
+          "public/build/glean-32.4.1.aar.asc": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1.aar.asc"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-32.4.1.pom.asc": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1.pom.asc"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-32.4.1-sources.jar.asc": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean/32.4.1/glean-32.4.1-sources.jar.asc"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-forUnitTests-32.4.1.jar.asc": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean-forUnitTests/32.4.1/glean-forUnitTests-32.4.1.jar.asc"
+            ],
+            "checksums_path": ""
+          },
+          "public/build/glean-forUnitTests-32.4.1.pom.asc": {
+            "destinations": [
+              "maven2/org/mozilla/telemetry/glean-forUnitTests/32.4.1/glean-forUnitTests-32.4.1.pom.asc"
+            ],
+            "checksums_path": ""
+          }
+        },
+        "locale": "en-US",
+        "taskId": "ZuSxSVk-Q5-Sbdiy7PBBmA"
+      }
+    ],
+    "releaseProperties": {
+      "appName": "telemetry"
+    },
+    "upstreamArtifacts": [
+      {
+        "paths": [
+          "public/build/glean-32.4.1.aar",
+          "public/build/glean-32.4.1.aar.sha1",
+          "public/build/glean-32.4.1.aar.md5",
+          "public/build/glean-32.4.1.pom",
+          "public/build/glean-32.4.1.pom.sha1",
+          "public/build/glean-32.4.1.pom.md5",
+          "public/build/glean-32.4.1-sources.jar",
+          "public/build/glean-32.4.1-sources.jar.sha1",
+          "public/build/glean-32.4.1-sources.jar.md5",
+          "public/build/glean-forUnitTests-32.4.1.jar",
+          "public/build/glean-forUnitTests-32.4.1.jar.sha1",
+          "public/build/glean-forUnitTests-32.4.1.jar.md5",
+          "public/build/glean-forUnitTests-32.4.1.pom",
+          "public/build/glean-forUnitTests-32.4.1.pom.sha1",
+          "public/build/glean-forUnitTests-32.4.1.pom.md5"
+        ],
+        "taskId": "E1__QlpvTle9kvK7QGAXfQ",
+        "taskType": "build"
+      },
+      {
+        "paths": [
+          "public/build/glean-32.4.1.aar.asc",
+          "public/build/glean-32.4.1.pom.asc",
+          "public/build/glean-32.4.1-sources.jar.asc",
+          "public/build/glean-forUnitTests-32.4.1.jar.asc",
+          "public/build/glean-forUnitTests-32.4.1.pom.asc"
+        ],
+        "taskId": "ZuSxSVk-Q5-Sbdiy7PBBmA",
+        "taskType": "signing"
+      }
+    ]
+  }
+}

--- a/beetmoverscript/tests/test_integration.py
+++ b/beetmoverscript/tests/test_integration.py
@@ -15,37 +15,30 @@ def get_test_task(task_name):
     return load_json(f"tests/task_examples/{task_name}.json")
 
 
+_CONFIG_MAP = {
+    "android-components": {
+        "taskcluster_scope_prefix": "project:mobile:android-components:releng:beetmover:",
+        "bucket_config_key": "maven-nightly-staging",
+        "bucket_name": "nightly_components",
+    },
+    "app-services": {
+        "taskcluster_scope_prefix": "project:mozilla:app-services:releng:beetmover:",
+        "bucket_config_key": "maven-production",
+        "bucket_name": "appservices",
+    },
+    "geckoview": {"taskcluster_scope_prefix": "project:releng:beetmover:", "bucket_config_key": "maven-production", "bucket_name": "geckoview"},
+    "glean": {"taskcluster_scope_prefix": "project:mozilla:glean:releng:beetmover:", "bucket_config_key": "maven-production", "bucket_name": "telemetry"},
+}
+
+
 def get_config(config_name):
-    return {"android-components": _config_android_components, "app-services": _config_app_services, "geckoview": _config_geckoview, "glean": _config_glean}[
-        config_name
-    ]()
-
-
-def _config_android_components():
     config = get_fake_valid_config()
-    config["taskcluster_scope_prefix"] = "project:mobile:android-components:releng:beetmover:"
-    config["bucket_config"]["maven-nightly-staging"] = {"buckets": {"nightly_components": "dummy"}, "credentials": {"id": "dummy", "key": "dummy"}}
-    return config
-
-
-def _config_app_services():
-    config = get_fake_valid_config()
-    config["taskcluster_scope_prefix"] = "project:mozilla:app-services:releng:beetmover:"
-    config["bucket_config"]["maven-production"] = {"buckets": {"appservices": "dummy"}, "credentials": {"id": "dummy", "key": "dummy"}}
-    return config
-
-
-def _config_geckoview():
-    config = get_fake_valid_config()
-    config["taskcluster_scope_prefix"] = "project:releng:beetmover:"
-    config["bucket_config"]["maven-production"] = {"buckets": {"geckoview": "dummy"}, "credentials": {"id": "dummy", "key": "dummy"}}
-    return config
-
-
-def _config_glean():
-    config = get_fake_valid_config()
-    config["taskcluster_scope_prefix"] = "project:mozilla:glean:releng:beetmover:"
-    config["bucket_config"]["maven-production"] = {"buckets": {"telemetry": "dummy"}, "credentials": {"id": "dummy", "key": "dummy"}}
+    config_props = _CONFIG_MAP[config_name]
+    config["taskcluster_scope_prefix"] = config_props["taskcluster_scope_prefix"]
+    config["bucket_config"][config_props["bucket_config_key"]] = {
+        "buckets": {config_props["bucket_name"]: "dummy"},
+        "credentials": {"id": "dummy", "key": "dummy"},
+    }
     return config
 
 

--- a/beetmoverscript/tests/test_integration.py
+++ b/beetmoverscript/tests/test_integration.py
@@ -16,7 +16,9 @@ def get_test_task(task_name):
 
 
 def get_config(config_name):
-    return {"android-components": _config_android_components(), "geckoview": _config_geckoview()}[config_name]
+    return {"android-components": _config_android_components, "app-services": _config_app_services, "geckoview": _config_geckoview, "glean": _config_glean}[
+        config_name
+    ]()
 
 
 def _config_android_components():
@@ -26,10 +28,24 @@ def _config_android_components():
     return config
 
 
+def _config_app_services():
+    config = get_fake_valid_config()
+    config["taskcluster_scope_prefix"] = "project:mozilla:app-services:releng:beetmover:"
+    config["bucket_config"]["maven-production"] = {"buckets": {"appservices": "dummy"}, "credentials": {"id": "dummy", "key": "dummy"}}
+    return config
+
+
 def _config_geckoview():
     config = get_fake_valid_config()
     config["taskcluster_scope_prefix"] = "project:releng:beetmover:"
     config["bucket_config"]["maven-production"] = {"buckets": {"geckoview": "dummy"}, "credentials": {"id": "dummy", "key": "dummy"}}
+    return config
+
+
+def _config_glean():
+    config = get_fake_valid_config()
+    config["taskcluster_scope_prefix"] = "project:mozilla:glean:releng:beetmover:"
+    config["bucket_config"]["maven-production"] = {"buckets": {"telemetry": "dummy"}, "credentials": {"id": "dummy", "key": "dummy"}}
     return config
 
 
@@ -123,7 +139,13 @@ def prepare_scriptworker_config(path, config, task):
 
 
 @pytest.mark.parametrize(
-    "config_name, task_name, expected_number_of_artifacts", (("android-components", "android_components_nightly", 12), ("geckoview", "geckoview_nightly", 16))
+    "config_name, task_name, expected_number_of_artifacts",
+    (
+        ("android-components", "android_components_nightly", 12),
+        ("geckoview", "geckoview_nightly", 16),
+        ("app-services", "application_services_release", 12),
+        ("glean", "glean_release", 20),
+    ),
 )
 def test_main_push_to_maven(config_name, task_name, expected_number_of_artifacts, tmp_path, boto3_client_mock, aiohttp_session_mock):
     config = get_config(config_name)

--- a/beetmoverscript/tests/test_integration.py
+++ b/beetmoverscript/tests/test_integration.py
@@ -6,140 +6,31 @@ import pytest
 
 import beetmoverscript.script
 from beetmoverscript.script import main
+from beetmoverscript.utils import load_json
 
 from . import get_fake_valid_config
 
 
-@pytest.fixture
-def config():
+def get_test_task(task_name):
+    return load_json(f"tests/task_examples/{task_name}.json")
+
+
+def get_config(config_name):
+    return {"android-components": _config_android_components(), "geckoview": _config_geckoview()}[config_name]
+
+
+def _config_android_components():
     config = get_fake_valid_config()
     config["taskcluster_scope_prefix"] = "project:mobile:android-components:releng:beetmover:"
     config["bucket_config"]["maven-nightly-staging"] = {"buckets": {"nightly_components": "dummy"}, "credentials": {"id": "dummy", "key": "dummy"}}
     return config
 
 
-@pytest.fixture
-def task():
-    return {
-        "dependencies": ["dependency-task-id"],
-        "scopes": [
-            "project:mobile:android-components:releng:beetmover:action:push-to-maven",
-            "project:mobile:android-components:releng:beetmover:bucket:maven-nightly-staging",
-        ],
-        "payload": {
-            "version": "63.0.20201013153553",
-            "artifactMap": [
-                {"paths": {}, "locale": "en-US", "taskId": "AKjtHrqYQ32EDZ3GNzwXGg"},
-                {
-                    "paths": {
-                        "public/build/browser-awesomebar-63.0.20201013153553.aar.asc": {
-                            "destinations": [
-                                "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.aar.asc"
-                            ],
-                            "checksums_path": "",
-                        },
-                        "public/build/browser-awesomebar-63.0.20201013153553.pom.asc": {
-                            "destinations": [
-                                "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.pom.asc"
-                            ],
-                            "checksums_path": "",
-                        },
-                        "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.asc": {
-                            "destinations": [
-                                "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553-sources.jar.asc"
-                            ],
-                            "checksums_path": "",
-                        },
-                    },
-                    "locale": "en-US",
-                    "taskId": "ZYfA8OtXRZuDeF5Xq3ubxg",
-                },
-                {
-                    "paths": {
-                        "public/build/browser-awesomebar-63.0.20201013153553.aar": {
-                            "destinations": ["maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.aar"],
-                            "checksums_path": "",
-                        },
-                        "public/build/browser-awesomebar-63.0.20201013153553.pom": {
-                            "destinations": ["maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.pom"],
-                            "checksums_path": "",
-                        },
-                        "public/build/browser-awesomebar-63.0.20201013153553.aar.md5": {
-                            "destinations": [
-                                "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.aar.md5"
-                            ],
-                            "checksums_path": "",
-                        },
-                        "public/build/browser-awesomebar-63.0.20201013153553.pom.md5": {
-                            "destinations": [
-                                "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.pom.md5"
-                            ],
-                            "checksums_path": "",
-                        },
-                        "public/build/browser-awesomebar-63.0.20201013153553.aar.sha1": {
-                            "destinations": [
-                                "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.aar.sha1"
-                            ],
-                            "checksums_path": "",
-                        },
-                        "public/build/browser-awesomebar-63.0.20201013153553.pom.sha1": {
-                            "destinations": [
-                                "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553.pom.sha1"
-                            ],
-                            "checksums_path": "",
-                        },
-                        "public/build/browser-awesomebar-63.0.20201013153553-sources.jar": {
-                            "destinations": [
-                                "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553-sources.jar"
-                            ],
-                            "checksums_path": "",
-                        },
-                        "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.md5": {
-                            "destinations": [
-                                "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553-sources.jar.md5"
-                            ],
-                            "checksums_path": "",
-                        },
-                        "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.sha1": {
-                            "destinations": [
-                                "maven2/org/mozilla/components/browser-awesomebar/63.0.20201013153553/browser-awesomebar-63.0.20201013153553-sources.jar.sha1"
-                            ],
-                            "checksums_path": "",
-                        },
-                    },
-                    "locale": "en-US",
-                    "taskId": "XGsGR0qdRmaWNE9fW5CmKQ",
-                },
-            ],
-            "releaseProperties": {"appName": "nightly_components"},
-            "upstreamArtifacts": [
-                {
-                    "paths": [
-                        "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.asc",
-                        "public/build/browser-awesomebar-63.0.20201013153553.aar.asc",
-                        "public/build/browser-awesomebar-63.0.20201013153553.pom.asc",
-                    ],
-                    "taskId": "ZYfA8OtXRZuDeF5Xq3ubxg",
-                    "taskType": "signing",
-                },
-                {
-                    "paths": [
-                        "public/build/browser-awesomebar-63.0.20201013153553-sources.jar",
-                        "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.md5",
-                        "public/build/browser-awesomebar-63.0.20201013153553-sources.jar.sha1",
-                        "public/build/browser-awesomebar-63.0.20201013153553.aar",
-                        "public/build/browser-awesomebar-63.0.20201013153553.aar.md5",
-                        "public/build/browser-awesomebar-63.0.20201013153553.aar.sha1",
-                        "public/build/browser-awesomebar-63.0.20201013153553.pom",
-                        "public/build/browser-awesomebar-63.0.20201013153553.pom.md5",
-                        "public/build/browser-awesomebar-63.0.20201013153553.pom.sha1",
-                    ],
-                    "taskId": "XGsGR0qdRmaWNE9fW5CmKQ",
-                    "taskType": "build",
-                },
-            ],
-        },
-    }
+def _config_geckoview():
+    config = get_fake_valid_config()
+    config["taskcluster_scope_prefix"] = "project:releng:beetmover:"
+    config["bucket_config"]["maven-production"] = {"buckets": {"geckoview": "dummy"}, "credentials": {"id": "dummy", "key": "dummy"}}
+    return config
 
 
 def create_dummy_artifacts_for_task(task, root_path):
@@ -214,13 +105,12 @@ def aiohttp_session_mock(monkeypatch):
     return aiohttp_mock_data
 
 
-@pytest.fixture
-def scriptworker_config(tmp_path, config, task):
-    work_dir = tmp_path / "work"
+def prepare_scriptworker_config(path, config, task):
+    work_dir = path / "work"
     work_dir.mkdir()
     config["work_dir"] = str(work_dir)
 
-    config_path = tmp_path / "config.json"
+    config_path = path / "config.json"
     with open(config_path, "w") as config_file:
         json.dump(config, config_file)
 
@@ -232,11 +122,18 @@ def scriptworker_config(tmp_path, config, task):
     return config_path
 
 
-def test_main_android_components_nightly(scriptworker_config, task, boto3_client_mock, aiohttp_session_mock):
+@pytest.mark.parametrize(
+    "config_name, task_name, expected_number_of_artifacts", (("android-components", "android_components_nightly", 12), ("geckoview", "geckoview_nightly", 16))
+)
+def test_main_push_to_maven(config_name, task_name, expected_number_of_artifacts, tmp_path, boto3_client_mock, aiohttp_session_mock):
+    config = get_config(config_name)
+    task = get_test_task(task_name)
+    scriptworker_config = prepare_scriptworker_config(tmp_path, config, task)
+
     main(config_path=scriptworker_config)
 
     # Number of artifacts put matches expected
-    assert len(aiohttp_session_mock["put"]) == 12
+    assert len(aiohttp_session_mock["put"]) == expected_number_of_artifacts
 
     # Check paths
     expected_paths = get_paths_for_task(task)


### PR DESCRIPTION
This adds more test cases for integration testing on beetmover.

In a first draft, I'm adding a test for geckoview-nightly, moving task data to a separate folder and reorganized helper functions to make it easier to reuse common setup and assertion logic.

Would it be possible to get a list of possible cases worth adding so that I can build some sort of checklist to have a better of idea of when I'm done?