### PR TITLE
Bug 1635488 - part 9 and 10: Fix git branch that cannot be checked out

### DIFF
--- a/treescript/src/treescript/git.py
+++ b/treescript/src/treescript/git.py
@@ -44,9 +44,10 @@ async def checkout_repo(config, task, repo_path):
         # create a new branch and manually set the upstream branch
         log.info('Checking out branch "{}"'.format(branch))
         remote_branches = repo.remotes.origin.fetch()
+        remote_branches_names = [fetch_info.name for fetch_info in remote_branches]
         remote_branch = get_single_item_from_sequence(
-            remote_branches,
-            condition=lambda fetch_info: fetch_info.name == "origin/{}".format(branch),
+            remote_branches_names,
+            condition=lambda remote_branch_name: remote_branch_name == "origin/{}".format(branch),
             ErrorClass=TaskVerificationError,
             no_item_error_message="Branch does not exist on remote repo",
             too_many_item_error_message="Too many branches with that name",

--- a/treescript/src/treescript/task.py
+++ b/treescript/src/treescript/task.py
@@ -83,11 +83,14 @@ def get_short_source_repo(task):
     return parts[-1]
 
 
+_GIT_REF_HEADS = "refs/heads/"
+
+
 # get_branch {{{1
 def get_branch(task, default=None):
     """Get the optional branch from the task payload.
 
-    This is largely for relbranch support in mercurial.
+    This is to support relbranch in mercurial and regular git branches
 
     Args:
         task (dict): the running task
@@ -97,7 +100,12 @@ def get_branch(task, default=None):
         str: the branch specified in the task
 
     """
-    return task.get("payload", {}).get("branch", default)
+    branch = task.get("payload", {}).get("branch", default)
+    if branch and branch.startswith(_GIT_REF_HEADS):
+        # fmt: off
+        branch = branch[len(_GIT_REF_HEADS):]   # Black and flake8 don't agree on this line
+        # fmt: on
+    return branch
 
 
 # get_tag_info {{{1

--- a/treescript/tests/test_git.py
+++ b/treescript/tests/test_git.py
@@ -68,7 +68,7 @@ async def test_checkout_repo(config, task, mocker, repo_subdir, branch, must_clo
         RepoClassMock.assert_called_once_with(repo_path)
 
     if must_checkout_branch:
-        repo_mock.create_head.assert_called_once_with(branch, _FetchInfo("origin/some-branch"))
+        repo_mock.create_head.assert_called_once_with(branch, "origin/some-branch")
         production_branch.checkout.assert_called_once_with()
     else:
         repo_mock.create_head.assert_not_called()

--- a/treescript/tests/test_task.py
+++ b/treescript/tests/test_task.py
@@ -145,11 +145,18 @@ def test_get_payload_source_repo(task_defn, source_repo):
     assert source_repo == ttask.get_source_repo(task_defn)
 
 
-@pytest.mark.parametrize("branch", ("foo", None))
-def test_get_branch(task_defn, branch):
+@pytest.mark.parametrize(
+    "branch, expected_result",
+    (
+        ("foo", "foo"),
+        ("refs/heads/foo", "foo"),
+        (None, None),
+    ),
+)
+def test_get_branch(task_defn, branch, expected_result):
     if branch:
         task_defn["payload"]["branch"] = branch
-    assert ttask.get_branch(task_defn) == branch
+    assert ttask.get_branch(task_defn) == expected_result
 
 
 @pytest.mark.parametrize("config", ({}, {"dummy": 1}))


### PR DESCRIPTION
Fixes this error and this unhelpful message: 

```
2020-11-20 16:10:24,603 - treescript.git - INFO - Checking out branch "refs/heads/releases/v84.0.0"
2020-11-20 16:10:24,605 - git.cmd - DEBUG - Popen(['git', 'fetch', '-v', 'origin'], cwd=/app/workdir/src, universal_newlines=True, shell=None, istream=None)
2020-11-20 16:10:24,959 - scriptworker_client.client - ERROR - Failed to run async_main
Traceback (most recent call last):
  File "/app/lib/python3.8/site-packages/scriptworker_client/client.py", line 182, in _handle_asyncio_loop
    await async_main(config, task)
  File "/app/lib/python3.8/site-packages/treescript/script.py", line 105, in async_main
    await retry_async(do_actions, args=(config, task, actions_to_perform, repo_path), retry_exceptions=(CheckoutError, PushError))
  File "/app/lib/python3.8/site-packages/scriptworker_client/aio.py", line 322, in retry_async
    return await func(*args, **kwargs)
  File "/app/lib/python3.8/site-packages/treescript/script.py", line 63, in do_actions
    await vcs.checkout_repo(config, task, repo_path)
  File "/app/lib/python3.8/site-packages/treescript/git.py", line 47, in checkout_repo
    remote_branch = get_single_item_from_sequence(
  File "/app/lib/python3.8/site-packages/scriptworker_client/utils.py", line 566, in get_single_item_from_sequence
    raise ErrorClass(error_message)
treescript.exceptions.TaskVerificationError: Branch does not exist on remote repo. Given: [<git.remote.FetchInfo object at 0x7f27a077f090>, <git.remote.FetchInfo object at 0x7f27a077f130>, <git.remote.FetchInfo object at 0x7f27a077f220>, <git.remote.FetchInfo object at 0x7f27a077f2c0>, <git.remote.FetchInfo object at 0x7f27a077f360>, <git.remote.FetchInfo object at 0x7f27a077f400>, <git.remote.FetchInfo object at 0x7f27a077f450>, <git.remote.FetchInfo object at 0x7f27a077f4f0>, <git.remote.FetchInfo object at 0x7f27a077f590>, <git.remote.FetchInfo object at 0x7f27a077f630>, <git.remote.FetchInfo object at 0x7f27a077f6d0>, <git.remote.FetchInfo object at 0x7f27a077f770>, <git.remote.FetchInfo object at 0x7f27a077f810>, <git.remote.FetchInfo object at 0x7f27a077f8b0>, <git.remote.FetchInfo object at 0x7f27a077f9a0>, <git.remote.FetchInfo object at 0x7f27a077f9f0>, <git.remote.FetchInfo object at 0x7f27a077fa90>, <git.remote.FetchInfo object at 0x7f27a077fb30>, <git.remote.FetchInfo object at 0x7f27a077fc20>, <git.remote.FetchInfo object at 0x7f27a077fd10>]
exit code: 3
```

https://firefox-ci-tc.services.mozilla.com/tasks/I7G0P52NR8-tf7N5GHDo4Q/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FI7G0P52NR8-tf7N5GHDo4Q%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log#L70