### PR TITLE
shipitscript: don't consider pushes before a version bump as shippable

### DIFF
--- a/shipitscript/tests/test_pushlog.py
+++ b/shipitscript/tests/test_pushlog.py
@@ -424,7 +424,7 @@ import shipitscript.pushlog_scan as pushlog
                     ]
                 },
             },
-            "14ac73797dd828cc30a99df36befbec79069bde4",
+            None,
         ),
         (
             "releases/mozilla-beta",


### PR DESCRIPTION
We shouldn't be building a release off a revision that pre-dates the
version number being updated after shipping the previous release, or our
new release will end up with the wrong version number.

Fixes #365