### PR TITLE
Bug 1732888 - add new mime types for beetmoverscript

### DIFF
--- a/beetmoverscript/src/beetmoverscript/constants.py
+++ b/beetmoverscript/src/beetmoverscript/constants.py
@@ -12,12 +12,15 @@ MIME_MAP = {
     ".json": "application/json",
     ".mar": "application/octet-stream",
     ".md5": "text/plain",
+    ".module": "application/json",
     ".msi": "application/x-msi",
     # Per https://docs.microsoft.com/en-us/windows/msix/app-installer/web-install-iis
     ".msix": "application/msix",
     ".pkg": "application/x-newton-compatible-pkg",
     ".pom": "application/xml",
     ".sha1": "text/plain",
+    ".sha256": "text/plain",
+    ".sha512": "text/plain",
     ".snap": "application/octet-stream",
     ".xpi": "application/x-xpinstall",
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1732727 added a new ".module" file
for geckoview, which appears to be json, as well as new checksums.