### PR TITLE
balrogscript: don't use the prod instance for "dep"

### DIFF
--- a/balrogscript/docker.d/init_worker.sh
+++ b/balrogscript/docker.d/init_worker.sh
@@ -18,9 +18,11 @@ test_var_set 'AUTH0_CLIENT_SECRET'
 case $ENV in
   dev|fake-prod)
     export API_ROOT="https://admin-stage.balrog.nonprod.cloudops.mozgcp.net/api"
+    export STAGE_API_ROOT="https://admin-stage.balrog.nonprod.cloudops.mozgcp.net/api"
     ;;
   prod)
     export API_ROOT="https://aus4-admin.mozilla.org/api"
+    export STAGE_API_ROOT="https://admin-stage.balrog.nonprod.cloudops.mozgcp.net/api"
     ;;
   *)
     exit 1

--- a/balrogscript/docker.d/worker.yml
+++ b/balrogscript/docker.d/worker.yml
@@ -52,7 +52,7 @@ server_config:
       - 'esr-localtest'
       - 'esr-cdntest'
   dep:
-    api_root: { "$eval": "API_ROOT" }
+    api_root: { "$eval": "STAGE_API_ROOT" }
     auth0_domain: { "$eval": "AUTH0_DOMAIN"}
     auth0_client_id: { "$eval": "AUTH0_CLIENT_ID" }
     auth0_client_secret: { "$eval": "AUTH0_CLIENT_SECRET" }

--- a/balrogscript/tests/test_config.py
+++ b/balrogscript/tests/test_config.py
@@ -34,6 +34,7 @@ def test_config():
         "VERBOSE": "true",
         "TASKCLUSTER_SCOPE_PREFIX": "",
         "API_ROOT": "",
+        "STAGE_API_ROOT": "",
         "AUTH0_DOMAIN": "",
         "AUTH0_CLIENT_ID": "",
         "AUTH0_CLIENT_SECRET": "",


### PR DESCRIPTION
When a task has the balrog:server:dep scope we shouldn't talk to the
production instance, even on a production worker.