### PR TITLE
bustage fix - balrogscript timestamp

### DIFF
--- a/balrogscript/src/balrogscript/submitter/cli.py
+++ b/balrogscript/src/balrogscript/submitter/cli.py
@@ -523,7 +523,7 @@ class ReleaseScheduler(object):
             data["rule_id"] = rule_id
             data["change_type"] = "update"
             # We receive an iso8601 datetime, but what Balrog needs is a to-the-millisecond epoch timestamp
-            data["when"] = when.timestamp * 1000
+            data["when"] = when.int_timestamp * 1000
             if backgroundRate:
                 data["backgroundRate"] = backgroundRate
 


### PR DESCRIPTION
for [arrow 1.0.x](https://github.com/arrow-py/arrow/issues/832)

Already pushed to production-balrogscript to fix thunderbird; asking for review to merge to master.