### PR TITLE
Remove the experimental timestamp url (sectigo), falling back to digicert

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -152,7 +152,6 @@ case $ENV in
   prod)
     case $COT_PRODUCT in
       firefox|thunderbird)
-        export AUTHENTICODE_TIMESTAMP_URL=http://timestamp.sectigo.com
         test_var_set 'AUTOGRAPH_AUTHENTICODE_PASSWORD'
         test_var_set 'AUTOGRAPH_AUTHENTICODE_USERNAME'
         test_var_set 'AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD'


### PR DESCRIPTION
The sectigo timestamp server mostly worked, but intermittently failed. It seems possible to easily change our timestamp server this way, but sectigo is unreliable. I'm keeping most of the earlier patch, just removing the sectigo selection, so that signingscript explicitly specifies the digicert server going forward.