### PR TITLE
Add macOS aarch64 build target

### DIFF
--- a/balrogscript/src/balrogscript/submitter/release.py
+++ b/balrogscript/src/balrogscript/submitter/release.py
@@ -64,11 +64,9 @@ update_platform_map = {
     "linux64": ["Linux_x86_64-gcc3"],
     "linux64-asan-reporter": ["Linux_x86_64-gcc3-asan"],
     "macosx64": [
-        "Darwin_x86_64-gcc3-u-i386-x86_64",  # The main platofrm
+        "Darwin_x86_64-gcc3-u-i386-x86_64",
         "Darwin_x86-gcc3-u-i386-x86_64",
-        # We don't ship builds with these build targets, but some users
-        # modify their builds in a way that has them report like these.
-        # See bug 1071576 for details.
+        "Darwin_aarch64-gcc3",
         "Darwin_x86-gcc3",
         "Darwin_x86_64-gcc3",
     ],


### PR DESCRIPTION
This should get aarch64 macOS updates working - it'll cause us to add an alias to balrog releases for the Darwin_aarch64-gcc3 build target.