### PR TITLE
Don't sign some files with entitlements for MozillaVPN

### DIFF
--- a/iscript/src/iscript/constants.py
+++ b/iscript/src/iscript/constants.py
@@ -21,6 +21,7 @@ MAC_PRODUCT_CONFIG = {
         "skip_dirs": ("MozillaVPNLoginItem.app",),
         "zipfile_cmd": "ditto",
         "create_pkg": False,
+        "no_entitlements_files": ["wg", "wireguard-go"],
     },
 }
 


### PR DESCRIPTION
We discovered today that `wg` and `wireguard-go` break if they're signed with entitlements. So, we have to sign them as part of the Mozilla VPN.app signing, but the signing command has to be different.