### PR TITLE
Fix branch reference in msix-packaging repo

### DIFF
--- a/signingscript/docker.d/build_msix_packaging.sh
+++ b/signingscript/docker.d/build_msix_packaging.sh
@@ -4,7 +4,7 @@ set +e
 git clone https://github.com/mozilla/msix-packaging msix-packaging
 
 cd msix-packaging
-git checkout signing2
+git checkout johnmcpms/signing
 
 ./makelinux.sh --pack
 


### PR DESCRIPTION
`signing2` doesn't exist! We'll use a specific hash in the near future.