### PR TITLE
Disable the k8s-image task

### DIFF
--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -11,8 +11,8 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 jobs:
-    k8s-image:
-        definition: k8s-image
+    # k8s-image:
+    #     definition: k8s-image
     python38:
         definition: python
         args:


### PR DESCRIPTION
We pinned the k8s-image to one in docker hub so the image build here is
no longer being used. We'll need to upgrade this image to kaniko and
figure out how to distribute it to cloudops-jenkins.

Commenting out the task rather than removing so we remember why we
still have all the associated Dockerfiles lying around.