### PR TITLE
fix the timestamp hack

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -35,17 +35,13 @@ export AUTHENTICODE_CERT_PATH_202005=/app/signingscript/src/signingscript/data/a
 export AUTHENTICODE_CA_PATH=/app/signingscript/src/signingscript/data/authenticode_dep_ca.crt
 export AUTHENTICODE_CA_TIMESTAMP_PATH=/usr/lib/ssl/certs/ca-certificates.crt
 export AUTHENTICODE_CROSS_CERT_PATH=/app/signingscript/src/signingscript/data/authenticode_stub.crt
+export AUTHENTICODE_ADD_DIGICERT_CROSS=false
 if [ "$ENV" == "prod" ]; then
   export AUTHENTICODE_TIMESTAMP_STYLE=old
   export AUTHENTICODE_CERT_PATH=/app/signingscript/src/signingscript/data/authenticode_prod_202005.crt
   export AUTHENTICODE_CERT_PATH_202005=/app/signingscript/src/signingscript/data/authenticode_prod_202005.crt
   export AUTHENTICODE_CA_PATH=/app/signingscript/src/signingscript/data/authenticode_prod_202005.crt
   export AUTHENTICODE_CA_TIMESTAMP_PATH=/usr/lib/ssl/certs/ca-certificates.crt
-fi
-if [ "$COT_PRODUCT" == "adhoc" ]; then
-  export AUTHENTICODE_ADD_DIGICERT_CROSS=true
-else
-  export AUTHENTICODE_ADD_DIGICERT_CROSS=false
 fi
 
 echo $GPG_PUBKEY | base64 -d > $GPG_PUBKEY_PATH
@@ -72,6 +68,7 @@ case $COT_PRODUCT in
     test_var_set 'WIDEVINE_CERT'
 
     echo $WIDEVINE_CERT | base64 -d > $WIDEVINE_CERT_PATH
+    export AUTHENTICODE_ADD_DIGICERT_CROSS=true
     ;;
   *)
     exit 1

--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -42,7 +42,7 @@ if [ "$ENV" == "prod" ]; then
   export AUTHENTICODE_CA_PATH=/app/signingscript/src/signingscript/data/authenticode_prod_202005.crt
   export AUTHENTICODE_CA_TIMESTAMP_PATH=/usr/lib/ssl/certs/ca-certificates.crt
 fi
-if [ "$COT_PRODUCT" = "adhoc" ]; then
+if [ "$COT_PRODUCT" == "adhoc" ]; then
   export AUTHENTICODE_ADD_DIGICERT_CROSS=true
 else
   export AUTHENTICODE_ADD_DIGICERT_CROSS=false

--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -35,7 +35,7 @@ export AUTHENTICODE_CERT_PATH_202005=/app/signingscript/src/signingscript/data/a
 export AUTHENTICODE_CA_PATH=/app/signingscript/src/signingscript/data/authenticode_dep_ca.crt
 export AUTHENTICODE_CA_TIMESTAMP_PATH=/usr/lib/ssl/certs/ca-certificates.crt
 export AUTHENTICODE_CROSS_CERT_PATH=/app/signingscript/src/signingscript/data/authenticode_stub.crt
-export AUTHENTICODE_ADD_DIGICERT_CROSS=false
+export AUTHENTICODE_ADD_DIGICERT_CROSS=0
 if [ "$ENV" == "prod" ]; then
   export AUTHENTICODE_TIMESTAMP_STYLE=old
   export AUTHENTICODE_CERT_PATH=/app/signingscript/src/signingscript/data/authenticode_prod_202005.crt
@@ -68,7 +68,7 @@ case $COT_PRODUCT in
     test_var_set 'WIDEVINE_CERT'
 
     echo $WIDEVINE_CERT | base64 -d > $WIDEVINE_CERT_PATH
-    export AUTHENTICODE_ADD_DIGICERT_CROSS=true
+    export AUTHENTICODE_ADD_DIGICERT_CROSS=1
     ;;
   *)
     exit 1

--- a/signingscript/docker.d/worker.yml
+++ b/signingscript/docker.d/worker.yml
@@ -42,4 +42,4 @@ authenticode_cross_cert: { "$eval": "AUTHENTICODE_CROSS_CERT_PATH" }
 authenticode_timestamp_style: { "$eval": "AUTHENTICODE_TIMESTAMP_STYLE" }
 authenticode_timestamp_url: { "$eval": "AUTHENTICODE_TIMESTAMP_URL" }
 authenticode_url: "https://mozilla.org"
-authenticode_add_digicert_cross: { "$eval": "AUTHENTICODE_ADD_DIGICERT_CROSS == true" }
+authenticode_add_digicert_cross: { "$eval": "AUTHENTICODE_ADD_DIGICERT_CROSS" }

--- a/signingscript/docker.d/worker.yml
+++ b/signingscript/docker.d/worker.yml
@@ -42,4 +42,4 @@ authenticode_cross_cert: { "$eval": "AUTHENTICODE_CROSS_CERT_PATH" }
 authenticode_timestamp_style: { "$eval": "AUTHENTICODE_TIMESTAMP_STYLE" }
 authenticode_timestamp_url: { "$eval": "AUTHENTICODE_TIMESTAMP_URL" }
 authenticode_url: "https://mozilla.org"
-authenticode_add_digicert_cross: { "$eval": "AUTHENTICODE_ADD_DIGICERT_CROSS" }
+authenticode_add_digicert_cross: { "$eval": "AUTHENTICODE_ADD_DIGICERT_CROSS == '1'" }

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -1420,6 +1420,7 @@ async def sign_authenticode_file(context, orig_path, fmt, *, authenticode_commen
     )
     os.rename(outfile, infile)
     if context.config["authenticode_add_digicert_cross"]:
+        log.info("Adding Digicert Cross hack")
         with tempfile.TemporaryDirectory() as tmpdir:
             digicerthack.add_cert_to_signed_file(infile, outfile, os.path.join(tmpdir, "signature"), cafile, timestampfile)
         os.rename(outfile, infile)

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -1426,6 +1426,8 @@ async def sign_authenticode_file(context, orig_path, fmt, *, authenticode_commen
         with tempfile.TemporaryDirectory() as tmpdir:
             digicerthack.add_cert_to_signed_file(infile, outfile, os.path.join(tmpdir, "signature"), cafile, timestampfile)
         os.rename(outfile, infile)
+    else:
+        log.info("Digicert Cross hack is not enabled, skipping...")
 
     return True
 

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -1423,8 +1423,7 @@ async def sign_authenticode_file(context, orig_path, fmt, *, authenticode_commen
     os.rename(outfile, infile)
     if context.config["authenticode_add_digicert_cross"]:
         log.info("Adding Digicert Cross hack")
-        with tempfile.TemporaryDirectory() as tmpdir:
-            digicerthack.add_cert_to_signed_file(infile, outfile, cafile, timestampfile)
+        digicerthack.add_cert_to_signed_file(infile, outfile, cafile, timestampfile)
         os.rename(outfile, infile)
     else:
         log.info("Digicert Cross hack is not enabled, skipping...")

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -1404,19 +1404,21 @@ async def sign_authenticode_file(context, orig_path, fmt, *, authenticode_commen
         log.info("Not using specified comment to sign %s, not yet implemented for non *.msi files.", orig_path)
         authenticode_comment = None
 
+    winsign_kwargs = {
+        "cafile": cafile,
+        "timestampfile": timestampfile,
+        "url": url,
+        "comment": authenticode_comment,
+        "crosscert": crosscert,
+        "timestamp_style": timestamp_style,
+        "timestamp_url": timestamp_url,
+    }
+    log.info(f"running winsign.sign.sign_file with kwargs {winsign_kwargs}...")
     # Retry winsign.sign.sign_file, because the timestamp server can hiccup
     await retry_async(
         _winsign_helper,
         args=(f"Couldn't sign {orig_path}", infile, outfile, digest_algo, certs, signer),
-        kwargs={
-            "cafile": cafile,
-            "timestampfile": timestampfile,
-            "url": url,
-            "comment": authenticode_comment,
-            "crosscert": crosscert,
-            "timestamp_style": timestamp_style,
-            "timestamp_url": timestamp_url,
-        },
+        kwargs=winsign_kwargs,
     )
     os.rename(outfile, infile)
     if context.config["authenticode_add_digicert_cross"]:

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -1424,7 +1424,7 @@ async def sign_authenticode_file(context, orig_path, fmt, *, authenticode_commen
     if context.config["authenticode_add_digicert_cross"]:
         log.info("Adding Digicert Cross hack")
         with tempfile.TemporaryDirectory() as tmpdir:
-            digicerthack.add_cert_to_signed_file(infile, outfile, os.path.join(tmpdir, "signature"), cafile, timestampfile)
+            digicerthack.add_cert_to_signed_file(infile, outfile, cafile, timestampfile)
         os.rename(outfile, infile)
     else:
         log.info("Digicert Cross hack is not enabled, skipping...")

--- a/signingscript/tox.ini
+++ b/signingscript/tox.ini
@@ -8,9 +8,7 @@ usedevelop = false
 depends =
 skip_install = true
 commands =
-    docker build --build-arg PYTHON_VERSION=3.8 --build-arg PYTHON_REQ_SUFFIX=.py38 -t signingscript-{envname}-py38-test -f Dockerfile.test .
-    docker run --rm -v {toxinidir}:/app -v signingscript-{envname}-py38-tox:/app/.tox signingscript-{envname}-py38-test py38
-    docker build --build-arg PYTHON_VERSION=3.9.7 -t signingscript-{envname}-py39-test -f Dockerfile.test .
+    docker build --build-arg PYTHON_VERSION=3.9 -t signingscript-{envname}-py39-test -f Dockerfile.test .
     docker run --rm -v {toxinidir}:/app -v signingscript-{envname}-py39-tox:/app/.tox signingscript-{envname}-py39-test py39,check
 
 [testenv]
@@ -21,7 +19,6 @@ setenv =
     PYTHONPATH = {toxinidir}/tests
 deps=
     py39: -rrequirements/test.txt
-    py38: -rrequirements/test.py38.txt
     check: -rrequirements/test.txt
 
 commands =

--- a/signingscript/tox.ini
+++ b/signingscript/tox.ini
@@ -19,6 +19,7 @@ setenv =
     PYTHONPATH = {toxinidir}/tests
 deps=
     py39: -rrequirements/test.txt
+    py38: -rrequirements/test.py38.txt
     check: -rrequirements/test.txt
 
 commands =


### PR DESCRIPTION
- add timestamp logging
- fix local signingscript testing

Other than the number of args mismatch, the main issue where we weren't running the hack was:
- env vars are strings
- we were probably comparing against a bool, so it was always false