### PR TITLE
RELENG-167: Add support for signing system extensions in iscript

### DIFF
--- a/iscript/src/iscript/constants.py
+++ b/iscript/src/iscript/constants.py
@@ -13,12 +13,14 @@ MAC_PRODUCT_CONFIG = {
         "sign_dirs": ("MacOS", "Library"),
         "skip_dirs": tuple(),
         "zipfile_cmd": "zip",
+        "create_pkg": True,
     },
     "mozillavpn": {
         "designated_requirements": """=designated => certificate leaf[subject.OU] = "%(subject_ou)s" """,
         "sign_dirs": ("MacOS", "Frameworks"),
         "skip_dirs": ("MozillaVPNLoginItem.app",),
         "zipfile_cmd": "ditto",
+        "create_pkg": False,
     },
 }
 

--- a/iscript/src/iscript/mac.py
+++ b/iscript/src/iscript/mac.py
@@ -377,7 +377,7 @@ def get_app_dir(parent_dir):
         UnknownAppDir: if there is no single app dir
 
     """
-    apps = glob("{}/*.app*".format(parent_dir)) + glob("{}/*/*.app*".format(parent_dir))
+    apps = glob("{}/*.app*".format(parent_dir)) + glob("{}/*/*.app*".format(parent_dir)) + glob("{}/*.systemextension*".format(parent_dir))
     if len(apps) != 1:
         raise UnknownAppDir("Can't find a single .app in {}: {}".format(parent_dir, apps))
     return apps[0]
@@ -926,7 +926,7 @@ async def create_pkg_files(config, sign_config, all_paths):
     for app in all_paths:
         # call set_app_path_and_name because we may not have called sign_app() earlier
         set_app_path_and_name(app)
-        app.pkg_path = app.app_path.replace(".appex", ".pkg").replace(".app", ".pkg")
+        app.pkg_path = app.app_path.replace(".appex", ".pkg").replace(".app", ".pkg").replace(".systemextension", ".pkg")
         app.pkg_name = os.path.basename(app.pkg_path)
         pkg_opts = []
         if sign_config.get("pkg_cert_id"):

--- a/iscript/tests/test_mac.py
+++ b/iscript/tests/test_mac.py
@@ -943,6 +943,7 @@ async def test_sign_and_pkg_behavior(mocker, tmpdir, use_langpack):
                 "apple_notarization_password": "apple_password",
                 "apple_asc_provider": "apple_asc_provider",
                 "notarization_poll_timeout": 2,
+                "create_pkg": True,
             }
         },
     }
@@ -1002,6 +1003,7 @@ async def test_notarize_behavior(mocker, tmpdir, notarize_type, use_langpack):
                 "apple_notarization_password": "apple_password",
                 "apple_asc_provider": "apple_asc_provider",
                 "notarization_poll_timeout": 2,
+                "create_pkg": True,
             }
         },
     }
@@ -1059,6 +1061,7 @@ async def test_notarize_1_behavior(mocker, tmpdir, notarize_type, use_langpack):
                 "apple_notarization_password": "apple_password",
                 "apple_asc_provider": "apple_asc_provider",
                 "notarization_poll_timeout": 2,
+                "create_pkg": True,
             }
         },
     }
@@ -1097,6 +1100,7 @@ async def test_notarize_3_behavior(mocker, tmpdir):
     config = {
         "artifact_dir": artifact_dir,
         "work_dir": work_dir,
+        "taskcluster_scope_prefix": "project:releng:signing:",
         "mac_config": {
             "dep": {
                 "designated_requirements": "",  # put this here bc it's easier
@@ -1110,11 +1114,15 @@ async def test_notarize_3_behavior(mocker, tmpdir):
                 "apple_notarization_password": "apple_password",
                 "apple_asc_provider": "apple_asc_provider",
                 "notarization_poll_timeout": 2,
+                "create_pkg": True,
             }
         },
     }
 
     task = {
+        "scopes": [
+            "project:releng:signing:cert:dep-signing",
+        ],
         "payload": {
             "upstreamArtifacts": [
                 {
@@ -1124,7 +1132,7 @@ async def test_notarize_3_behavior(mocker, tmpdir):
                 },
                 {"taskId": "task2", "paths": ["public/build/3/target.tar.gz", "public/build/3/target.tar.gz"], "formats": []},
             ]
-        }
+        },
     }
 
     mocker.patch.object(mac, "run_command", new=noop_async)
@@ -1159,6 +1167,7 @@ async def test_geckodriver_behavior(mocker, tmpdir, use_langpack):
                 "apple_notarization_password": "apple_password",
                 "apple_asc_provider": "apple_asc_provider",
                 "notarization_poll_timeout": 2,
+                "create_pkg": True,
             }
         },
     }


### PR DESCRIPTION
This has been tested for MozillaVPN, but not for other products. It's hard to imagine how this could break Firefox though.