### PR TITLE
[bug 1728330] reenable pushsnap for esr78

### DIFF
--- a/pushsnapscript/src/pushsnapscript/snap_store.py
+++ b/pushsnapscript/src/pushsnapscript/snap_store.py
@@ -10,6 +10,7 @@ from snapcraft.storeapi import StoreClient
 from snapcraft.storeapi.constants import DEFAULT_SERIES
 from snapcraft.storeapi.errors import StoreReviewError
 
+from pushsnapscript import task
 from pushsnapscript.exceptions import AlreadyLatestError
 
 log = logging.getLogger(__name__)
@@ -47,10 +48,8 @@ def push(context, snap_file_path, channel):
         snap_file_path (str): The full path to the snap file
         channel (str): The Snap Store channel.
     """
-    # Bug 1728330: Let's not push to the store.
-    # We'll disable the pushsnap task in-tree, but for 92 let's disable here.
-    if True:
-        log.warning("Skipping Snap store push...")
+    if not task.is_allowed_to_push_to_snap_store(context.config, channel=channel):
+        log.warning("Not allowed to push to Snap store. Skipping push...")
         # We don't raise an error because we still want green tasks on dev instances
         return
 

--- a/pushsnapscript/tests/integration/test_integration_script.py
+++ b/pushsnapscript/tests/integration/test_integration_script.py
@@ -128,5 +128,5 @@ def test_script_can_push_snaps_with_credentials(monkeypatch, channel, expected_r
                 monkeypatch.setattr(snap_store, "snapcraft_store_client", snapcraft_store_client_mock)
                 main(config_path=config_file.name)
 
-    snapcraft_store_client_mock.push.assert_not_called()
-    store_mock.release.assert_not_called()
+    snapcraft_store_client_mock.push.assert_called_once_with(snap_filename=snap_artifact_path)
+    store_mock.release.assert_called_once_with(snap_name="firefox", revision=expected_revision, channels=[channel])

--- a/pushsnapscript/tests/test_snap_store.py
+++ b/pushsnapscript/tests/test_snap_store.py
@@ -47,11 +47,12 @@ def test_push(monkeypatch, channel, expected_macaroon_location, raises, exceptio
     monkeypatch.setattr(snap_store, "_release_if_needed", fake_release_if_needed)
 
     if bubbles_up_exception:
-        snap_store.push(context, "/path/to/snap", channel)
+        with pytest.raises(snap_store.StoreReviewError):
+            snap_store.push(context, "/path/to/snap", channel)
         assert next(fake_release_if_needed_count) == 0
     else:
         snap_store.push(context, "/path/to/snap", channel)
-        assert next(fake_release_if_needed_count) == 0
+        assert next(fake_release_if_needed_count) == 1
 
 
 def test_push_early_return_if_not_allowed(monkeypatch):


### PR DESCRIPTION
We want to reenable pushsnap for esr78.
I will:
- push the gecko patch to remove the pushsnap task from all release branches except esr78,
- land+roll out this patch to reenable the pushsnap pool's ability to push to the store, and
- rerun/retrigger the pushsnap task on esr78, and/or craft a custom relpro graph to just run pushsnap.

This patch just backs out b592c765.