### PR TITLE
Fix bashism in pre-stop script

### DIFF
--- a/docker.d/pre-stop.sh
+++ b/docker.d/pre-stop.sh
@@ -30,7 +30,7 @@ while true; do
     fi
 
     now=$(date +%s)
-    duration=$[ $now - $started ]
+    duration=$(( $now - $started ))
 
     if [ $duration -gt $POLL_DURATION ]; then
         echo "Waited too long ($duration), giving up"


### PR DESCRIPTION
The `$[ ]` syntax for arithmetic expansion is bash specific and deprecated
even there.  Because the script is run by /bin/sh, that fails with:
```
/app/docker.d/pre-stop.sh: 33: 1653906858: not found
/app/docker.d/pre-stop.sh: 35: [: -gt: unexpected operator

```