### PR TITLE
Bug 1635488 - part 11: Do not use the `branch@{u}` syntax

### DIFF
--- a/treescript/src/treescript/git.py
+++ b/treescript/src/treescript/git.py
@@ -47,7 +47,7 @@ async def checkout_repo(config, task, repo_path):
         remote_branches_names = [fetch_info.name for fetch_info in remote_branches]
         remote_branch = get_single_item_from_sequence(
             remote_branches_names,
-            condition=lambda remote_branch_name: remote_branch_name == "origin/{}".format(branch),
+            condition=lambda remote_branch_name: remote_branch_name == _get_upstream_branch_name(branch),
             ErrorClass=TaskVerificationError,
             no_item_error_message="Branch does not exist on remote repo",
             too_many_item_error_message="Too many branches with that name",
@@ -132,7 +132,7 @@ async def strip_outgoing(config, task, repo_path):
 
 
 def _get_upstream_branch_name(branch):
-    return "{}@{{u}}".format(branch)  # E.g.: main@{u}
+    return "origin/{}".format(branch)
 
 
 async def commit(config, repo_path, commit_msg):

--- a/treescript/tests/test_git.py
+++ b/treescript/tests/test_git.py
@@ -112,7 +112,7 @@ async def test_log_outgoing(config, task, mocker, output):
     number_of_changesets = await git.log_outgoing(config, task, config["work_dir"])
 
     assert number_of_changesets == 2
-    repo_mock.iter_commits.assert_called_once_with("master@{u}..master")
+    repo_mock.iter_commits.assert_called_once_with("origin/master..master")
     repo_mock.git.diff.assert_called_once_with("master")
     if output:
         with open(os.path.join(config["artifact_dir"], "public", "logs", "outgoing.diff"), "r") as fh:
@@ -127,7 +127,7 @@ async def test_strip_outgoing(config, task, mocker):
     mocker.patch.object(git, "Repo", RepoClassMock)
 
     await git.strip_outgoing(config, task, config["work_dir"])
-    repo_mock.head.reset.assert_called_once_with(commit="master@{u}", working_tree=True)
+    repo_mock.head.reset.assert_called_once_with(commit="origin/master", working_tree=True)
     repo_mock.git.clean.assert_called_once_with("-fdx")
 
 


### PR DESCRIPTION
`master@{u}` was working in staging, but `releases/v84.0.0` is busted in prod:

```
2020-11-20 17:14:07,154 - git.cmd - DEBUG - Popen(['git', 'rev-list', 'releases/v84.0.0@{u}..releases/v84.0.0', '--'], cwd=/app/workdir/src, universal_newlines=False, shell=None, istream=None)
2020-11-20 17:14:07,158 - git.cmd - DEBUG - AutoInterrupt wait stderr: b"fatal: no upstream configured for branch 'releases/v84.0.0'\n"
Traceback (most recent call last):
  File "/app/bin/treescript", line 8, in <module>
    sys.exit(main())
  File "/app/lib/python3.8/site-packages/treescript/script.py", line 132, in main
    return sync_main(async_main, default_config=get_default_config())
  File "/app/lib/python3.8/site-packages/scriptworker_client/client.py", line 127, in sync_main
    loop.run_until_complete(_handle_asyncio_loop(async_main, config, task))
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/app/lib/python3.8/site-packages/scriptworker_client/client.py", line 182, in _handle_asyncio_loop
    await async_main(config, task)
  File "/app/lib/python3.8/site-packages/treescript/script.py", line 105, in async_main
    await retry_async(do_actions, args=(config, task, actions_to_perform, repo_path), retry_exceptions=(CheckoutError, PushError))
  File "/app/lib/python3.8/site-packages/scriptworker_client/aio.py", line 322, in retry_async
    return await func(*args, **kwargs)
  File "/app/lib/python3.8/site-packages/treescript/script.py", line 79, in do_actions
    num_outgoing = await vcs.log_outgoing(config, task, repo_path)
  File "/app/lib/python3.8/site-packages/treescript/git.py", line 101, in log_outgoing
    num_changesets = len(list(repo.iter_commits(upstream_to_local_branch_interval)))
  File "/app/lib/python3.8/site-packages/git/objects/commit.py", line 277, in _iter_from_process_or_stream
    finalize_process(proc_or_stream)
  File "/app/lib/python3.8/site-packages/git/util.py", line 329, in finalize_process
    proc.wait(**kwargs)
  File "/app/lib/python3.8/site-packages/git/cmd.py", line 408, in wait
    raise GitCommandError(self.args, status, errstr)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git rev-list releases/v84.0.0@{u}..releases/v84.0.0 --
  stderr: 'fatal: no upstream configured for branch 'releases/v84.0.0'
'
exit code: 1
```

https://firefox-ci-tc.services.mozilla.com/tasks/I7G0P52NR8-tf7N5GHDo4Q/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FI7G0P52NR8-tf7N5GHDo4Q%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log#L70

Let's switch back to the old `origin/{branch}`