### PR TITLE
re-add adhoc gpg release signing

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -392,6 +392,11 @@ in:
              {"$eval": "AUTOGRAPH_MAR_RELEASE_PASSWORD"},
              ["autograph_mar384", "autograph_hash_only_mar384"]
             ]
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+             {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+             ["autograph_gpg"]
+            ]
         '${scope_prefix[0]}cert:nightly-signing':
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_USERNAME"},


### PR DESCRIPTION
Copied the gecko-3 signing gpg user/pass to the adhoc-3 signing configs in k8s sops `5d0bac1fff4174bb471134523832da48d2b13d41` .