### PR TITLE
[signingscript] Add 'autograph_apk' format to mozillavpn

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -205,6 +205,8 @@ case $ENV in
       mozillavpn)
         test_var_set 'AUTOGRAPH_AUTHENTICODE_PASSWORD'
         test_var_set 'AUTOGRAPH_AUTHENTICODE_USERNAME'
+        test_var_set 'AUTOGRAPH_MOZILLAVPN_PASSWORD'
+        test_var_set 'AUTOGRAPH_MOZILLAVPN_USERNAME'
         test_var_set 'AUTHENTICODE_CERT_PATH'
         test_var_set 'AUTHENTICODE_CA_PATH'
         test_var_set 'AUTHENTICODE_CA_TIMESTAMP_PATH'

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -355,6 +355,11 @@ in:
              {"$eval": "AUTOGRAPH_AUTHENTICODE_PASSWORD"},
              ["autograph_authenticode", "autograph_authenticode_stub"]
             ]
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_MOZILLAVPN_USERNAME"},
+             {"$eval": "AUTOGRAPH_MOZILLAVPN_PASSWORD"},
+             ["autograph_apk"]
+            ]
 
       # passwords-adhoc.json
       'ENV == "prod" && COT_PRODUCT == "adhoc"':


### PR DESCRIPTION
The VPN team is standing up a signing task for their Android app and need autograph_apk support.