### PR TITLE
Bug 1635488 - part 12: Set upstream branch at push time

### DIFF
--- a/treescript/src/treescript/git.py
+++ b/treescript/src/treescript/git.py
@@ -178,7 +178,7 @@ async def push(config, task, repo_path, target_repo):
     log.debug("Push using ssh command: {}".format(git_ssh_cmd))
     with repo.git.custom_environment(GIT_SSH_COMMAND=git_ssh_cmd):
         log.info("Pushing local changes to {}".format(target_repo_ssh))
-        push_results = repo.remote().push(verbose=True)
+        push_results = repo.remote().push(verbose=True, set_upstream="origin")
 
     try:
         _check_if_push_successful(push_results)

--- a/treescript/tests/test_git.py
+++ b/treescript/tests/test_git.py
@@ -179,7 +179,7 @@ async def test_push(config, task, mocker, tmpdir, ssh_key_file, push_return, exp
     with expectation:
         await git.push(config, task, tmpdir, "https://github.com/some-user/some-repo")
         remote_mock.set_url.assert_called_once_with("git@github.com:some-user/some-repo.git", push=True)
-        remote_mock.push.assert_called_once_with(verbose=True)
+        remote_mock.push.assert_called_once_with(verbose=True, set_upstream="origin")
         repo_mock.git.custom_environment.assert_called_once_with(GIT_SSH_COMMAND=expected_ssh_command)
 
 


### PR DESCRIPTION
Fixes

```
2020-11-20 17:53:31,299 - git.cmd - DEBUG - Popen(['git', 'push', '--porcelain', '--verbose', 'origin'], cwd=/app/workdir/src, universal_newlines=True, shell=None, istream=None)
2020-11-20 17:53:31,303 - git.cmd - DEBUG - AutoInterrupt wait stderr: b'fatal: The current branch releases/v84.0.0 has no upstream branch.\nTo push the current branch and set the remote as upstream, use\n\n    git push --set-upstream origin releases/v84.0.0\n'
Traceback (most recent call last):
  File "/app/bin/treescript", line 8, in <module>
    sys.exit(main())
  File "/app/lib/python3.8/site-packages/treescript/script.py", line 132, in main
    return sync_main(async_main, default_config=get_default_config())
  File "/app/lib/python3.8/site-packages/scriptworker_client/client.py", line 127, in sync_main
    loop.run_until_complete(_handle_asyncio_loop(async_main, config, task))
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/app/lib/python3.8/site-packages/scriptworker_client/client.py", line 182, in _handle_asyncio_loop
    await async_main(config, task)
  File "/app/lib/python3.8/site-packages/treescript/script.py", line 105, in async_main
    await retry_async(do_actions, args=(config, task, actions_to_perform, repo_path), retry_exceptions=(CheckoutError, PushError))
  File "/app/lib/python3.8/site-packages/scriptworker_client/aio.py", line 322, in retry_async
    return await func(*args, **kwargs)
  File "/app/lib/python3.8/site-packages/treescript/script.py", line 84, in do_actions
    await vcs.push(config, task, repo_path, target_repo=get_source_repo(task))
  File "/app/lib/python3.8/site-packages/treescript/git.py", line 181, in push
    push_results = repo.remote().push(verbose=True)
  File "/app/lib/python3.8/site-packages/git/remote.py", line 849, in push
    return self._get_push_info(proc, progress)
  File "/app/lib/python3.8/site-packages/git/remote.py", line 736, in _get_push_info
    proc.wait(stderr=stderr_text)
  File "/app/lib/python3.8/site-packages/git/cmd.py", line 408, in wait
    raise GitCommandError(self.args, status, errstr)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git push --porcelain --verbose origin
  stderr: 'fatal: The current branch releases/v84.0.0 has no upstream branch.
To push the current branch and set the remote as upstream, use
    git push --set-upstream origin releases/v84.0.0
'
```

https://firefox-ci-tc.services.mozilla.com/tasks/I7G0P52NR8-tf7N5GHDo4Q/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FI7G0P52NR8-tf7N5GHDo4Q%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log#L70

`set_upstream` is allowed per https://github.com/gitpython-developers/GitPython/blob/0c6e67013fd22840d6cd6cb1a22fcf52eecab530/git/remote.py#L837 