### PR TITLE
Allow multiple msix uploads in one Store submission

### DIFF
--- a/pushmsixscript/src/pushmsixscript/artifacts.py
+++ b/pushmsixscript/src/pushmsixscript/artifacts.py
@@ -1,17 +1,13 @@
 from scriptworker_client import artifacts
 from scriptworker_client.exceptions import TaskVerificationError
-from scriptworker_client.utils import get_single_item_from_sequence
 
 
-def get_msix_file_path(config, task):
+def get_msix_file_paths(config, task):
     artifacts_per_task_id, _ = artifacts.get_upstream_artifacts_full_paths_per_task_id(config, task)
 
     all_artifacts = [artifact for artifacts in artifacts_per_task_id.values() for artifact in artifacts]
 
-    return get_single_item_from_sequence(
-        all_artifacts,
-        condition=lambda artifact: artifact.endswith(".store.msix"),
-        ErrorClass=TaskVerificationError,
-        no_item_error_message="No upstream artifact is a store msix",
-        too_many_item_error_message="Too many msix artifacts found",
-    )
+    filtered_artifacts = [item for item in all_artifacts if item.endswith(".store.msix")]
+    if len(filtered_artifacts) == 0:
+        raise TaskVerificationError("No upstream artifact is a store msix")
+    return filtered_artifacts

--- a/pushmsixscript/src/pushmsixscript/script.py
+++ b/pushmsixscript/src/pushmsixscript/script.py
@@ -12,14 +12,15 @@ log = logging.getLogger(__name__)
 
 
 async def async_main(config, task_dict):
-    msix_file_path = artifacts.get_msix_file_path(config, task_dict)
-    log.info(f"found msix at {msix_file_path}")
-    manifest.verify_msix(msix_file_path)
+    msix_file_paths = artifacts.get_msix_file_paths(config, task_dict)
+    for msix_file_path in msix_file_paths:
+        log.info(f"found msix at {msix_file_path}")
+        manifest.verify_msix(msix_file_path)
 
     channel = task.get_msix_channel(config, task_dict)
     _log_warning_forewords(config, channel)
 
-    microsoft_store.push(config, msix_file_path, channel)
+    microsoft_store.push(config, msix_file_paths, channel)
 
 
 def _log_warning_forewords(config, channel):

--- a/pushmsixscript/tests/integration/test_integration_script.py
+++ b/pushmsixscript/tests/integration/test_integration_script.py
@@ -49,7 +49,7 @@ from pushmsixscript.script import main
             },
             "release",
             False,
-            7,
+            8,
         ),
     ),
 )
@@ -59,7 +59,9 @@ def test_script_can_push_msix(monkeypatch, config, channel, raises, requests_cal
         "scopes": [f"project:releng:microsoftstore:{channel}"],
         "payload": {
             "channel": channel,
-            "upstreamArtifacts": [{"paths": ["public/build/target.store.msix"], "taskId": "some_msix_build_taskId", "taskType": "build"}],
+            "upstreamArtifacts": [
+                {"paths": ["public/build/target.x86.store.msix", "public/build/target.x64.store.msix"], "taskId": "some_msix_build_taskId", "taskType": "build"}
+            ],
         },
     }
 
@@ -101,9 +103,10 @@ def test_script_can_push_msix(monkeypatch, config, channel, raises, requests_cal
 
             msix_artifact_dir = os.path.join(work_dir, "cot/some_msix_build_taskId/public/build/")
             makedirs(msix_artifact_dir)
-            msix_artifact_path = os.path.join(msix_artifact_dir, "target.store.msix")
-            with open(msix_artifact_path, "w") as msix_file:
-                msix_file.write(" ")
+            for arch in ["x86", "x64"]:
+                msix_artifact_path = os.path.join(msix_artifact_dir, f"target.{arch}.store.msix")
+                with open(msix_artifact_path, "w") as msix_file:
+                    msix_file.write(" ")
 
             # config_file is not put in the TemporaryDirectory() (like the others), because it usually lives
             # elsewhere on the filesystem

--- a/pushmsixscript/tests/test_artifacts.py
+++ b/pushmsixscript/tests/test_artifacts.py
@@ -2,24 +2,28 @@ import pytest
 from scriptworker_client import artifacts
 from scriptworker_client.exceptions import TaskVerificationError
 
-from pushmsixscript.artifacts import get_msix_file_path
+from pushmsixscript.artifacts import get_msix_file_paths
 
 
 @pytest.mark.parametrize(
     "raises, returned, expected",
     (
-        (False, ({"taskId": ["/path/to/file.store.msix"]}, {}), "/path/to/file.store.msix"),
-        (False, ({"taskId": ["/path/to/file.store.msix", "/some/other/file.txt"]}, {}), "/path/to/file.store.msix"),
-        (False, ({"taskId": ["/path/to/file.store.msix"], "otherTaskId": "/some/other/file.txt"}, {}), "/path/to/file.store.msix"),
-        (True, ({}, {"taskId": ["/path/to/file.store.msix"]}), None),
+        (False, ({"taskId": ["/path/to/file.store.msix"]}, {}), ["/path/to/file.store.msix"]),
+        (False, ({"taskId": ["/path/to/file.store.msix", "/some/other/file.txt"]}, {}), ["/path/to/file.store.msix"]),
+        (False, ({"taskId": ["/path/to/file.store.msix"], "otherTaskId": "/some/other/file.txt"}, {}), ["/path/to/file.store.msix"]),
+        (True, ({}, {"taskId": ["/path/to/file.store.msix"]}), ["/path/to/file.store.msix"]),
         (True, ({"taskId": ["/some/other/file.txt"]}, {}), None),
-        (True, ({"taskId": ["/path/to/file.store.msix"], "otherTaskId": ["/some/other/file.store.msix"]}, {}), None),
+        (
+            False,
+            ({"taskId": ["/path/to/file.store.msix"], "otherTaskId": ["/some/other/file.store.msix"]}, {}),
+            ["/path/to/file.store.msix", "/some/other/file.store.msix"],
+        ),
     ),
 )
-def test_get_msix_file_path(monkeypatch, raises, returned, expected):
+def test_get_msix_file_paths(monkeypatch, raises, returned, expected):
     monkeypatch.setattr(artifacts, "get_upstream_artifacts_full_paths_per_task_id", lambda c, t: returned)
     if raises:
         with pytest.raises(TaskVerificationError):
-            get_msix_file_path({}, {})
+            get_msix_file_paths({}, {})
     else:
-        assert get_msix_file_path({}, {}) == expected
+        assert get_msix_file_paths({}, {}) == expected

--- a/pushmsixscript/tests/test_artifacts.py
+++ b/pushmsixscript/tests/test_artifacts.py
@@ -11,7 +11,7 @@ from pushmsixscript.artifacts import get_msix_file_paths
         (False, ({"taskId": ["/path/to/file.store.msix"]}, {}), ["/path/to/file.store.msix"]),
         (False, ({"taskId": ["/path/to/file.store.msix", "/some/other/file.txt"]}, {}), ["/path/to/file.store.msix"]),
         (False, ({"taskId": ["/path/to/file.store.msix"], "otherTaskId": "/some/other/file.txt"}, {}), ["/path/to/file.store.msix"]),
-        (True, ({}, {"taskId": ["/path/to/file.store.msix"]}), ["/path/to/file.store.msix"]),
+        (True, ({}, {"taskId": ["/path/to/file.store.msix"]}), None),
         (True, ({"taskId": ["/some/other/file.txt"]}, {}), None),
         (
             False,

--- a/pushmsixscript/tests/test_microsoft_store.py
+++ b/pushmsixscript/tests/test_microsoft_store.py
@@ -129,9 +129,9 @@ def test_update_submission(status_code, upload_status_code, raises):
                 m.put(upload_url, headers=headers, json=mocked_response, status_code=upload_status_code)
                 if raises:
                     with pytest.raises(requests.exceptions.HTTPError):
-                        microsoft_store._update_submission(CONFIG, channel, session, submission_request, headers, f.name)
+                        microsoft_store._update_submission(CONFIG, channel, session, submission_request, headers, [f.name])
                 else:
-                    microsoft_store._update_submission(CONFIG, channel, session, submission_request, headers, f.name)
+                    microsoft_store._update_submission(CONFIG, channel, session, submission_request, headers, [f.name])
 
 
 @pytest.mark.parametrize(
@@ -227,6 +227,6 @@ def test_push_to_store(status_code, raises, mocked_response):
 
             if raises:
                 with pytest.raises(requests.exceptions.HTTPError):
-                    microsoft_store._push_to_store(CONFIG, channel, f.name, access_token)
+                    microsoft_store._push_to_store(CONFIG, channel, [f.name], access_token)
             else:
-                microsoft_store._push_to_store(CONFIG, channel, f.name, access_token)
+                microsoft_store._push_to_store(CONFIG, channel, [f.name], access_token)

--- a/pushmsixscript/tests/test_script.py
+++ b/pushmsixscript/tests/test_script.py
@@ -16,12 +16,12 @@ async def test_async_main(monkeypatch):
     config = {"push_to_store": True}
     msix_file_path = os.path.join(TEST_DATA_DIR, "valid-zip-valid-content.msix")
     monkeypatch.setattr(client, "get_task", lambda _: {})
-    monkeypatch.setattr(artifacts, "get_msix_file_path", lambda c, t: msix_file_path)
+    monkeypatch.setattr(artifacts, "get_msix_file_paths", lambda c, t: [msix_file_path])
     monkeypatch.setattr(task, "get_msix_channel", lambda config, channel: "release")
 
     def assert_push(config_, file_, channel):
         assert config_ == config
-        assert file_ == msix_file_path
+        assert file_ == [msix_file_path]
         assert channel == "release"
         next(function_call_counter)
 


### PR DESCRIPTION
It turns out we need to upload both 32-bit and 64-bit msix files in one submission to the Microsoft Store.