### PR TITLE
Update version-control-tools to current version (for firefoxtree).

### DIFF
--- a/treescript/Dockerfile
+++ b/treescript/Dockerfile
@@ -25,7 +25,7 @@ RUN python -m venv /app \
  && /app/configloader_venv/bin/pip install -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app \
- && hg clone -r d47591074dc0d44a0b9e0838ce790db528cbd534 https://hg.mozilla.org/hgcustom/version-control-tools /app/version-control-tools
+ && hg clone -r 0180a71f29b2f71113665cf9425fd73693d0265c https://hg.mozilla.org/hgcustom/version-control-tools /app/version-control-tools
 
 COPY treescript/src/treescript/data/hgrc /etc/mercurial/hgrc.d/treescript.rc
 COPY treescript/docker.d/extensions.rc /etc/mercurial/hgrc.d/extensions.rc


### PR DESCRIPTION
version-control-tools in the Docker image is from 2019, and the
firefoxtree extension is not aware of comm-esr91. Thunderbird does not
currently have a "unified" repository, so to perform merge-day
actions with comm-esr91 an update is needed.

An unintended side effect is that robustcheckout is also updated.