### PR TITLE
[bug 1654250] surface -11 and -15 exit codes in run_command

### DIFF
--- a/scriptworker_client/src/scriptworker_client/client.py
+++ b/scriptworker_client/src/scriptworker_client/client.py
@@ -181,5 +181,5 @@ async def _handle_asyncio_loop(async_main, config, task):
     try:
         await async_main(config, task)
     except ClientError as exc:
-        log.exception("Failed to run async_main")
+        log.exception(f"Failed to run async_main; exiting {exc.exit_code}")
         sys.exit(exc.exit_code)

--- a/scriptworker_client/src/scriptworker_client/utils.py
+++ b/scriptworker_client/src/scriptworker_client/utils.py
@@ -182,7 +182,7 @@ async def run_command(
     env=None,
     exception=None,
     expected_exit_codes=(0,),
-    copy_exit_codes=(-11, -15, 245, 241),  # 245 == -11, 241 == -15
+    copy_exit_codes=(245, 241),  # 245 == -11, 241 == -15
     output_log_on_exception=False,
 ):
     """Run a command using ``asyncio.create_subprocess_exec``.
@@ -215,7 +215,7 @@ async def run_command(
             Defaults to ``(0, )``.
         copy_exit_codes (list, optional): the list of exit codes that we
             set ``exit_code`` to if ``exception`` is an instance of
-            ``ClientError``. Defaults to ``(-11, -15, 245, 241)``.
+            ``ClientError``. Defaults to ``(245, 241)``.
         output_log_on_exception (bool, optional): log the output log if we're
             raising an exception.
 

--- a/scriptworker_client/src/scriptworker_client/utils.py
+++ b/scriptworker_client/src/scriptworker_client/utils.py
@@ -182,7 +182,7 @@ async def run_command(
     env=None,
     exception=None,
     expected_exit_codes=(0,),
-    # https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
+    # https://stackoverflow.com/questions/18731791/determining-if-a-python-subprocess-segmentation-faults
     # Shell exit codes range from 0 to 255. Therefore 245 == -11, 241 == -15
     copy_exit_codes=(245, 241),
     output_log_on_exception=False,

--- a/scriptworker_client/src/scriptworker_client/utils.py
+++ b/scriptworker_client/src/scriptworker_client/utils.py
@@ -182,7 +182,9 @@ async def run_command(
     env=None,
     exception=None,
     expected_exit_codes=(0,),
-    copy_exit_codes=(245, 241),  # 245 == -11, 241 == -15
+    # https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html
+    # Shell exit codes range from 0 to 255. Therefore 245 == -11, 241 == -15
+    copy_exit_codes=(245, 241),
     output_log_on_exception=False,
 ):
     """Run a command using ``asyncio.create_subprocess_exec``.

--- a/scriptworker_client/tests/test_client.py
+++ b/scriptworker_client/tests/test_client.py
@@ -184,7 +184,7 @@ async def test_fail_handle_asyncio_loop(mocker):
         await client._handle_asyncio_loop(async_error, {}, {})
 
     assert excinfo.value.code == 42
-    m.exception.assert_called_once_with("Failed to run async_main")
+    m.exception.assert_called_once_with("Failed to run async_main; exiting 42")
 
 
 def test_init_config_cli(mocker, tmpdir):


### PR DESCRIPTION
I think we're hitting -11 exit codes in iscript when we restart scriptworker. Scriptworker would turn a -11 exit code into an `intermittent-task`, which would automatically retry the task. However, `run_command` turns that -11 exit code into an exit code of 1, which is `failed`.

Let's surface the -11 and -15 exit codes if they show up in `run_command`.

If we're worried about how large of a change this is, we could set the default `copy_exit_codes` to `None` and only override the `copy_exit_codes` in the iscript `run_command` calls.

Besides the unit tests, I also had a test script where I did

```python
#!/usr/bin/env python

from scriptworker_client.exceptions import TaskError

t = TaskError("foo", exit_code=-11)
print(t.exit_code)
```

which gave me -11. Setting the exit code through bash seems to translate `-11` to `245`, though.