### PR TITLE
remove remaining scriptworker imports from pushmsixscript

### DIFF
--- a/pushmsixscript/src/pushmsixscript/artifacts.py
+++ b/pushmsixscript/src/pushmsixscript/artifacts.py
@@ -1,10 +1,10 @@
-from scriptworker import artifacts
-from scriptworker.utils import get_single_item_from_sequence
+from scriptworker_client import artifacts
 from scriptworker_client.exceptions import TaskVerificationError
+from scriptworker_client.utils import get_single_item_from_sequence
 
 
-def get_msix_file_path(context):
-    artifacts_per_task_id, _ = artifacts.get_upstream_artifacts_full_paths_per_task_id(context)
+def get_msix_file_path(config, task):
+    artifacts_per_task_id, _ = artifacts.get_upstream_artifacts_full_paths_per_task_id(config, task)
 
     all_artifacts = [artifact for artifacts in artifacts_per_task_id.values() for artifact in artifacts]
 

--- a/pushmsixscript/src/pushmsixscript/script.py
+++ b/pushmsixscript/src/pushmsixscript/script.py
@@ -4,7 +4,6 @@
 import logging
 import os
 
-import scriptworker
 from scriptworker_client import client
 
 from pushmsixscript import artifacts, manifest, microsoft_store, task
@@ -12,17 +11,15 @@ from pushmsixscript import artifacts, manifest, microsoft_store, task
 log = logging.getLogger(__name__)
 
 
-async def async_main(context):
-    context.task = client.get_task(context.config)
-
-    msix_file_path = artifacts.get_msix_file_path(context)
+async def async_main(config, task_dict):
+    msix_file_path = artifacts.get_msix_file_path(config, task_dict)
     log.info(f"found msix at {msix_file_path}")
     manifest.verify_msix(msix_file_path)
 
-    channel = task.get_msix_channel(context.config, context.task)
-    _log_warning_forewords(context.config, channel)
+    channel = task.get_msix_channel(config, task_dict)
+    _log_warning_forewords(config, channel)
 
-    microsoft_store.push(context.config, msix_file_path, channel)
+    microsoft_store.push(config, msix_file_path, channel)
 
 
 def _log_warning_forewords(config, channel):
@@ -41,9 +38,7 @@ def get_default_config(base_dir=None):
 
 
 def main(config_path=None):
-    # TODO: Cannot yet use scriptworker_client here, as that does not pass the context
-    # to async_main, which still requires context to use scriptworker.artifacts, etc.
-    return scriptworker.client.sync_main(async_main, config_path=config_path, default_config=get_default_config())
+    return client.sync_main(async_main, config_path=config_path, default_config=get_default_config())
 
 
 __name__ == "__main__" and main()

--- a/pushmsixscript/tests/test_artifacts.py
+++ b/pushmsixscript/tests/test_artifacts.py
@@ -1,5 +1,5 @@
 import pytest
-from scriptworker import artifacts
+from scriptworker_client import artifacts
 from scriptworker_client.exceptions import TaskVerificationError
 
 from pushmsixscript.artifacts import get_msix_file_path
@@ -17,11 +17,9 @@ from pushmsixscript.artifacts import get_msix_file_path
     ),
 )
 def test_get_msix_file_path(monkeypatch, raises, returned, expected):
-    context = None
-
-    monkeypatch.setattr(artifacts, "get_upstream_artifacts_full_paths_per_task_id", lambda _: returned)
+    monkeypatch.setattr(artifacts, "get_upstream_artifacts_full_paths_per_task_id", lambda c, t: returned)
     if raises:
         with pytest.raises(TaskVerificationError):
-            get_msix_file_path(context)
+            get_msix_file_path({}, {})
     else:
-        assert get_msix_file_path(context) == expected
+        assert get_msix_file_path({}, {}) == expected

--- a/pushmsixscript/tests/test_script.py
+++ b/pushmsixscript/tests/test_script.py
@@ -1,5 +1,4 @@
 import os
-from unittest.mock import MagicMock
 
 import pytest
 from scriptworker_client import client
@@ -14,22 +13,21 @@ TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 async def test_async_main(monkeypatch):
     function_call_counter = (n for n in range(0, 2))
 
-    context = MagicMock()
-    context.config = {"push_to_store": True}
+    config = {"push_to_store": True}
     msix_file_path = os.path.join(TEST_DATA_DIR, "valid-zip-valid-content.msix")
     monkeypatch.setattr(client, "get_task", lambda _: {})
-    monkeypatch.setattr(artifacts, "get_msix_file_path", lambda _: msix_file_path)
+    monkeypatch.setattr(artifacts, "get_msix_file_path", lambda c, t: msix_file_path)
     monkeypatch.setattr(task, "get_msix_channel", lambda config, channel: "release")
 
     def assert_push(config_, file_, channel):
-        assert config_ == context.config
+        assert config_ == config
         assert file_ == msix_file_path
         assert channel == "release"
         next(function_call_counter)
 
     monkeypatch.setattr(microsoft_store, "push", assert_push)
 
-    await async_main(context)
+    await async_main(config, {})
 
     assert next(function_call_counter) == 1
 

--- a/scriptworker_client/src/scriptworker_client/artifacts.py
+++ b/scriptworker_client/src/scriptworker_client/artifacts.py
@@ -1,0 +1,154 @@
+"""Scriptworker-client artifact-related operations."""
+import logging
+import os
+from pathlib import Path
+
+from scriptworker_client.exceptions import TaskVerificationError
+from scriptworker_client.utils import add_enumerable_item_to_dict
+
+log = logging.getLogger(__name__)
+
+
+def get_upstream_artifacts_full_paths_per_task_id(config, task):
+    """List the downloaded upstream artifacts.
+
+    Args:
+        config (dict): the running config
+        task (dict): the running task
+
+    Returns:
+        dict, dict: lists of the paths to upstream artifacts, sorted by task_id.
+            First dict represents the existing upstream artifacts. The second one
+            maps the optional artifacts that couldn't be downloaded
+
+    Raises:
+        scriptworker_client.exceptions.TaskVerificationError: when an artifact doesn't exist.
+
+    """
+    upstream_artifacts = task["payload"]["upstreamArtifacts"]
+    task_ids_and_relative_paths = [
+        (artifact_definition["taskId"], artifact_definition["paths"])
+        for artifact_definition in upstream_artifacts
+    ]
+
+    optional_artifacts_per_task_id = get_optional_artifacts_per_task_id(
+        upstream_artifacts
+    )
+
+    upstream_artifacts_full_paths_per_task_id = {}
+    failed_paths_per_task_id = {}
+    for task_id, paths in task_ids_and_relative_paths:
+        for path in paths:
+            try:
+                path_to_add = get_and_check_single_upstream_artifact_full_path(
+                    config, task_id, path
+                )
+                add_enumerable_item_to_dict(
+                    dict_=upstream_artifacts_full_paths_per_task_id,
+                    key=task_id,
+                    item=path_to_add,
+                )
+            except TaskVerificationError:
+                if path in optional_artifacts_per_task_id.get(task_id, []):
+                    log.warning(
+                        'Optional artifact "{}" of task "{}" not found'.format(
+                            path, task_id
+                        )
+                    )
+                    add_enumerable_item_to_dict(
+                        dict_=failed_paths_per_task_id, key=task_id, item=path
+                    )
+                else:
+                    raise
+
+    return upstream_artifacts_full_paths_per_task_id, failed_paths_per_task_id
+
+
+def get_and_check_single_upstream_artifact_full_path(config, task_id, path):
+    """Return the full path where an upstream artifact is located on disk.
+
+    Args:
+        config (dict): the running config
+        task_id (str): the task id of the task that published the artifact
+        path (str): the relative path of the artifact
+
+    Returns:
+        str: absolute path to the artifact
+
+    Raises:
+        scriptworker_client.exceptions.TaskVerificationError: when an artifact doesn't exist.
+
+    """
+    abs_path = get_single_upstream_artifact_full_path(config, task_id, path)
+    if not os.path.exists(abs_path):
+        raise TaskVerificationError(
+            "upstream artifact with path: {}, does not exist".format(abs_path)
+        )
+
+    return abs_path
+
+
+def get_single_upstream_artifact_full_path(config, task_id, path):
+    """Return the full path where an upstream artifact should be located.
+
+    Artifact may not exist. If you want to be sure if does, use
+    ``get_and_check_single_upstream_artifact_full_path()`` instead.
+
+    This function is mainly used to move artifacts to the expected location.
+
+    Args:
+        config (dict): the running config
+        task_id (str): the task id of the task that published the artifact
+        path (str): the relative path of the artifact
+
+    Returns:
+        str: absolute path to the artifact should be.
+
+    """
+    parent_dir = os.path.abspath(os.path.join(config["work_dir"], "cot", task_id))
+    full_path = os.path.join(parent_dir, path)
+    assert_is_parent(full_path, parent_dir)
+    return full_path
+
+
+def get_optional_artifacts_per_task_id(upstream_artifacts):
+    """Return every optional artifact defined in ``upstream_artifacts``, ordered by taskId.
+
+    Args:
+        upstream_artifacts: the list of upstream artifact definitions
+
+    Returns:
+        dict: list of paths to downloaded artifacts ordered by taskId
+
+    """
+    # A given taskId might be defined many times in upstreamArtifacts. Thus, we can't
+    # use a dict comprehension
+    optional_artifacts_per_task_id = {}
+
+    for artifact_definition in upstream_artifacts:
+        if artifact_definition.get("optional", False) is True:
+            task_id = artifact_definition["taskId"]
+            artifacts_paths = artifact_definition["paths"]
+
+            add_enumerable_item_to_dict(
+                dict_=optional_artifacts_per_task_id, key=task_id, item=artifacts_paths
+            )
+
+    return optional_artifacts_per_task_id
+
+
+def assert_is_parent(path, parent_dir):
+    """Raise ``TaskVerificationError`` if ``path`` is not under ``parent_dir``.
+
+    Args:
+        path (str): the path to inspect.
+        parent_dir (str): the path that ``path`` should be under.
+
+    Raises:
+        TaskVerificationError: if ``path`` is not under ``parent_dir``.
+
+    """
+    p1 = Path(os.path.realpath(path))
+    p2 = Path(os.path.realpath(parent_dir))
+    if p1 != p2 and p2 not in p1.parents:
+        raise TaskVerificationError("{} is not under {}!".format(p1, p2))

--- a/scriptworker_client/src/scriptworker_client/utils.py
+++ b/scriptworker_client/src/scriptworker_client/utils.py
@@ -583,3 +583,28 @@ def get_single_item_from_sequence(
     if append_sequence_to_error_message:
         error_message = "{}. Given: {}".format(error_message, sequence)
     raise ErrorClass(error_message)
+
+
+# add_enumerable_item_to_dict {{{1
+def add_enumerable_item_to_dict(dict_, key, item):
+    """Add an item to a list contained in a dict.
+
+    For example: If the dict is ``{'some_key': ['an_item']}``, then calling this function
+    will alter the dict to ``{'some_key': ['an_item', 'another_item']}``.
+
+    If the key doesn't exist yet, the function initializes it with a list containing the
+    item.
+
+    List-like items are allowed. In this case, the existing list will be extended.
+
+    Args:
+        dict_ (dict): the dict to modify
+        key (str): the key to add the item to
+        item (whatever): The item to add to the list associated to the key
+
+    """
+    dict_.setdefault(key, [])
+    if isinstance(item, (list, tuple)):
+        dict_[key].extend(item)
+    else:
+        dict_[key].append(item)

--- a/scriptworker_client/tests/__init__.py
+++ b/scriptworker_client/tests/__init__.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# coding=utf-8
+"""Test base files
+"""
+
+
+def touch(path):
+    """Create an empty file.  Different from the system 'touch' in that it
+    will overwrite an existing file.
+    """
+    with open(path, "w") as fh:
+        print(path, file=fh, end="")

--- a/scriptworker_client/tests/test_artifacts.py
+++ b/scriptworker_client/tests/test_artifacts.py
@@ -1,0 +1,258 @@
+import itertools
+import json
+import os
+
+import mock
+import pytest
+
+import scriptworker_client.artifacts as swartifacts
+from scriptworker_client.artifacts import (
+    get_and_check_single_upstream_artifact_full_path,
+    get_optional_artifacts_per_task_id,
+    get_single_upstream_artifact_full_path,
+    get_upstream_artifacts_full_paths_per_task_id,
+)
+
+from scriptworker_client.exceptions import TaskVerificationError
+
+from . import touch
+
+
+def test_get_upstream_artifacts_full_paths_per_task_id():
+    artifacts_to_succeed = [
+        {"paths": ["public/file_a1"], "taskId": "dependency1", "taskType": "signing"},
+        {
+            "paths": ["public/file_b1", "public/file_b2"],
+            "taskId": "dependency2",
+            "taskType": "signing",
+        },
+        {
+            "paths": ["some_other_folder/file_c"],
+            "taskId": "dependency3",
+            "taskType": "signing",
+        },
+        {
+            # Case where the same taskId was given. In some occasion we may want to split
+            # upstreamArtifacts of the same taskId into 2. For instance: 1 taskId with a given
+            # parameter (like beetmover's "locale") but not the other
+            "paths": ["public/file_a2"],
+            "taskId": "dependency1",
+            "taskType": "signing",
+        },
+    ]
+
+    task = {}
+    task["payload"] = {
+        "upstreamArtifacts": [
+            {
+                "paths": ["public/failed_optional_file1"],
+                "taskId": "failedDependency1",
+                "taskType": "signing",
+                "optional": True,
+            },
+            {
+                "paths": [
+                    "public/failed_optional_file2",
+                    "public/failed_optional_file3",
+                ],
+                "taskId": "failedDependency2",
+                "taskType": "signing",
+                "optional": True,
+            },
+        ]
+    }
+    config = {}
+    config["work_dir"] = os.path.abspath("some/path")
+
+    task["payload"]["upstreamArtifacts"].extend(artifacts_to_succeed)
+    for artifact in artifacts_to_succeed:
+        folder = os.path.join(config["work_dir"], "cot", artifact["taskId"])
+
+        for path in artifact["paths"]:
+            try:
+                os.makedirs(os.path.join(folder, os.path.dirname(path)))
+            except FileExistsError:
+                pass
+            touch(os.path.join(folder, path))
+
+    (
+        succeeded_artifacts,
+        failed_artifacts,
+    ) = get_upstream_artifacts_full_paths_per_task_id(config, task)
+
+    assert succeeded_artifacts == {
+        "dependency1": [
+            os.path.join(config["work_dir"], "cot", "dependency1", "public", "file_a1"),
+            os.path.join(config["work_dir"], "cot", "dependency1", "public", "file_a2"),
+        ],
+        "dependency2": [
+            os.path.join(config["work_dir"], "cot", "dependency2", "public", "file_b1"),
+            os.path.join(config["work_dir"], "cot", "dependency2", "public", "file_b2"),
+        ],
+        "dependency3": [
+            os.path.join(
+                config["work_dir"], "cot", "dependency3", "some_other_folder", "file_c"
+            )
+        ],
+    }
+    assert failed_artifacts == {
+        "failedDependency1": ["public/failed_optional_file1"],
+        "failedDependency2": [
+            "public/failed_optional_file2",
+            "public/failed_optional_file3",
+        ],
+    }
+
+
+def test_fail_get_upstream_artifacts_full_paths_per_task_id():
+    task = {}
+    task["payload"] = {
+        "upstreamArtifacts": [
+            {
+                "paths": ["public/failed_mandatory_file"],
+                "taskId": "failedDependency",
+                "taskType": "signing",
+            }
+        ]
+    }
+    config = {}
+    config["work_dir"] = os.path.abspath("some/path")
+    with pytest.raises(TaskVerificationError):
+        get_upstream_artifacts_full_paths_per_task_id(config, task)
+
+
+def test_get_and_check_single_upstream_artifact_full_path():
+    task = {}
+    config = {}
+    config["work_dir"] = os.path.abspath("some/path")
+    folder = os.path.join(config["work_dir"], "cot", "dependency1")
+    touch(os.path.join(folder, "public/file_a"))
+
+    assert get_and_check_single_upstream_artifact_full_path(
+        config, "dependency1", "public/file_a"
+    ) == os.path.join(config["work_dir"], "cot", "dependency1", "public", "file_a")
+
+    with pytest.raises(TaskVerificationError):
+        get_and_check_single_upstream_artifact_full_path(
+            config, "dependency1", "public/non_existing_file"
+        )
+
+    with pytest.raises(TaskVerificationError):
+        get_and_check_single_upstream_artifact_full_path(
+            config, "non-existing-dep", "public/file_a"
+        )
+
+
+def test_get_single_upstream_artifact_full_path():
+    config = {}
+    config["work_dir"] = os.path.abspath("some/path")
+    os.path.join(config["work_dir"], "cot", "dependency1")
+
+    assert get_single_upstream_artifact_full_path(
+        config, "dependency1", "public/file_a"
+    ) == os.path.join(config["work_dir"], "cot", "dependency1", "public", "file_a")
+
+    assert get_single_upstream_artifact_full_path(
+        config, "dependency1", "public/non_existing_file"
+    ) == os.path.join(
+        config["work_dir"], "cot", "dependency1", "public", "non_existing_file"
+    )
+
+    assert get_single_upstream_artifact_full_path(
+        config, "non-existing-dep", "public/file_a"
+    ) == os.path.join(config["work_dir"], "cot", "non-existing-dep", "public", "file_a")
+
+
+@pytest.mark.parametrize(
+    "upstream_artifacts, expected",
+    (
+        ([{}], {}),
+        ([{"taskId": "someTaskId", "paths": ["mandatory_artifact_1"]}], {}),
+        (
+            [
+                {
+                    "taskId": "someTaskId",
+                    "paths": ["optional_artifact_1"],
+                    "optional": True,
+                }
+            ],
+            {"someTaskId": ["optional_artifact_1"]},
+        ),
+        (
+            [
+                {
+                    "taskId": "someTaskId",
+                    "paths": ["optional_artifact_1", "optional_artifact_2"],
+                    "optional": True,
+                }
+            ],
+            {"someTaskId": ["optional_artifact_1", "optional_artifact_2"]},
+        ),
+        (
+            [
+                {
+                    "taskId": "someTaskId",
+                    "paths": ["optional_artifact_1"],
+                    "optional": True,
+                },
+                {
+                    "taskId": "someOtherTaskId",
+                    "paths": ["optional_artifact_2"],
+                    "optional": True,
+                },
+                {"taskId": "anotherOtherTaskId", "paths": ["mandatory_artifact_1"]},
+            ],
+            {
+                "someTaskId": ["optional_artifact_1"],
+                "someOtherTaskId": ["optional_artifact_2"],
+            },
+        ),
+        (
+            [
+                {
+                    "taskId": "taskIdGivenThreeTimes",
+                    "paths": ["optional_artifact_1"],
+                    "optional": True,
+                },
+                {"taskId": "taskIdGivenThreeTimes", "paths": ["mandatory_artifact_1"]},
+                {
+                    "taskId": "taskIdGivenThreeTimes",
+                    "paths": ["optional_artifact_2"],
+                    "optional": True,
+                },
+            ],
+            {"taskIdGivenThreeTimes": ["optional_artifact_1", "optional_artifact_2"]},
+        ),
+    ),
+)
+def test_get_optional_artifacts_per_task_id(upstream_artifacts, expected):
+    assert get_optional_artifacts_per_task_id(upstream_artifacts) == expected
+
+
+# assert_is_parent {{{1
+@pytest.mark.parametrize(
+    "path, parent_path, raises",
+    (
+        ("/foo/bar/baz", "/foo/bar", False),
+        ("/foo", "/foo/bar", True),
+        ("/foo/bar/..", "/foo/bar", True),
+    ),
+)
+def test_assert_is_parent(path, parent_path, raises):
+    if raises:
+        with pytest.raises(TaskVerificationError):
+            swartifacts.assert_is_parent(path, parent_path)
+    else:
+        swartifacts.assert_is_parent(path, parent_path)
+
+
+def test_assert_is_parent_softlink(tmpdir):
+    """A softlink that points outside of a parent_dir is not under parent_dir."""
+    work_dir = os.path.join(tmpdir, "work")
+    external_dir = os.path.join(tmpdir, "external")
+    os.mkdir(work_dir)
+    os.mkdir(external_dir)
+    link = os.path.join(work_dir, "link")
+    os.symlink(external_dir, link)
+    with pytest.raises(TaskVerificationError):
+        swartifacts.assert_is_parent(link, work_dir)


### PR DESCRIPTION
Adds scriptworker_client.artifacts (a copy of part of scriptworker.artifact) and other changes to eliminate direct use of scriptworker by pushmsixscript.

Closes #443 