### PR TITLE
Add staging-focus-android to githubscript

### DIFF
--- a/githubscript/docker.d/worker.yml
+++ b/githubscript/docker.d/worker.yml
@@ -34,6 +34,12 @@ github_projects:
         github_owner: mozilla-releng
         github_repo_name: staging-android-components
         contact_github: true
+      staging-focus-android:
+        allowed_actions: ["release"]
+        github_token: { "$eval": "GITHUB_TOKEN_WRITE_ACCESS_STAGING" }
+        github_owner: mozilla-releng
+        github_repo_name: staging-focus-android
+        contact_github: true
     'COT_PRODUCT == "mobile" && ENV == "dev"':
       mock:
         allowed_actions: ["release"]

--- a/githubscript/docker.d/worker.yml
+++ b/githubscript/docker.d/worker.yml
@@ -53,6 +53,12 @@ github_projects:
         github_owner: mozilla-releng
         github_repo_name: staging-android-components
         contact_github: true
+      staging-focus-android:
+        allowed_actions: ["release"]
+        github_token: { "$eval": "GITHUB_TOKEN_WRITE_ACCESS_STAGING" }
+        github_owner: mozilla-releng
+        github_repo_name: staging-focus-android
+        contact_github: true
     'COT_PRODUCT == "xpi" && ENV == "prod"':
       mozilla-extensions/*:
         allowed_actions: ["release"]


### PR DESCRIPTION
Realizing per Aki's [comment](https://github.com/mozilla-releng/scriptworker-scripts/pull/440/files#r756405126) that I should probably add the staging repo (assuming that if I create a release locally against the staging repo, githubscript will create a release and upload the apks there).