### PR TITLE
Bug 1619767 - [treescript] Do not use upstream_repo on Thunderbird clones.

### DIFF
--- a/treescript/docker.d/init_worker.sh
+++ b/treescript/docker.d/init_worker.sh
@@ -33,7 +33,7 @@ case $COT_PRODUCT in
     test_var_set 'SSH_KEY'
     test_var_set 'SSH_USER'
     export TASKCLUSTER_SCOPE_PREFIX="project:comm:thunderbird:releng:${PROJECT_NAME}script:"
-    export UPSTREAM_REPO="https://hg.mozilla.org/comm-central"
+    export UPSTREAM_REPO=""
     export MERGE_DAY_CLOBBER_FILE=""
     ;;
   *)

--- a/treescript/src/treescript/mercurial.py
+++ b/treescript/src/treescript/mercurial.py
@@ -161,9 +161,10 @@ async def checkout_repo(config, task, repo_path):
     source_repo = get_source_repo(task)
     # branch default is used to pull tip of the repo at checkout time
     branch = get_branch(task, "default")
-    await run_hg_command(
-        config, "robustcheckout", source_repo, repo_path, "--sharebase", share_base, "--upstream", upstream_repo, "--branch", branch, exception=CheckoutError
-    )
+    cmd_args = [config, "robustcheckout", source_repo, repo_path, "--sharebase", share_base, "--branch", branch]
+    if upstream_repo:
+        cmd_args.extend(["--upstream", upstream_repo])
+    await run_hg_command(*cmd_args, exception=CheckoutError)
 
 
 # do_tagging {{{1


### PR DESCRIPTION
As there is no comm-unified repository with all of the various branch heads,
separate pulls are needed for the to_branch and from_branch when doing merges
on those repositories.

The separate pulls are triggered by a false value for upstream_repo, in this case
an empty string. Usually, that's set to comm-central and hg robustcheckout does
what it needs to do, but it's not a required parameter.