### PR TITLE
Separate Focus release apps per package

### DIFF
--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -69,10 +69,15 @@ products:
           skip_check_same_locales: true
           skip_checks_fennec: true
           apps:
-            release:
-              package_names:
-                - "org.mozilla.focus"
-                - "org.mozilla.klar"
+            focus-release:
+              package_names: ["org.mozilla.focus"]
+              certificate_alias: 'focus'
+              google:
+                default_track: 'alpha'
+                service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FOCUS" }
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_PATH" }
+            klar-release:
+              package_names: ["org.mozilla.klar"]
               certificate_alias: 'focus'
               google:
                 default_track: 'alpha'
@@ -174,10 +179,15 @@ products:
           skip_check_same_locales: true
           skip_checks_fennec: true
           apps:
-            release:
-              package_names:
-                - "org.mozilla.focus"
-                - "org.mozilla.klar"
+            focus-release:
+              package_names: ["org.mozilla.focus"]
+              certificate_alias: 'focus'
+              google:
+                default_track: 'alpha'
+                service_account: 'dummy'
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_DEP_PATH" }
+            klar-release:
+              package_names: ["org.mozilla.klar"]
               certificate_alias: 'focus'
               google:
                 default_track: 'alpha'


### PR DESCRIPTION
* This will avoid custom taskgraph code in focus-android and stay consistent with the separation of builds and signing tasks per app