### PR TITLE
reland zipfile_cmd change from #302

### DIFF
--- a/iscript/src/iscript/constants.py
+++ b/iscript/src/iscript/constants.py
@@ -12,11 +12,13 @@ MAC_PRODUCT_CONFIG = {
         ),
         "sign_dirs": ("MacOS", "Library"),
         "skip_dirs": tuple(),
+        "zipfile_cmd": "zip",
     },
     "mozillavpn": {
         "designated_requirements": """=designated => certificate leaf[subject.OU] = "%(subject_ou)s" """,
         "sign_dirs": ("MacOS", "Frameworks"),
         "skip_dirs": ("MozillaVPNLoginItem.app",),
+        "zipfile_cmd": "ditto",
     },
 }
 

--- a/iscript/src/iscript/mac.py
+++ b/iscript/src/iscript/mac.py
@@ -516,7 +516,12 @@ async def create_one_notarization_zipfile(work_dir, all_paths, sign_config, path
         app.check_required_attrs(required_attrs)
         for path_attr in path_attrs:
             app_paths.append(os.path.relpath(getattr(app, path_attr), work_dir))
-    await run_command(["ditto", "-c", "-k", "--sequesterRsrc", "--keepParent", "0", zip_path], cwd=work_dir, exception=IScriptError)
+    if sign_config["zipfile_cmd"] == "zip":
+        await run_command(["zip", "-r", zip_path, *app_paths], cwd=work_dir, exception=IScriptError)
+    elif sign_config["zipfile_cmd"] == "ditto":
+        await run_command(["ditto", "-c", "-k", "--sequesterRsrc", "--keepParent", "0", zip_path], cwd=work_dir, exception=IScriptError)
+    else:
+        raise IScriptError(f"Unknown zipfile_cmd {sign_config['zipfile_cmd']}!")
     return zip_path
 
 

--- a/iscript/tests/test_mac.py
+++ b/iscript/tests/test_mac.py
@@ -350,18 +350,21 @@ async def test_create_all_notarization_zipfiles(mocker, tmpdir, raises):
 
 
 # create_one_notarization_zipfile {{{1
-@pytest.mark.parametrize("raises", ((True, "zip"), (False, "zip"), (False, "ditto")))
+@pytest.mark.parametrize("raises, zipfile_cmd", ((True, "zip"), (False, "zip"), (False, "ditto"), (True, "unknown_zipfile_cmd")))
 @pytest.mark.asyncio
-async def test_create_one_notarization_zipfile(mocker, tmpdir, raises):
+async def test_create_one_notarization_zipfile(mocker, tmpdir, raises, zipfile_cmd):
     """``create_one_notarization_zipfile`` calls the expected cmdline, and raises on
     failure.
 
     """
     work_dir = str(tmpdir)
-    sign_config = {}
+    sign_config = {"zipfile_cmd": zipfile_cmd}
 
     async def fake_run_command(*args, **kwargs):
-        assert args[0] == ["ditto", "-c", "-k", "--sequesterRsrc", "--keepParent", "0", os.path.join(work_dir, "notarization.zip")]
+        if zipfile_cmd == "zip":
+            assert args[0] == ["zip", "-r", os.path.join(work_dir, "notarization.zip"), "0/0.app", "0/0.pkg", "1/1.app", "1/1.pkg", "2/2.app", "2/2.pkg"]
+        elif zipfile_cmd == "ditto":
+            assert args[0] == ["ditto", "-c", "-k", "--sequesterRsrc", "--keepParent", "0", os.path.join(work_dir, "notarization.zip")]
         if raises:
             raise IScriptError("foo")
 


### PR DESCRIPTION
Using ditto appears to break l10n notarization.

I may end up crash-landing this as a bustage fix for today's nightlies.