### PR TITLE
Bug 1635488 - part 14: Fix branch parameter

### DIFF
--- a/treescript/src/treescript/git.py
+++ b/treescript/src/treescript/git.py
@@ -176,9 +176,10 @@ async def push(config, task, repo_path, target_repo):
     target_repo_ssh = extract_github_repo_ssh_url(target_repo)
     repo.remote().set_url(target_repo_ssh, push=True)
     log.debug("Push using ssh command: {}".format(git_ssh_cmd))
+    branch = get_branch(task, "master")
     with repo.git.custom_environment(GIT_SSH_COMMAND=git_ssh_cmd):
         log.info("Pushing local changes to {}".format(target_repo_ssh))
-        push_results = repo.remote().push(verbose=True, set_upstream=True)
+        push_results = repo.remote().push(branch, verbose=True, set_upstream=True)
 
     try:
         _check_if_push_successful(push_results)

--- a/treescript/tests/test_git.py
+++ b/treescript/tests/test_git.py
@@ -179,7 +179,7 @@ async def test_push(config, task, mocker, tmpdir, ssh_key_file, push_return, exp
     with expectation:
         await git.push(config, task, tmpdir, "https://github.com/some-user/some-repo")
         remote_mock.set_url.assert_called_once_with("git@github.com:some-user/some-repo.git", push=True)
-        remote_mock.push.assert_called_once_with(verbose=True, set_upstream=True)
+        remote_mock.push.assert_called_once_with("master", verbose=True, set_upstream=True)
         repo_mock.git.custom_environment.assert_called_once_with(GIT_SSH_COMMAND=expected_ssh_command)
 
 


### PR DESCRIPTION
I ended up debugging that stuff in prod, but I now can tell it works!

```
2020-12-01 11:02:21,379 - git.cmd - DEBUG - Popen(['git', 'push', '--porcelain', '--set-upstream', '--verbose', 'origin', 'relbot/AC-67.0.6'], cwd=/app/workdir/src, universal_newlines=True, shell=None, istream=None)
2020-12-01 11:02:25,596 - treescript.git - INFO - Push done succesfully!
2020-12-01 11:02:25,598 - treescript.git - INFO - Resetting repo state to match upstream's...
2020-12-01 11:02:25,598 - git.cmd - DEBUG - Popen(['git', 'reset', '--hard', 'origin/relbot/AC-67.0.6', '--'], cwd=/app/workdir/src, universal_newlines=False, shell=None, istream=None)
2020-12-01 11:02:25,623 - git.cmd - DEBUG - Popen(['git', 'clean', '-fdx'], cwd=/app/workdir/src, universal_newlines=False, shell=None, istream=None)
2020-12-01 11:02:25,637 - treescript.git - INFO - Repo state reset.
2020-12-01 11:02:25,637 - treescript.script - INFO - Done!
exit code: 0
```


https://firefox-ci-tc.services.mozilla.com/tasks/eI8dFWdETrW-vYSu2SMUqA/runs/1/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FeI8dFWdETrW-vYSu2SMUqA%2Fruns%2F1%2Fartifacts%2Fpublic%2Flogs%2Flive_backing.log 


The branch was wrong, but it's because of shipit. I'm going to work on this. 