### PR TITLE
Bug 1672691 - part 3: [beetmoverscript] Add integration tests to beetmover (push-to-nightly)

### DIFF
--- a/beetmoverscript/tests/task_examples/firefox_desktop_nightly.json
+++ b/beetmoverscript/tests/task_examples/firefox_desktop_nightly.json
@@ -1,0 +1,308 @@
+{
+    "dependencies": ["dependency-task-id"],
+    "scopes": [
+	"project:releng:beetmover:bucket:nightly",
+	"project:releng:beetmover:action:push-to-nightly"
+    ],
+    "payload": {
+	"version": "84.0a1",
+	"appVersion": "84.0a1",
+	"maxRunTime": 600,
+	"artifactMap": [
+	    {
+		"paths": {
+		    "public/build/target.txt": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.txt",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.txt"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.txt"
+		    },
+		    "public/build/target.json": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.json",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.json"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.json"
+		    },
+		    "public/build/host/bin/mar": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/mar-tools/linux/mar",
+			    "pub/firefox/nightly/latest-mozilla-central/mar-tools/linux/mar"
+			],
+			"checksums_path": "mar"
+		    },
+		    "public/build/buildhub.json": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.buildhub.json",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.buildhub.json",
+			    "pub/firefox/nightly/latest-mozilla-central-l10n/firefox-84.0a1.en-US.linux-i686.buildhub.json"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.buildhub.json"
+		    },
+		    "public/build/mozharness.zip": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/mozharness.zip",
+			    "pub/firefox/nightly/latest-mozilla-central/mozharness.zip"
+			],
+			"checksums_path": "mozharness.zip"
+		    },
+		    "public/build/target_info.txt": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686_info.txt",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686_info.txt"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686_info.txt"
+		    },
+		    "public/build/host/bin/mbsdiff": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/mar-tools/linux/mbsdiff",
+			    "pub/firefox/nightly/latest-mozilla-central/mar-tools/linux/mbsdiff"
+			],
+			"checksums_path": "mbsdiff"
+		    },
+		    "public/build/target.jsshell.zip": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/jsshell-linux-i686.zip",
+			    "pub/firefox/nightly/latest-mozilla-central/jsshell-linux-i686.zip"
+			],
+			"checksums_path": "jsshell-linux-i686.zip"
+		    },
+		    "public/build/target.mozinfo.json": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.mozinfo.json",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.mozinfo.json"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.mozinfo.json"
+		    },
+		    "public/build/target.awsy.tests.tar.gz": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.awsy.tests.tar.gz",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.awsy.tests.tar.gz"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.awsy.tests.tar.gz"
+		    },
+		    "public/build/target.talos.tests.tar.gz": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.talos.tests.tar.gz",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.talos.tests.tar.gz"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.talos.tests.tar.gz"
+		    },
+		    "public/build/target.test_packages.json": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.test_packages.json",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.test_packages.json"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.test_packages.json"
+		    },
+		    "public/build/target.common.tests.tar.gz": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.common.tests.tar.gz",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.common.tests.tar.gz"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.common.tests.tar.gz"
+		    },
+		    "public/build/target.reftest.tests.tar.gz": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.reftest.tests.tar.gz",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.reftest.tests.tar.gz"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.reftest.tests.tar.gz"
+		    },
+		    "public/build/target.xpcshell.tests.tar.gz": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.xpcshell.tests.tar.gz",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.xpcshell.tests.tar.gz"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.xpcshell.tests.tar.gz"
+		    },
+		    "public/build/target.mochitest.tests.tar.gz": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.mochitest.tests.tar.gz",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.mochitest.tests.tar.gz"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.mochitest.tests.tar.gz"
+		    },
+		    "public/build/target.cppunittest.tests.tar.gz": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.cppunittest.tests.tar.gz",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.cppunittest.tests.tar.gz"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.cppunittest.tests.tar.gz"
+		    },
+		    "public/build/target.crashreporter-symbols.zip": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.crashreporter-symbols.zip",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.crashreporter-symbols.zip"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.crashreporter-symbols.zip"
+		    },
+		    "public/build/target.web-platform.tests.tar.gz": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.web-platform.tests.tar.gz",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.web-platform.tests.tar.gz"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.web-platform.tests.tar.gz"
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "ARI2zIZcRm6HEfmpB7XNqw"
+	    },
+	    {
+		"paths": {
+		    "public/build/target.complete.mar": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.complete.mar",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.complete.mar",
+			    "pub/firefox/nightly/latest-mozilla-central-l10n/firefox-84.0a1.en-US.linux-i686.complete.mar"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.complete.mar",
+			"update_balrog_manifest": true
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "PcKd-7OOSmSXcCo5RWtkeA"
+	    },
+	    {
+		"paths": {
+		    "public/build/target.tar.bz2": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.tar.bz2",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.tar.bz2",
+			    "pub/firefox/nightly/latest-mozilla-central-l10n/firefox-84.0a1.en-US.linux-i686.tar.bz2"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.tar.bz2"
+		    },
+		    "public/build/target.tar.bz2.asc": {
+			"destinations": [
+			    "pub/firefox/nightly/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-84.0a1.en-US.linux-i686.tar.bz2.asc",
+			    "pub/firefox/nightly/latest-mozilla-central/firefox-84.0a1.en-US.linux-i686.tar.bz2.asc",
+			    "pub/firefox/nightly/latest-mozilla-central-l10n/firefox-84.0a1.en-US.linux-i686.tar.bz2.asc"
+			],
+			"checksums_path": "firefox-84.0a1.en-US.linux-i686.tar.bz2.asc"
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "JFY047GEQUGFq4IuCI_yEA"
+	    },
+	    {
+		"paths": {
+		    "public/build/target.partial-1.mar": {
+			"destinations": [
+			    "pub/firefox/nightly/partials/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-mozilla-central-84.0a1-linux-i686-en-US-20201029155212-20201030034830.partial.mar"
+			],
+			"from_buildid": "20201029155212",
+			"checksums_path": "firefox-mozilla-central-84.0a1-linux-i686-en-US-20201029155212-20201030034830.partial.mar",
+			"update_balrog_manifest": true
+		    },
+		    "public/build/target.partial-2.mar": {
+			"destinations": [
+			    "pub/firefox/nightly/partials/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-mozilla-central-84.0a1-linux-i686-en-US-20201029095639-20201030034830.partial.mar"
+			],
+			"from_buildid": "20201029095639",
+			"checksums_path": "firefox-mozilla-central-84.0a1-linux-i686-en-US-20201029095639-20201030034830.partial.mar",
+			"update_balrog_manifest": true
+		    },
+		    "public/build/target.partial-3.mar": {
+			"destinations": [
+			    "pub/firefox/nightly/partials/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-mozilla-central-84.0a1-linux-i686-en-US-20201028214727-20201030034830.partial.mar"
+			],
+			"from_buildid": "20201028214727",
+			"checksums_path": "firefox-mozilla-central-84.0a1-linux-i686-en-US-20201028214727-20201030034830.partial.mar",
+			"update_balrog_manifest": true
+		    },
+		    "public/build/target.partial-4.mar": {
+			"destinations": [
+			    "pub/firefox/nightly/partials/2020/10/2020-10-30-03-48-30-mozilla-central/firefox-mozilla-central-84.0a1-linux-i686-en-US-20201028092421-20201030034830.partial.mar"
+			],
+			"from_buildid": "20201028092421",
+			"checksums_path": "firefox-mozilla-central-84.0a1-linux-i686-en-US-20201028092421-20201030034830.partial.mar",
+			"update_balrog_manifest": true
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "K3mJW6lqTzKiKpJc0etAAg"
+	    }
+	],
+	"upload_date": 1604029710,
+	"build_number": 1,
+	"next_version": null,
+	"releaseProperties": {
+	    "branch": "mozilla-central",
+	    "appName": "Firefox",
+	    "buildid": "20201030034830",
+	    "hashType": "sha512",
+	    "platform": "linux",
+	    "appVersion": "84.0a1"
+	},
+	"upstreamArtifacts": [
+	    {
+		"paths": [
+		    "public/build/buildhub.json",
+		    "public/build/host/bin/mar",
+		    "public/build/host/bin/mbsdiff",
+		    "public/build/mozharness.zip",
+		    "public/build/target.awsy.tests.tar.gz",
+		    "public/build/target.common.tests.tar.gz",
+		    "public/build/target.cppunittest.tests.tar.gz",
+		    "public/build/target.crashreporter-symbols.zip",
+		    "public/build/target.json",
+		    "public/build/target.jsshell.zip",
+		    "public/build/target.mochitest.tests.tar.gz",
+		    "public/build/target.mozinfo.json",
+		    "public/build/target.reftest.tests.tar.gz",
+		    "public/build/target.talos.tests.tar.gz",
+		    "public/build/target.test_packages.json",
+		    "public/build/target.txt",
+		    "public/build/target.web-platform.tests.tar.gz",
+		    "public/build/target.xpcshell.tests.tar.gz",
+		    "public/build/target_info.txt"
+		],
+		"locale": "en-US",
+		"taskId": "ARI2zIZcRm6HEfmpB7XNqw",
+		"taskType": "build"
+	    },
+	    {
+		"paths": [
+		    "public/build/target.complete.mar"
+		],
+		"locale": "en-US",
+		"taskId": "PcKd-7OOSmSXcCo5RWtkeA",
+		"taskType": "signing"
+	    },
+	    {
+		"paths": [
+		    "public/build/target.tar.bz2",
+		    "public/build/target.tar.bz2.asc"
+		],
+		"locale": "en-US",
+		"taskId": "JFY047GEQUGFq4IuCI_yEA",
+		"taskType": "signing"
+	    },
+	    {
+		"paths": [
+		    "public/build/target.partial-2.mar",
+		    "public/build/target.partial-3.mar",
+		    "public/build/target.partial-1.mar",
+		    "public/build/target.partial-4.mar"
+		],
+		"locale": "en-US",
+		"taskId": "K3mJW6lqTzKiKpJc0etAAg",
+		"taskType": "signing"
+	    }
+	]
+    },
+    "metadata": {
+	"name": "beetmover-repackage-linux-shippable/opt",
+	"owner": "cron@noreply.mozilla.org",
+	"source": "https://hg.mozilla.org/mozilla-central/file/9a7e5873fac52c3fea4e8d9843e0aaf8e9158eb7/taskcluster/ci/beetmover-repackage",
+	"description": "Beetmover submission for locale 'en-US' for build 'linux-shippable/opt' ([Treeherder job](https://treeherder.mozilla.org/#/jobs?repo=mozilla-central&revision=9a7e5873fac52c3fea4e8d9843e0aaf8e9158eb7&selectedTaskRun=JD3Pxn_HRj6YxbqEfpKchw))"
+    },
+    "tags": {
+	"kind": "beetmover-repackage",
+	"label": "beetmover-repackage-linux-shippable/opt",
+	"retrigger": "false",
+	"createdForUser": "cron@noreply.mozilla.org"
+    }
+}

--- a/beetmoverscript/tests/task_examples/firefox_generated_screenshots_release.json
+++ b/beetmoverscript/tests/task_examples/firefox_generated_screenshots_release.json
@@ -1,0 +1,114 @@
+{
+    "dependencies": ["dependency-task-id"],
+    "scopes": [
+	"project:releng:beetmover:bucket:release",
+	"project:releng:beetmover:action:push-to-candidates"
+    ],
+    "payload": {
+	"version": "82.0.2",
+	"appVersion": "82.0.2",
+	"maxRunTime": 600,
+	"artifactMap": [
+	    {
+		"paths": {
+		    "public/build/SHA256SUMMARY": {
+			"destinations": [
+			    "pub/firefox/candidates/82.0.2-candidates/build1/SHA256SUMMARY"
+			],
+			"checksums_path": "SHA256SUMMARY"
+		    },
+		    "public/build/SHA512SUMMARY": {
+			"destinations": [
+			    "pub/firefox/candidates/82.0.2-candidates/build1/SHA512SUMMARY"
+			],
+			"checksums_path": "SHA512SUMMARY"
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "c7vpVThDQhGu_GASiehxNg"
+	    },
+	    {
+		"paths": {
+		    "public/build/KEY": {
+			"destinations": [
+			    "pub/firefox/candidates/82.0.2-candidates/build1/KEY"
+			],
+			"checksums_path": "KEY"
+		    },
+		    "public/build/SHA256SUMS": {
+			"destinations": [
+			    "pub/firefox/candidates/82.0.2-candidates/build1/SHA256SUMS"
+			],
+			"checksums_path": "SHA256SUMS"
+		    },
+		    "public/build/SHA512SUMS": {
+			"destinations": [
+			    "pub/firefox/candidates/82.0.2-candidates/build1/SHA512SUMS"
+			],
+			"checksums_path": "SHA512SUMS"
+		    },
+		    "public/build/SHA256SUMS.asc": {
+			"destinations": [
+			    "pub/firefox/candidates/82.0.2-candidates/build1/SHA256SUMS.asc"
+			],
+			"checksums_path": "SHA256SUMS.asc"
+		    },
+		    "public/build/SHA512SUMS.asc": {
+			"destinations": [
+			    "pub/firefox/candidates/82.0.2-candidates/build1/SHA512SUMS.asc"
+			],
+			"checksums_path": "SHA512SUMS.asc"
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "eyWBXkEDTnOsnRFwRNdl3g"
+	    }
+	],
+	"upload_date": 1603824823,
+	"build_number": 1,
+	"next_version": "82.0.3",
+	"releaseProperties": {
+	    "branch": "mozilla-release",
+	    "appName": "Firefox",
+	    "buildid": "20201027185343",
+	    "hashType": "sha512",
+	    "platform": "firefox-release",
+	    "appVersion": "82.0.2"
+	},
+	"upstreamArtifacts": [
+	    {
+		"paths": [
+		    "public/build/KEY",
+		    "public/build/SHA256SUMS",
+		    "public/build/SHA256SUMS.asc",
+		    "public/build/SHA512SUMS",
+		    "public/build/SHA512SUMS.asc"
+		],
+		"locale": "en-US",
+		"taskId": "eyWBXkEDTnOsnRFwRNdl3g",
+		"taskType": "signing"
+	    },
+	    {
+		"paths": [
+		    "public/build/SHA256SUMMARY",
+		    "public/build/SHA512SUMMARY"
+		],
+		"locale": "en-US",
+		"taskId": "c7vpVThDQhGu_GASiehxNg",
+		"taskType": "build"
+	    }
+	]
+    },
+    "metadata": {
+	"name": "release-generate-checksums-firefox-beetmover",
+	"owner": "jcristau@mozilla.com",
+	"source": "https://hg.mozilla.org/releases/mozilla-release/file/690c4477e78a86bf10b1d3e4cf5d9b9cf65ddb4d/taskcluster/ci/release-generate-checksums-beetmover",
+	"description": "Transfer *SUMS and *SUMMARY checksums file to S3. ([Treeherder job](https://treeherder.mozilla.org/#/jobs?repo=mozilla-release&revision=690c4477e78a86bf10b1d3e4cf5d9b9cf65ddb4d&selectedTaskRun=bAGO1prJQESNjKjmFbtaIQ))"
+    },
+    "tags": {
+	"kind": "release-generate-checksums-beetmover",
+	"label": "release-generate-checksums-firefox-beetmover",
+	"retrigger": "false",
+	"createdForUser": "jcristau@mozilla.com"
+    }
+}

--- a/beetmoverscript/tests/task_examples/firefox_langpacks_beta.json
+++ b/beetmoverscript/tests/task_examples/firefox_langpacks_beta.json
@@ -1,0 +1,59 @@
+{
+    "dependencies": ["dependency-task-id"],
+    "scopes": [
+	"project:releng:beetmover:bucket:release",
+	"project:releng:beetmover:action:push-to-candidates"
+    ],
+    "payload": {
+	"version": "83.0b6",
+	"appVersion": "83.0",
+	"maxRunTime": 600,
+	"artifactMap": [
+	    {
+		"paths": {
+		    "public/build/target.langpack.xpi": {
+			"destinations": [
+			    "pub/devedition/candidates/83.0b6-candidates/build1/win64/xpi/en-US.xpi"
+			],
+			"checksums_path": "win64/xpi/en-US.xpi"
+		    }
+		},
+		"locale": "en-US",
+		"taskId": "XBrxp_LQTeirKUU4gAjaag"
+	    }
+	],
+	"upload_date": 1603995829,
+	"build_number": 1,
+	"next_version": "83.0b7",
+	"releaseProperties": {
+	    "branch": "mozilla-beta",
+	    "appName": "Firefox",
+	    "buildid": "20201029182349",
+	    "hashType": "sha512",
+	    "platform": "win64-devedition",
+	    "appVersion": "83.0"
+	},
+	"upstreamArtifacts": [
+	    {
+		"paths": [
+		    "public/build/target.langpack.xpi"
+		],
+		"locale": "en-US",
+		"taskId": "XBrxp_LQTeirKUU4gAjaag",
+		"taskType": "scriptworker"
+	    }
+	]
+    },
+    "metadata": {
+	"name": "release-beetmover-signed-langpacks-win64-devedition/opt",
+	"owner": "ryanvm@gmail.com",
+	"source": "https://hg.mozilla.org/releases/mozilla-beta/file/dcd1bd71910ce9dbb20aee38fa4dd36def652687/taskcluster/ci/release-beetmover-signed-langpacks",
+	"description": "Beetmover submission for platform-independent langpacks en-US in win64-devedition directory ([Treeherder job](https://treeherder.mozilla.org/#/jobs?repo=mozilla-beta&revision=dcd1bd71910ce9dbb20aee38fa4dd36def652687&selectedTaskRun=JErgjPZ8QqiwMxG91lnm8g))"
+    },
+    "tags": {
+	"kind": "release-beetmover-signed-langpacks",
+	"label": "release-beetmover-signed-langpacks-win64-devedition/opt",
+	"retrigger": "false",
+	"createdForUser": "ryanvm@gmail.com"
+    }
+}

--- a/beetmoverscript/tests/test_integration.py
+++ b/beetmoverscript/tests/test_integration.py
@@ -16,33 +16,32 @@ def get_test_task(task_name):
     return load_json(f"tests/task_examples/{task_name}.json")
 
 
-_CONFIG_MAP = {
-    "android-components": {
-        "taskcluster_scope_prefix": "project:mobile:android-components:releng:beetmover:",
-        "bucket_config_key": "maven-nightly-staging",
-        "bucket_name": "nightly_components",
-    },
-    "app-services": {
-        "taskcluster_scope_prefix": "project:mozilla:app-services:releng:beetmover:",
-        "bucket_config_key": "maven-production",
-        "bucket_name": "appservices",
-    },
-    "geckoview": {"taskcluster_scope_prefix": "project:releng:beetmover:", "bucket_config_key": "maven-production", "bucket_name": "geckoview"},
-    "glean": {"taskcluster_scope_prefix": "project:mozilla:glean:releng:beetmover:", "bucket_config_key": "maven-production", "bucket_name": "telemetry"},
-    "firefox-nightly": {"taskcluster_scope_prefix": "project:releng:beetmover:", "bucket_config_key": "nightly", "bucket_name": "firefox"},
-    "firefox-langpacks": {"taskcluster_scope_prefix": "project:releng:beetmover:", "bucket_config_key": "release", "bucket_name": "devedition"},
-    "firefox-generated-screenshots": {"taskcluster_scope_prefix": "project:releng:beetmover:", "bucket_config_key": "release", "bucket_name": "firefox"},
-}
-
-
-def get_config(config_name):
+def get_config(scope_prefix):
     config = get_fake_valid_config()
-    config_props = _CONFIG_MAP[config_name]
-    config["taskcluster_scope_prefix"] = config_props["taskcluster_scope_prefix"]
-    config["bucket_config"][config_props["bucket_config_key"]] = {
-        "buckets": {config_props["bucket_name"]: "dummy"},
-        "credentials": {"id": "dummy", "key": "dummy"},
-        "url_prefix": "https://url.prefix",
+    credentials = {"id": "dummy", "key": "dummy"}
+    url_prefix = "https://url.prefix"
+    config["taskcluster_scope_prefix"] = scope_prefix
+    config["bucket_config"] = {
+        "maven-nightly-staging": {
+            "buckets": {"nightly_components": "dummy"},
+            "credentials": credentials,
+            "url_prefix": url_prefix,
+        },
+        "maven-production": {
+            "buckets": {"appservices": "dummy", "geckoview": "dummy", "telemetry": "dummy"},
+            "credentials": credentials,
+            "url_prefix": url_prefix,
+        },
+        "nightly": {
+            "buckets": {"firefox": "dummy"},
+            "credentials": credentials,
+            "url_prefix": url_prefix,
+        },
+        "release": {
+            "buckets": {"devedition": "dummy", "firefox": "dummy"},
+            "credentials": credentials,
+            "url_prefix": url_prefix,
+        },
     }
     return config
 
@@ -147,26 +146,26 @@ def prepare_scriptworker_config(path, config, task):
 
 
 @pytest.mark.parametrize(
-    "config_name, task_name, expected_number_of_artifacts",
+    "task_name, scope_prefix, expected_number_of_moved_artifacts",
     (
-        ("android-components", "android_components_nightly", 12),
-        ("geckoview", "geckoview_nightly", 16),
-        ("app-services", "application_services_release", 12),
-        ("glean", "glean_release", 20),
-        ("firefox-nightly", "firefox_desktop_nightly", 52),
-        ("firefox-langpacks", "firefox_langpacks_beta", 1),
-        ("firefox-generated-screenshots", "firefox_generated_screenshots_release", 7),
+        ("android_components_nightly", "project:mobile:android-components:releng:beetmover:", 12),
+        ("application_services_release", "project:mozilla:app-services:releng:beetmover:", 12),
+        ("geckoview_nightly", "project:releng:beetmover:", 16),
+        ("glean_release", "project:mozilla:glean:releng:beetmover:", 20),
+        ("firefox_desktop_nightly", "project:releng:beetmover:", 52),
+        ("firefox_langpacks_beta", "project:releng:beetmover:", 1),
+        ("firefox_generated_screenshots_release", "project:releng:beetmover:", 7),
     ),
 )
-def test_main_maven_nightly_candidates(config_name, task_name, expected_number_of_artifacts, tmp_path, boto3_client_mock, aiohttp_session_mock):
-    config = get_config(config_name)
+def test_main_maven_nightly_candidates(task_name, scope_prefix, expected_number_of_moved_artifacts, tmp_path, boto3_client_mock, aiohttp_session_mock):
+    config = get_config(scope_prefix)
     task = get_test_task(task_name)
     scriptworker_config = prepare_scriptworker_config(tmp_path, config, task)
 
     main(config_path=scriptworker_config)
 
     # Number of artifacts put matches expected
-    assert len(aiohttp_session_mock["put"]) == expected_number_of_artifacts
+    assert len(aiohttp_session_mock["put"]) == expected_number_of_moved_artifacts
 
     # Check paths
     expected_paths = get_paths_for_task(task)
@@ -179,4 +178,3 @@ def test_main_maven_nightly_candidates(config_name, task_name, expected_number_o
             assert put_call["data"] == b"some data"
         _, unsigned_url = put_call["url"].split("+")
         assert put_call["source"].endswith(expected_paths[unsigned_url])
-

--- a/beetmoverscript/tests/test_integration.py
+++ b/beetmoverscript/tests/test_integration.py
@@ -128,6 +128,12 @@ def prepare_scriptworker_config(path, config, task):
     work_dir.mkdir()
     config["work_dir"] = str(work_dir)
 
+    # An artifact dir is needed with a public subdir for push-to-nightly paths
+    artifact_dir = path / "artifact"
+    artifact_dir.mkdir()
+    (artifact_dir / "public").mkdir()
+    config["artifact_dir"] = str(artifact_dir)
+
     config_path = path / "config.json"
     with open(config_path, "w") as config_file:
         json.dump(config, config_file)

--- a/beetmoverscript/tests/test_integration.py
+++ b/beetmoverscript/tests/test_integration.py
@@ -29,7 +29,9 @@ _CONFIG_MAP = {
     },
     "geckoview": {"taskcluster_scope_prefix": "project:releng:beetmover:", "bucket_config_key": "maven-production", "bucket_name": "geckoview"},
     "glean": {"taskcluster_scope_prefix": "project:mozilla:glean:releng:beetmover:", "bucket_config_key": "maven-production", "bucket_name": "telemetry"},
-    "nightly": {"taskcluster_scope_prefix": "project:releng:beetmover:", "bucket_config_key": "nightly", "bucket_name": "firefox"},
+    "firefox-nightly": {"taskcluster_scope_prefix": "project:releng:beetmover:", "bucket_config_key": "nightly", "bucket_name": "firefox"},
+    "firefox-langpacks": {"taskcluster_scope_prefix": "project:releng:beetmover:", "bucket_config_key": "release", "bucket_name": "devedition"},
+    "firefox-generated-screenshots": {"taskcluster_scope_prefix": "project:releng:beetmover:", "bucket_config_key": "release", "bucket_name": "firefox"},
 }
 
 
@@ -171,7 +173,11 @@ def test_main_push_to_maven(config_name, task_name, expected_number_of_artifacts
 
 @pytest.mark.parametrize(
     "config_name, task_name, expected_number_of_artifacts",
-    (("nightly", "firefox_desktop_nightly", 52),),
+    (
+        ("firefox-nightly", "firefox_desktop_nightly", 52),
+        ("firefox-langpacks", "firefox_langpacks_beta", 1),
+        ("firefox-generated-screenshots", "firefox_generated_screenshots_release", 7),
+    ),
 )
 def test_main_push_to_nightly(config_name, task_name, expected_number_of_artifacts, tmp_path, boto3_client_mock, aiohttp_session_mock):
     config = get_config(config_name)

--- a/beetmoverscript/tests/test_integration.py
+++ b/beetmoverscript/tests/test_integration.py
@@ -153,39 +153,12 @@ def prepare_scriptworker_config(path, config, task):
         ("geckoview", "geckoview_nightly", 16),
         ("app-services", "application_services_release", 12),
         ("glean", "glean_release", 20),
-    ),
-)
-def test_main_push_to_maven(config_name, task_name, expected_number_of_artifacts, tmp_path, boto3_client_mock, aiohttp_session_mock):
-    config = get_config(config_name)
-    task = get_test_task(task_name)
-    scriptworker_config = prepare_scriptworker_config(tmp_path, config, task)
-
-    main(config_path=scriptworker_config)
-
-    # Number of artifacts put matches expected
-    assert len(aiohttp_session_mock["put"]) == expected_number_of_artifacts
-
-    # Check paths
-    expected_paths = get_paths_for_task(task)
-    # Check that the destinations match exactly, and that they have been through signing
-    expected_signed_paths = set(f"presigned_url+{dest}" for dest in expected_paths)
-    assert expected_signed_paths == set(put_call["url"] for put_call in aiohttp_session_mock["put"])
-    # Check that the source matches expected for every destination
-    for put_call in aiohttp_session_mock["put"]:
-        assert put_call["data"] == b"some data"
-        _, unsigned_url = put_call["url"].split("+")
-        assert put_call["source"].endswith(expected_paths[unsigned_url])
-
-
-@pytest.mark.parametrize(
-    "config_name, task_name, expected_number_of_artifacts",
-    (
         ("firefox-nightly", "firefox_desktop_nightly", 52),
         ("firefox-langpacks", "firefox_langpacks_beta", 1),
         ("firefox-generated-screenshots", "firefox_generated_screenshots_release", 7),
     ),
 )
-def test_main_push_to_nightly(config_name, task_name, expected_number_of_artifacts, tmp_path, boto3_client_mock, aiohttp_session_mock):
+def test_main_maven_nightly_candidates(config_name, task_name, expected_number_of_artifacts, tmp_path, boto3_client_mock, aiohttp_session_mock):
     config = get_config(config_name)
     task = get_test_task(task_name)
     scriptworker_config = prepare_scriptworker_config(tmp_path, config, task)
@@ -206,3 +179,4 @@ def test_main_push_to_nightly(config_name, task_name, expected_number_of_artifac
             assert put_call["data"] == b"some data"
         _, unsigned_url = put_call["url"].split("+")
         assert put_call["source"].endswith(expected_paths[unsigned_url])
+


### PR DESCRIPTION
Continuation of #287. This PR covers cases that trigger push-to-nightly and push-to-candidates actions.