### PR TITLE
signingscript: don't try to add the digicert cross-cert to msix files

### DIFF
--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -28,6 +28,7 @@ from mardor.reader import MarReader
 from mardor.writer import add_signature_block
 from scriptworker.utils import get_single_item_from_sequence, makedirs, raise_future_exceptions, retry_async, rm
 from winsign.crypto import load_pem_certs
+from winsign.makemsix import is_msixfile
 
 from signingscript import digicerthack, task, utils
 from signingscript.createprecomplete import generate_precomplete
@@ -1421,7 +1422,7 @@ async def sign_authenticode_file(context, orig_path, fmt, *, authenticode_commen
         kwargs=winsign_kwargs,
     )
     os.rename(outfile, infile)
-    if context.config["authenticode_add_digicert_cross"]:
+    if context.config["authenticode_add_digicert_cross"] and not is_msixfile(infile):
         log.info("Adding Digicert Cross hack")
         digicerthack.add_cert_to_signed_file(infile, outfile, cafile, timestampfile)
         os.rename(outfile, infile)


### PR DESCRIPTION
MSIX files don't go through osslsigncode for signing, so the code
doesn't work there.