### PR TITLE
bug 1728330 - stop pushing snap to the snap store

### DIFF
--- a/pushsnapscript/src/pushsnapscript/snap_store.py
+++ b/pushsnapscript/src/pushsnapscript/snap_store.py
@@ -10,7 +10,6 @@ from snapcraft.storeapi import StoreClient
 from snapcraft.storeapi.constants import DEFAULT_SERIES
 from snapcraft.storeapi.errors import StoreReviewError
 
-from pushsnapscript import task
 from pushsnapscript.exceptions import AlreadyLatestError
 
 log = logging.getLogger(__name__)

--- a/pushsnapscript/src/pushsnapscript/snap_store.py
+++ b/pushsnapscript/src/pushsnapscript/snap_store.py
@@ -65,7 +65,7 @@ def push(context, snap_file_path, channel):
             else:
                 raise
 
-        _release_if_needed(store, channel, snap_file_path)
+        # _release_if_needed(store, channel, snap_file_path)
 
 
 @contextlib.contextmanager

--- a/pushsnapscript/src/pushsnapscript/snap_store.py
+++ b/pushsnapscript/src/pushsnapscript/snap_store.py
@@ -65,6 +65,7 @@ def push(context, snap_file_path, channel):
             else:
                 raise
 
+        # Bug 1728330: Let's not push to any channels
         # _release_if_needed(store, channel, snap_file_path)
 
 

--- a/pushsnapscript/src/pushsnapscript/snap_store.py
+++ b/pushsnapscript/src/pushsnapscript/snap_store.py
@@ -48,8 +48,10 @@ def push(context, snap_file_path, channel):
         snap_file_path (str): The full path to the snap file
         channel (str): The Snap Store channel.
     """
-    if not task.is_allowed_to_push_to_snap_store(context.config, channel=channel):
-        log.warning("Not allowed to push to Snap store. Skipping push...")
+    # Bug 1728330: Let's not push to the store.
+    # We'll disable the pushsnap task in-tree, but for 92 let's disable here.
+    if True:
+        log.warning("Skipping Snap store push...")
         # We don't raise an error because we still want green tasks on dev instances
         return
 
@@ -65,8 +67,7 @@ def push(context, snap_file_path, channel):
             else:
                 raise
 
-        # Bug 1728330: Let's not push to any channels
-        # _release_if_needed(store, channel, snap_file_path)
+        _release_if_needed(store, channel, snap_file_path)
 
 
 @contextlib.contextmanager

--- a/pushsnapscript/tests/integration/test_integration_script.py
+++ b/pushsnapscript/tests/integration/test_integration_script.py
@@ -128,5 +128,5 @@ def test_script_can_push_snaps_with_credentials(monkeypatch, channel, expected_r
                 monkeypatch.setattr(snap_store, "snapcraft_store_client", snapcraft_store_client_mock)
                 main(config_path=config_file.name)
 
-    snapcraft_store_client_mock.push.assert_called_once_with(snap_filename=snap_artifact_path)
+    snapcraft_store_client_mock.push.assert_not_called()
     store_mock.release.assert_not_called()

--- a/pushsnapscript/tests/integration/test_integration_script.py
+++ b/pushsnapscript/tests/integration/test_integration_script.py
@@ -129,4 +129,4 @@ def test_script_can_push_snaps_with_credentials(monkeypatch, channel, expected_r
                 main(config_path=config_file.name)
 
     snapcraft_store_client_mock.push.assert_called_once_with(snap_filename=snap_artifact_path)
-    store_mock.release.assert_called_once_with(snap_name="firefox", revision=expected_revision, channels=[channel])
+    store_mock.release.assert_not_called()

--- a/pushsnapscript/tests/test_snap_store.py
+++ b/pushsnapscript/tests/test_snap_store.py
@@ -47,8 +47,7 @@ def test_push(monkeypatch, channel, expected_macaroon_location, raises, exceptio
     monkeypatch.setattr(snap_store, "_release_if_needed", fake_release_if_needed)
 
     if bubbles_up_exception:
-        with pytest.raises(snap_store.StoreReviewError):
-            snap_store.push(context, "/path/to/snap", channel)
+        snap_store.push(context, "/path/to/snap", channel)
         assert next(fake_release_if_needed_count) == 0
     else:
         snap_store.push(context, "/path/to/snap", channel)

--- a/pushsnapscript/tests/test_snap_store.py
+++ b/pushsnapscript/tests/test_snap_store.py
@@ -52,7 +52,7 @@ def test_push(monkeypatch, channel, expected_macaroon_location, raises, exceptio
         assert next(fake_release_if_needed_count) == 0
     else:
         snap_store.push(context, "/path/to/snap", channel)
-        assert next(fake_release_if_needed_count) == 1
+        assert next(fake_release_if_needed_count) == 0
 
 
 def test_push_early_return_if_not_allowed(monkeypatch):


### PR DESCRIPTION
We don't want to upload to the store at all.

This PR is to disable store uploads for 92, which is already in-progress. Patches coming in bug 1728330 to remove the tasks and delete the pools.

@mkaply