### PR TITLE
[RELENG-151] allow for android-components githubscript workers

### DIFF
--- a/githubscript/docker.d/worker.yml
+++ b/githubscript/docker.d/worker.yml
@@ -9,10 +9,15 @@ github_projects:
         github_token: { "$eval": "GITHUB_TOKEN_WRITE_ACCESS_PROD" }
         github_owner: mozilla-mobile
         github_repo_name: fenix
+      android-components:
+        allowed_actions: ["release"]
+        github_token: { "$eval": "GITHUB_TOKEN_WRITE_ACCESS_PROD" }
+        github_owner: mozilla-mobile
+        github_repo_name: android-components
     'COT_PRODUCT == "mobile" && ENV == "fake-prod"':
       mock:
         allowed_actions: ["release"]
         github_token: dummy
         github_owner: non-existing-owner
         github_repo_name: non-existing-repo
-taskcluster_scope_prefixes: ["project:mobile:fenix:releng:github:"]
+taskcluster_scope_prefixes: ["project:mobile:fenix:releng:github:", "project:mobile:android-components:releng:github:"]


### PR DESCRIPTION
We may want to wait for https://firefox-ci-tc.services.mozilla.com/tasks/fKCbYWfKSPa-pBmqpNh8Ow or similar task to go green. (That assumes `mobile-1-github-dev` spins up.)