### PR TITLE
Bug 1666377 - Add date to merge day clobber message

### DIFF
--- a/treescript/src/treescript/merges.py
+++ b/treescript/src/treescript/merges.py
@@ -61,7 +61,7 @@ def touch_clobber_file(config, repo_path):
             line = line.strip()
             if line.startswith("#") or line == "":
                 new_contents += f"{line}\n"
-        new_contents += "Merge day clobber " + str(date.today())
+        new_contents = f"{new_contents}Merge day clobber {str(date.today())}"
         with open(clobber_file, "w") as f:
             f.write(new_contents)
 

--- a/treescript/src/treescript/merges.py
+++ b/treescript/src/treescript/merges.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import string
+from datetime import date
 
 import attr
 from scriptworker_client.utils import makedirs
@@ -60,7 +61,7 @@ def touch_clobber_file(config, repo_path):
             line = line.strip()
             if line.startswith("#") or line == "":
                 new_contents += f"{line}\n"
-        new_contents += "Merge day clobber"
+        new_contents += "Merge day clobber " + str(date.today())
         with open(clobber_file, "w") as f:
             f.write(new_contents)
 


### PR DESCRIPTION
This should fix 

Try push: https://treeherder.mozilla.org/jobs?repo=try&revision=10cb39ff91b13576b4a592c0473d3d1efca5e088&selectedTaskRun=EhfjJcsBQAe6jj_uDJbd4w.0

Part of diff:
```
diff -r dac2994e65fe CLOBBER
--- a/CLOBBER	Wed Mar 16 22:21:26 2022 +0000
+++ b/CLOBBER	Wed Mar 16 22:21:31 2022 +0000
@@ -22,4 +22,4 @@
 # changes to stick? As of bug 928195, this shouldn't be necessary! Please
 # don't change CLOBBER for WebIDL changes any more.
 
-Merge day clobber
\ No newline at end of file
+Merge day clobber 2022-03-16
\ No newline at end of file
```