### PR TITLE
Remove the experimental timestamp url (certum), falling back to digicert

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -152,7 +152,6 @@ case $ENV in
   prod)
     case $COT_PRODUCT in
       firefox|thunderbird)
-        export AUTHENTICODE_TIMESTAMP_URL=http://time.certum.pl
         test_var_set 'AUTOGRAPH_AUTHENTICODE_PASSWORD'
         test_var_set 'AUTOGRAPH_AUTHENTICODE_USERNAME'
         test_var_set 'AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD'


### PR DESCRIPTION
Ben reports the certum-timestamped installer is invalid: "One of the countersignatures is invalid"