### PR TITLE
balrog & beetmover scriptworkers system addons support

### DIFF
--- a/balrogscript/docker.d/init_worker.sh
+++ b/balrogscript/docker.d/init_worker.sh
@@ -56,7 +56,7 @@ case $COT_PRODUCT in
         exit 1
         ;;
     esac
-    export TASKCLUSTER_SCOPE_PREFIX="project:releng:${PROJECT_NAME}:"
+    export TASKCLUSTER_SCOPE_PREFIX="project:xpi:balrog:"
     ;;
   thunderbird)
     case $ENV in

--- a/balrogscript/docker.d/worker.yml
+++ b/balrogscript/docker.d/worker.yml
@@ -69,3 +69,21 @@ server_config:
       - 'esr'
       - 'esr-localtest'
       - 'esr-cdntest'
+  staging:
+    api_root: { "$eval": "STAGE_API_ROOT" }
+    auth0_domain: { "$eval": "AUTH0_DOMAIN"}
+    auth0_client_id: { "$eval": "AUTH0_CLIENT_ID" }
+    auth0_client_secret: { "$eval": "AUTH0_CLIENT_SECRET" }
+    auth0_audience: { "$eval": "AUTH0_AUDIENCE" }
+    allowed_channels:
+      - 'nightly'
+      - 'aurora'
+      - 'beta'
+      - 'beta-localtest'
+      - 'beta-cdntest'
+      - 'release'
+      - 'release-localtest'
+      - 'release-cdntest'
+      - 'esr'
+      - 'esr-localtest'
+      - 'esr-cdntest'

--- a/balrogscript/pyproject.toml
+++ b/balrogscript/pyproject.toml
@@ -23,6 +23,7 @@ exclude = '''
 [tool.isort]
 line_length = 160
 known_first_party = 'balrogscript'
+profile = "black"
 
 [tool.towncrier]
 package = "balrogscript"

--- a/balrogscript/src/balrogscript/constants.py
+++ b/balrogscript/src/balrogscript/constants.py
@@ -4,4 +4,12 @@ Attributes:
     VALID_ACTIONS (tuple): the available actions supported by balrogscript.
 
 """
-VALID_ACTIONS = ("submit-locale", "submit-toplevel", "schedule", "set-readonly", "v2-submit-locale", "v2-submit-toplevel")
+VALID_ACTIONS = (
+    "submit-locale",
+    "submit-toplevel",
+    "schedule",
+    "set-readonly",
+    "v2-submit-locale",
+    "v2-submit-toplevel",
+    "submit-system-addons",
+)

--- a/balrogscript/src/balrogscript/constants.py
+++ b/balrogscript/src/balrogscript/constants.py
@@ -13,3 +13,19 @@ VALID_ACTIONS = (
     "v2-submit-toplevel",
     "submit-system-addons",
 )
+
+SYSTEM_ADDONS_PLATFORMS = {
+    "Darwin_x86-gcc3": {
+        "alias": "default",
+    },
+    "Darwin_x86_64-gcc3": {"alias": "default"},
+    "Darwin_x86-gcc3-u-i386-x86_64": {"alias": "default"},
+    "Darwin_x86_64-gcc3-u-i386-x86_64": {"alias": "default"},
+    "Linux_x86-gcc3": {"alias": "default"},
+    "Linux_x86_64-gcc3": {"alias": "default"},
+    "WINNT_x86-msvc": {"alias": "default"},
+    "WINNT_x86-msvc-x64": {"alias": "default"},
+    "WINNT_x86-msvc-x86": {"alias": "default"},
+    "WINNT_x86_64-msvc": {"alias": "default"},
+    "WINNT_x86_64-msvc-x64": {"alias": "default"},
+}

--- a/balrogscript/src/balrogscript/data/balrog_submit-system-addons_schema.json
+++ b/balrogscript/src/balrogscript/data/balrog_submit-system-addons_schema.json
@@ -1,0 +1,64 @@
+{
+    "title": "submit-system-addons release to balrog",
+    "type": "object",
+    "properties": {
+        "dependencies": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
+        },
+        "payload": {
+            "type": "object",
+            "properties": {
+                "upstreamArtifacts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "taskType": {
+                                "type": "string"
+                            },
+                            "taskId": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "minItems": 1,
+                                "uniqueItems": true,
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "required": [
+                            "taskId",
+                            "taskType",
+                            "paths"
+                        ]
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            },
+            "required": [
+                "upstreamArtifacts"
+            ]
+        },
+        "scopes": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "required": [
+        "payload",
+        "dependencies",
+        "scopes"
+    ]
+}

--- a/balrogscript/src/balrogscript/script.py
+++ b/balrogscript/src/balrogscript/script.py
@@ -9,7 +9,15 @@ import scriptworker_client.client
 from immutabledict import immutabledict
 from redo import retry  # noqa: E402
 
-from .submitter.cli import NightlySubmitterV4, ReleaseCreatorV9, ReleasePusher, ReleaseScheduler, ReleaseStateUpdater, ReleaseSubmitterV9, SystemAddonsReleaseCreator
+from .submitter.cli import (
+    NightlySubmitterV4,
+    ReleaseCreatorV9,
+    ReleasePusher,
+    ReleaseScheduler,
+    ReleaseStateUpdater,
+    ReleaseSubmitterV9,
+    SystemAddonsReleaseCreator,
+)
 from .task import get_manifest, get_task_behavior, get_task_server, get_upstream_artifacts, validate_task_schema
 
 log = logging.getLogger(__name__)
@@ -241,9 +249,7 @@ def get_default_config():
             "submit-toplevel": os.path.join(data_dir, "balrog_submit-toplevel_schema.json"),
             "schedule": os.path.join(data_dir, "balrog_schedule_schema.json"),
             "set-readonly": os.path.join(data_dir, "balrog_set-readonly_schema.json"),
-            "submit-system-addons": os.path.join(
-                data_dir, "balrog_submit-system-addons_schema.json"
-            ),
+            "submit-system-addons": os.path.join(data_dir, "balrog_submit-system-addons_schema.json"),
         }
     }
     return default_config

--- a/balrogscript/src/balrogscript/script.py
+++ b/balrogscript/src/balrogscript/script.py
@@ -9,7 +9,7 @@ import scriptworker_client.client
 from immutabledict import immutabledict
 from redo import retry  # noqa: E402
 
-from .submitter.cli import NightlySubmitterV4, ReleaseCreatorV9, ReleasePusher, ReleaseScheduler, ReleaseStateUpdater, ReleaseSubmitterV9
+from .submitter.cli import NightlySubmitterV4, ReleaseCreatorV9, ReleasePusher, ReleaseScheduler, ReleaseStateUpdater, ReleaseSubmitterV9, SystemAddonsReleaseCreator
 from .task import get_manifest, get_task_behavior, get_task_server, get_upstream_artifacts, validate_task_schema
 
 log = logging.getLogger(__name__)
@@ -71,6 +71,14 @@ def create_locale_submitter(e, extra_suffix, auth0_secrets, config, backend_vers
         return submitter, data
     else:
         raise RuntimeError("Unknown Balrog submission style. Check manifest.json")
+
+
+# submit_system_addons {{{1
+def submit_system_addons(task, config, auth0_secrets):
+    upstream_artifacts = get_upstream_artifacts(task)
+    manifest = get_manifest(config, upstream_artifacts)
+    release_creator = SystemAddonsReleaseCreator(config["api_root"], auth0_secrets)
+    release_creator.run(manifest)
 
 
 # submit_locale {{{1
@@ -233,6 +241,9 @@ def get_default_config():
             "submit-toplevel": os.path.join(data_dir, "balrog_submit-toplevel_schema.json"),
             "schedule": os.path.join(data_dir, "balrog_schedule_schema.json"),
             "set-readonly": os.path.join(data_dir, "balrog_set-readonly_schema.json"),
+            "submit-system-addons": os.path.join(
+                data_dir, "balrog_submit-system-addons_schema.json"
+            ),
         }
     }
     return default_config
@@ -254,6 +265,8 @@ async def async_main(config, task):
 
     if behavior == "submit-toplevel":
         submit_toplevel(task, config, auth0_secrets, backend_version)
+    elif behavior == "submit-system-addons":
+        submit_system_addons(task, config, auth0_secrets)
     elif behavior == "schedule":
         schedule(task, config, auth0_secrets)
     elif behavior == "set-readonly":

--- a/balrogscript/src/balrogscript/submitter/cli.py
+++ b/balrogscript/src/balrogscript/submitter/cli.py
@@ -6,6 +6,7 @@ from balrogclient import Release, ReleaseState, Rule, ScheduledRuleChange, Singl
 from deepmerge import always_merger
 from redo import retry
 from requests.exceptions import HTTPError
+from balrogscript.constants import SYSTEM_ADDONS_PLATFORMS
 
 from .release import buildbot2bouncer, buildbot2ftp, buildbot2updatePlatforms, getPrettyVersion, getProductDetails, makeCandidatesDir
 from .util import recursive_update
@@ -556,21 +557,13 @@ class SystemAddonsReleaseCreator(object):
         }
         for addon in manifest["addons"]:
             platforms = {
-                "Darwin_x86-gcc3": {"alias": "default"},
-                "Darwin_x86-gcc3-u-i386-x86_64": {"alias": "default"},
-                "Darwin_x86_64-gcc3": {"alias": "default"},
-                "Darwin_x86_64-gcc3-u-i386-x86_64": {"alias": "default"},
-                "Linux_x86-gcc3": {"alias": "default"},
-                "Linux_x86_64-gcc3": {"alias": "default"},
-                "WINNT_x86-msvc": {"alias": "default"},
-                "WINNT_x86-msvc-x64": {"alias": "default"},
-                "WINNT_x86-msvc-x86": {"alias": "default"},
-                "WINNT_x86_64-msvc": {"alias": "default"},
-                "WINNT_x86_64-msvc-x64": {"alias": "default"},
-                "default": {
-                    "fileUrl": addon["url"],
-                    "filesize": addon["size"],
-                    "hashValue": addon["hash"],
+                **SYSTEM_ADDONS_PLATFORMS,
+                **{
+                    "default": {
+                        "fileUrl": addon["url"],
+                        "filesize": addon["size"],
+                        "hashValue": addon["hash"],
+                    }
                 },
             }
             release_blob["addons"][addon["name"]] = {

--- a/balrogscript/src/balrogscript/submitter/cli.py
+++ b/balrogscript/src/balrogscript/submitter/cli.py
@@ -583,6 +583,4 @@ class SystemAddonsReleaseCreator(object):
             "product": "SystemAddons",
         }
         balrog_session = get_balrog_session(self.auth0_secrets)
-        balrog_request(
-            balrog_session, "POST", self.url, json=request_data, timeout=5, verify=True
-        )
+        balrog_request(balrog_session, "POST", self.url, json=request_data, timeout=5, verify=True)

--- a/balrogscript/src/balrogscript/submitter/cli.py
+++ b/balrogscript/src/balrogscript/submitter/cli.py
@@ -6,6 +6,7 @@ from balrogclient import Release, ReleaseState, Rule, ScheduledRuleChange, Singl
 from deepmerge import always_merger
 from redo import retry
 from requests.exceptions import HTTPError
+
 from balrogscript.constants import SYSTEM_ADDONS_PLATFORMS
 
 from .release import buildbot2bouncer, buildbot2ftp, buildbot2updatePlatforms, getPrettyVersion, getProductDetails, makeCandidatesDir

--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -45,6 +45,7 @@ from beetmoverscript.utils import (
     exists_or_endswith,
     extract_file_config_from_artifact_map,
     generate_beetmover_manifest,
+    get_addon_name,
     get_bucket_name,
     get_bucket_url_prefix,
     get_candidates_prefix,
@@ -64,7 +65,6 @@ from beetmoverscript.utils import (
     is_release_action,
     matches_exclude,
     write_json,
-    get_addon_name,
 )
 
 log = logging.getLogger(__name__)
@@ -503,32 +503,28 @@ def get_destination_for_partner_repack_path(context, manifest, full_path, locale
 def generate_system_addons_balrog_manifest(context):
     for entry in context.task["payload"]["artifactMap"]:
         locale = entry["locale"]
-        for path, path_info in entry['paths'].items():
+        for path, path_info in entry["paths"].items():
             destinations = path_info["destinations"]
             artifacts_to_beetmove = context.artifacts_to_beetmove[locale]
             filepath = artifacts_to_beetmove[path]
             addon_name = get_addon_name(filepath)
-            addon_version = "{}-{}".format(
-                context.release_props["appVersion"],
-                context.release_props["buildid"]
-            )
-            addon_url = "{prefix}/{s3_key}".format(
-                prefix=get_bucket_url_prefix(context),
-                s3_key=destinations[0]
-            )
-            checksums_path = path_info['checksums_path']
+            addon_version = "{}-{}".format(context.release_props["appVersion"], context.release_props["buildid"])
+            addon_url = "{prefix}/{s3_key}".format(prefix=get_bucket_url_prefix(context), s3_key=destinations[0])
+            checksums_path = path_info["checksums_path"]
             checksums_info = context.checksums[checksums_path]
             addon_hash_type = context.release_props["hashType"]
             addon_hash = checksums_info[addon_hash_type]
             addon_size = checksums_info["size"]
-            context.balrog_manifest.append({
-                "name": addon_name,
-                "version": addon_version,
-                "url": addon_url,
-                "hashType": addon_hash_type,
-                "hash": addon_hash,
-                "size": addon_size,
-            })
+            context.balrog_manifest.append(
+                {
+                    "name": addon_name,
+                    "version": addon_version,
+                    "url": addon_url,
+                    "hashType": addon_hash_type,
+                    "hash": addon_hash,
+                    "size": addon_size,
+                }
+            )
 
 
 # generate_balrog_info {{{1

--- a/beetmoverscript/src/beetmoverscript/utils.py
+++ b/beetmoverscript/src/beetmoverscript/utils.py
@@ -4,6 +4,8 @@ import logging
 import os
 import pprint
 import re
+import tempfile
+import zipfile
 
 import arrow
 import jinja2
@@ -43,6 +45,17 @@ def get_hash(filepath, hash_type="sha512"):
 def get_size(filepath):
     """Function to return the size of a file based on filename"""
     return os.path.getsize(filepath)
+
+
+def get_addon_name(filepath):
+    tmpdir = tempfile.mkdtemp()
+    with zipfile.ZipFile(filepath, 'r') as zf:
+        zf.extractall(tmpdir)
+    manifest_path = os.path.join(tmpdir, 'manifest.json')
+    with open(manifest_path) as f:
+        manifest = json.loads(f.read())
+    name = manifest.get('applications', {}).get('gecko', {}).get('id')
+    return name
 
 
 def load_json(path):

--- a/beetmoverscript/src/beetmoverscript/utils.py
+++ b/beetmoverscript/src/beetmoverscript/utils.py
@@ -6,6 +6,7 @@ import pprint
 import re
 import tempfile
 import zipfile
+from xml.etree import ElementTree
 
 import arrow
 import jinja2
@@ -47,15 +48,38 @@ def get_size(filepath):
     return os.path.getsize(filepath)
 
 
-def get_addon_name(filepath):
+class BadXPIFile(Exception):
+    def __init__(self, filepath):            
+        super().__init__("Error loading XPI data from " + filepath)
+
+
+def get_addon_data(filepath):
     tmpdir = tempfile.mkdtemp()
-    with zipfile.ZipFile(filepath, "r") as zf:
+    with zipfile.ZipFile(filepath, 'r') as zf:
         zf.extractall(tmpdir)
-    manifest_path = os.path.join(tmpdir, "manifest.json")
-    with open(manifest_path) as f:
-        manifest = json.loads(f.read())
-    name = manifest.get("applications", {}).get("gecko", {}).get("id")
-    return name
+    rdf_path = os.path.join(tmpdir, 'install.rdf')
+    manifest_path = os.path.join(tmpdir, 'manifest.json')
+    if os.path.exists(rdf_path):
+        rdf = ElementTree.parse(rdf_path)
+        description = rdf.getroot()[0]
+        for child in description:
+            if child.tag.endswith('id'):
+                name = child.text
+            if child.tag.endswith('version'):
+                version = child.text
+    elif os.path.exists(manifest_path):
+        with open(manifest_path) as f:
+            manifest = json.loads(f.read())
+            name = manifest.get('applications', {}).get('gecko', {}).get('id')
+            version = manifest.get('version')
+    else:
+        raise BadXPIFile(filepath)
+    if not name or not version:
+        raise BadXPIFile(filepath)
+    return {
+        "name": name,
+        "version": version
+    }
 
 
 def load_json(path):

--- a/beetmoverscript/src/beetmoverscript/utils.py
+++ b/beetmoverscript/src/beetmoverscript/utils.py
@@ -49,37 +49,34 @@ def get_size(filepath):
 
 
 class BadXPIFile(Exception):
-    def __init__(self, filepath):            
+    def __init__(self, filepath):
         super().__init__("Error loading XPI data from " + filepath)
 
 
 def get_addon_data(filepath):
     tmpdir = tempfile.mkdtemp()
-    with zipfile.ZipFile(filepath, 'r') as zf:
+    with zipfile.ZipFile(filepath, "r") as zf:
         zf.extractall(tmpdir)
-    rdf_path = os.path.join(tmpdir, 'install.rdf')
-    manifest_path = os.path.join(tmpdir, 'manifest.json')
+    rdf_path = os.path.join(tmpdir, "install.rdf")
+    manifest_path = os.path.join(tmpdir, "manifest.json")
     if os.path.exists(rdf_path):
         rdf = ElementTree.parse(rdf_path)
         description = rdf.getroot()[0]
         for child in description:
-            if child.tag.endswith('id'):
+            if child.tag.endswith("id"):
                 name = child.text
-            if child.tag.endswith('version'):
+            if child.tag.endswith("version"):
                 version = child.text
     elif os.path.exists(manifest_path):
         with open(manifest_path) as f:
             manifest = json.loads(f.read())
-            name = manifest.get('applications', {}).get('gecko', {}).get('id')
-            version = manifest.get('version')
+            name = manifest.get("applications", {}).get("gecko", {}).get("id")
+            version = manifest.get("version")
     else:
         raise BadXPIFile(filepath)
     if not name or not version:
         raise BadXPIFile(filepath)
-    return {
-        "name": name,
-        "version": version
-    }
+    return {"name": name, "version": version}
 
 
 def load_json(path):

--- a/beetmoverscript/src/beetmoverscript/utils.py
+++ b/beetmoverscript/src/beetmoverscript/utils.py
@@ -49,12 +49,12 @@ def get_size(filepath):
 
 def get_addon_name(filepath):
     tmpdir = tempfile.mkdtemp()
-    with zipfile.ZipFile(filepath, 'r') as zf:
+    with zipfile.ZipFile(filepath, "r") as zf:
         zf.extractall(tmpdir)
-    manifest_path = os.path.join(tmpdir, 'manifest.json')
+    manifest_path = os.path.join(tmpdir, "manifest.json")
     with open(manifest_path) as f:
         manifest = json.loads(f.read())
-    name = manifest.get('applications', {}).get('gecko', {}).get('id')
+    name = manifest.get("applications", {}).get("gecko", {}).get("id")
     return name
 
 


### PR DESCRIPTION
These changes modify the balrog & beetmover scriptworkers to support system add-on releases.

I tested these changes in staging by shipping the balrog-dryrun add-on.

**Links**
* [beetmover task ✅](https://firefox-ci-tc.services.mozilla.com/tasks/NegBVXwVR4anezRhr4PXKQ)
  * [balrog manifest](https://firefoxci.taskcluster-artifacts.net/NegBVXwVR4anezRhr4PXKQ/0/public/manifest.json)
  * [artifact archive](https://ftp.stage.mozaws.net/pub/system-addons/balrog-dryrun/balrog-dryrun-3.0.0-build7/)
* [balrog task ✅](https://firefox-ci-tc.services.mozilla.com/tasks/LxmBLOfNT5WW0LGbYEDVSg)
  * [staging release](https://balrog-admin-static-stage.stage.mozaws.net/releases#balrog-dryrun-3.0.0-build7) 
  * [balrog payload](https://firefox-ci-tc.services.mozilla.com/tasks/LxmBLOfNT5WW0LGbYEDVSg/runs/1/logs/public/logs/live_backing.log#L9) 

