### PR TITLE
Fix mozilla vpn scope prefix

### DIFF
--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -13,7 +13,7 @@ taskcluster_scope_prefixes:
         - "project:mobile:fenix:releng:googleplay:product:"
         - "project:mobile:firefox-tv:releng:googleplay:product:"
       'COT_PRODUCT == "mozillavpn"':
-        - "project:mozillavpn:releng:googleplay:"
+        - "project:mozillavpn:releng:googleplay:product:"
 products:
   $flatten:
     $match:


### PR DESCRIPTION
After trying it out with push apk script I realized it's getting the product name from the scope.