### PR TITLE
RELENG-587: add mozillaonline signing format for dep signing

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -81,7 +81,7 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_FENIX_USERNAME"},
              {"$eval": "AUTOGRAPH_FENIX_PASSWORD"},
-             ["autograph_apk"]
+             ["autograph_apk", "autograph_apk_mozillaonline"]
             ]
         project:mobile:fennec-profile-manager:releng:signing:cert:dep-signing:
           # Reuse the same Fenix key since it's a fenix-related project


### PR DESCRIPTION
Turns out we need this for staging releases (they use dep-signing workers), eg: https://firefox-ci-tc.services.mozilla.com/tasks/ceXzy5U9TAyuBaI4wR3cCw/runs/0/logs/public/logs/live_backing.log. The alternative is to change the format in `fenix_taskgraph`, but I think this is more straightforward?