### PR TITLE
Bug 1635488 - part 13: Fix set-upstream flag

### DIFF
--- a/treescript/src/treescript/git.py
+++ b/treescript/src/treescript/git.py
@@ -178,7 +178,7 @@ async def push(config, task, repo_path, target_repo):
     log.debug("Push using ssh command: {}".format(git_ssh_cmd))
     with repo.git.custom_environment(GIT_SSH_COMMAND=git_ssh_cmd):
         log.info("Pushing local changes to {}".format(target_repo_ssh))
-        push_results = repo.remote().push(verbose=True, set_upstream="origin")
+        push_results = repo.remote().push(verbose=True, set_upstream=True)
 
     try:
         _check_if_push_successful(push_results)

--- a/treescript/tests/test_git.py
+++ b/treescript/tests/test_git.py
@@ -179,7 +179,7 @@ async def test_push(config, task, mocker, tmpdir, ssh_key_file, push_return, exp
     with expectation:
         await git.push(config, task, tmpdir, "https://github.com/some-user/some-repo")
         remote_mock.set_url.assert_called_once_with("git@github.com:some-user/some-repo.git", push=True)
-        remote_mock.push.assert_called_once_with(verbose=True, set_upstream="origin")
+        remote_mock.push.assert_called_once_with(verbose=True, set_upstream=True)
         repo_mock.git.custom_environment.assert_called_once_with(GIT_SSH_COMMAND=expected_ssh_command)
 
 


### PR DESCRIPTION
#299 wasn't the right fix. It triggered that error: 

```
2020-11-20 18:42:38,666 - treescript.git - INFO - Pushing local changes to git@github.com:mozilla-mobile/fenix.git
2020-11-20 18:42:38,667 - git.cmd - DEBUG - Popen(['git', 'push', '--porcelain', '--set-upstream=origin', '--verbose', 'origin'], cwd=/app/workdir/src, universal_newlines=True, shell=None, istream=None)
2020-11-20 18:42:38,673 - git.cmd - DEBUG - AutoInterrupt wait stderr: b"error: option `set-upstream' takes no value"
Traceback (most recent call last):
  File "/app/bin/treescript", line 8, in <module>
    sys.exit(main())
  File "/app/lib/python3.8/site-packages/treescript/script.py", line 132, in main
    return sync_main(async_main, default_config=get_default_config())
  File "/app/lib/python3.8/site-packages/scriptworker_client/client.py", line 127, in sync_main
    loop.run_until_complete(_handle_asyncio_loop(async_main, config, task))
  File "/usr/local/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/app/lib/python3.8/site-packages/scriptworker_client/client.py", line 182, in _handle_asyncio_loop
    await async_main(config, task)
  File "/app/lib/python3.8/site-packages/treescript/script.py", line 105, in async_main
    await retry_async(do_actions, args=(config, task, actions_to_perform, repo_path), retry_exceptions=(CheckoutError, PushError))
  File "/app/lib/python3.8/site-packages/scriptworker_client/aio.py", line 322, in retry_async
    return await func(*args, **kwargs)
  File "/app/lib/python3.8/site-packages/treescript/script.py", line 84, in do_actions
    await vcs.push(config, task, repo_path, target_repo=get_source_repo(task))
  File "/app/lib/python3.8/site-packages/treescript/git.py", line 181, in push
    push_results = repo.remote().push(verbose=True, set_upstream="origin")
  File "/app/lib/python3.8/site-packages/git/remote.py", line 849, in push
    return self._get_push_info(proc, progress)
  File "/app/lib/python3.8/site-packages/git/remote.py", line 736, in _get_push_info
    proc.wait(stderr=stderr_text)
  File "/app/lib/python3.8/site-packages/git/cmd.py", line 408, in wait
    raise GitCommandError(self.args, status, errstr)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(129)
  cmdline: git push --porcelain --set-upstream=origin --verbose origin
  stderr: 'error: option `set-upstream' takes no value'
exit code: 1
```


https://firefox-ci-tc.services.mozilla.com/tasks/I7G0P52NR8-tf7N5GHDo4Q/runs/3/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FI7G0P52NR8-tf7N5GHDo4Q%2Fruns%2F3%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log#L103