### PR TITLE
Update focus apps

### DIFF
--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -5,6 +5,8 @@ do_not_contact_server: { "$eval": "ENV != 'prod'" }
 taskcluster_scope_prefixes:
   $if: 'COT_PRODUCT == "mobile"'
   then:
+    - "project:mobile:focus-android:releng:googleplay:product:"
+      #TODO remove once Focus taskgraph integration is complete
     - "project:mobile:focus:releng:googleplay:product:"
     - "project:mobile:reference-browser:releng:googleplay:product:"
     - "project:mobile:fenix:releng:googleplay:product:"

--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -155,13 +155,30 @@ products:
           skip_check_same_locales: true
           skip_checks_fennec: true
           override_channel_model: "single_google_app"
-          app:
-            package_names:
-              - "org.mozilla.focus"
-              - "org.mozilla.klar"
-            service_account: "dummy"
-            credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_DEP_PATH" }
-            certificate_alias: "focus"
+          apps:
+            release:
+              package_names:
+                - "org.mozilla.focus"
+                - "org.mozilla.klar"
+              certificate_alias: 'focus'
+              google:
+                default_track: 'production'
+                service_account: 'dummy'
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_DEP_PATH" }
+            nightly:
+              package_names: ["org.mozilla.focus.nightly"]
+              certificate_alias: 'focus'
+              google:
+                default_track: 'alpha'
+                service_account: 'dummy'
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_DEP_PATH" }
+            beta:
+              package_names: ["org.mozilla.focus.beta"]
+              certificate_alias: 'focus'
+              google:
+                default_track: 'alpha'
+                service_account: 'dummy'
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_DEP_PATH" }
         - product_names: [ "firefox-tv" ]
           skip_check_multiple_locales: true
           skip_check_same_locales: true

--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -66,14 +66,30 @@ products:
           skip_check_multiple_locales: true
           skip_check_same_locales: true
           skip_checks_fennec: true
-          override_channel_model: "single_google_app"
-          app:
-            service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FOCUS" }
-            credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_PATH" }
-            package_names:
-              - 'org.mozilla.focus'
-              - 'org.mozilla.klar'
-            certificate_alias: 'focus'
+          apps:
+            release:
+              package_names:
+                - "org.mozilla.focus"
+                - "org.mozilla.klar"
+              certificate_alias: 'focus'
+              google:
+                default_track: 'alpha'
+                service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FOCUS" }
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_PATH" }
+            nightly:
+              package_names: ["org.mozilla.focus.nightly"]
+              certificate_alias: 'focus'
+              google:
+                default_track: 'alpha'
+                service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FOCUS" }
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_PATH" }
+            beta:
+              package_names: ["org.mozilla.focus.beta"]
+              certificate_alias: 'focus'
+              google:
+                default_track: 'alpha'
+                service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FOCUS" }
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_PATH" }
         - product_names: [ "reference-browser" ]
           digest_algorithm: "SHA-256"
           skip_check_multiple_locales: true
@@ -154,7 +170,6 @@ products:
           skip_check_multiple_locales: true
           skip_check_same_locales: true
           skip_checks_fennec: true
-          override_channel_model: "single_google_app"
           apps:
             release:
               package_names:
@@ -162,7 +177,7 @@ products:
                 - "org.mozilla.klar"
               certificate_alias: 'focus'
               google:
-                default_track: 'production'
+                default_track: 'alpha'
                 service_account: 'dummy'
                 credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_DEP_PATH" }
             nightly:

--- a/pushapkscript/src/pushapkscript/publish_config.py
+++ b/pushapkscript/src/pushapkscript/publish_config.py
@@ -106,8 +106,8 @@ def _get_channel_publish_config(product_config, task):
 def get_publish_config(product_config, task, scope_product):
     override_channel_model = product_config.get("override_channel_model")
     if override_channel_model == "single_google_app":
-        # Focus uses a single Google app and the "tracks" feature to represent different channels,
-        # rather than a separate app-per-channel. So, Focus is configured with "single_google_app"
+        # reference-browser uses a single Google app - with `channel` refering to the google default track -
+        # rather than a separate app-per-channel. So, reference-browser is configured with "single_google_app"
         return _get_single_google_app_publish_config(product_config, task)
 
     elif override_channel_model == "choose_google_app_with_scope":


### PR DESCRIPTION
* Switch to default of multiple apps/channels for Focus and update the scopes for focus-android. @jcristau finished setting up the draft apps in the google play store.

I also have a pr to update the channel for Focus (the old, non-taskgraph logic for releases) so this doesn't break anything.