### PR TITLE
Bump pre-stop.sh's poll-duration for treescript

### DIFF
--- a/docker.d/pre-stop.sh
+++ b/docker.d/pre-stop.sh
@@ -10,7 +10,7 @@ SCRIPTWORKER_PID=${SCRIPTWORKER_PID:-1}
 # in case the task takes too long, this script exits 2 minutes before
 # `terminationGracePeriodSeconds` to let scriptworker upload files and report
 # `machine-shutdown` to Taskcluster.
-POLL_DURATION=1080
+POLL_DURATION=2700
 POLL_INTERVAL=5
 
 started=$(date +%s)

--- a/pushmsixscript/tests/test_microsoft_store.py
+++ b/pushmsixscript/tests/test_microsoft_store.py
@@ -98,10 +98,11 @@ def test_create_submission(status_code, raises):
             m.post(url, headers=headers, json=mocked_response, status_code=status_code)
             if raises:
                 with pytest.raises(requests.exceptions.HTTPError):
-                    submission_request = microsoft_store._create_submission(CONFIG, channel, session, headers)
+                    (submission_request, enc) = microsoft_store._create_submission(CONFIG, channel, session, headers)
             else:
-                submission_request = microsoft_store._create_submission(CONFIG, channel, session, headers)
+                (submission_request, enc) = microsoft_store._create_submission(CONFIG, channel, session, headers)
                 assert submission_request == mocked_response
+                assert enc == "utf-8"
 
 
 @pytest.mark.parametrize(
@@ -121,6 +122,7 @@ def test_update_submission(status_code, raises, publish_mode):
     submission_id = submission_request["id"]
     upload_url = submission_request["fileUploadUrl"]
     mocked_response = {"status": "OK"}
+    encoding = "utf-8"
     with tempfile.NamedTemporaryFile(mode="wb") as f:
         f.write(b"hello there")
         with requests.Session() as session:
@@ -131,9 +133,9 @@ def test_update_submission(status_code, raises, publish_mode):
                 with patch.object(microsoft_store, "BlobClient"):
                     if raises:
                         with pytest.raises(requests.exceptions.HTTPError):
-                            microsoft_store._update_submission(CONFIG, channel, session, submission_request, headers, [f.name], publish_mode)
+                            microsoft_store._update_submission(CONFIG, channel, session, submission_request, headers, [f.name], publish_mode, encoding)
                     else:
-                        microsoft_store._update_submission(CONFIG, channel, session, submission_request, headers, [f.name], publish_mode)
+                        microsoft_store._update_submission(CONFIG, channel, session, submission_request, headers, [f.name], publish_mode, encoding)
 
 
 @pytest.mark.parametrize(

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -392,6 +392,11 @@ in:
              {"$eval": "AUTOGRAPH_MAR_RELEASE_PASSWORD"},
              ["autograph_mar384", "autograph_hash_only_mar384"]
             ]
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+             {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+             ["autograph_gpg"]
+            ]
         '${scope_prefix[0]}cert:nightly-signing':
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_USERNAME"},


### PR DESCRIPTION
This PR targets the production-treescript branch to unblock merge day before we come up with a proper fix.