### PR TITLE
Use certum for timestamp server, prod firefox only, temporarily

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -152,6 +152,7 @@ case $ENV in
   prod)
     case $COT_PRODUCT in
       firefox|thunderbird)
+        export AUTHENTICODE_TIMESTAMP_URL=http://time.certum.pl
         test_var_set 'AUTOGRAPH_AUTHENTICODE_PASSWORD'
         test_var_set 'AUTOGRAPH_AUTHENTICODE_USERNAME'
         test_var_set 'AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD'


### PR DESCRIPTION
This is a temporary, experimental change, to be landed in production for 1 nightly, then backed out before the next beta.