### PR TITLE
Bug 1777255 - Bump mozilla-version to 1.1.0

### DIFF
--- a/beetmoverscript/requirements/base.py38.txt
+++ b/beetmoverscript/requirements/base.py38.txt
@@ -358,9 +358,9 @@ mohawk==1.1.0 \
     --hash=sha256:3ed296a30453d0b724679e0fd41e4e940497f8e461a9a9c3b7f36e43bab0fa09 \
     --hash=sha256:d2a0e3ab10a209cc79e95e28f2dd54bd4a73fd1998ffe27b7ba0f962b6be9723
     # via taskcluster
-mozilla-version==1.0.1 \
-    --hash=sha256:9d6f50eb0b362106e468ba84cafd683d56cab153e252c2d272b135b5c65da48e \
-    --hash=sha256:eb913cc47fd244e8767d19eb53c68875ea77740eaf1ca518213c3e4b6b2f050b
+mozilla-version==1.1.0 \
+    --hash=sha256:1a56c1ea668ec10e18c0a2e394a79373b5ec0ea25a33d204ac6382f337cb9f8a \
+    --hash=sha256:1fdd9ed90eeec801852b981e98d5b4f6a69efee32eb5f492db86be97393ce4e9
     # via -r requirements/base.in
 multidict==6.0.2 \
     --hash=sha256:0327292e745a880459ef71be14e709aaea2f783f3537588fb4ed09b6c01bca60 \

--- a/beetmoverscript/requirements/base.txt
+++ b/beetmoverscript/requirements/base.txt
@@ -354,9 +354,9 @@ mohawk==1.1.0 \
     --hash=sha256:3ed296a30453d0b724679e0fd41e4e940497f8e461a9a9c3b7f36e43bab0fa09 \
     --hash=sha256:d2a0e3ab10a209cc79e95e28f2dd54bd4a73fd1998ffe27b7ba0f962b6be9723
     # via taskcluster
-mozilla-version==1.0.1 \
-    --hash=sha256:9d6f50eb0b362106e468ba84cafd683d56cab153e252c2d272b135b5c65da48e \
-    --hash=sha256:eb913cc47fd244e8767d19eb53c68875ea77740eaf1ca518213c3e4b6b2f050b
+mozilla-version==1.1.0 \
+    --hash=sha256:1a56c1ea668ec10e18c0a2e394a79373b5ec0ea25a33d204ac6382f337cb9f8a \
+    --hash=sha256:1fdd9ed90eeec801852b981e98d5b4f6a69efee32eb5f492db86be97393ce4e9
     # via -r requirements/base.in
 multidict==6.0.2 \
     --hash=sha256:0327292e745a880459ef71be14e709aaea2f783f3537588fb4ed09b6c01bca60 \

--- a/bouncerscript/requirements/base.py38.txt
+++ b/bouncerscript/requirements/base.py38.txt
@@ -294,9 +294,9 @@ mohawk==1.1.0 \
     --hash=sha256:3ed296a30453d0b724679e0fd41e4e940497f8e461a9a9c3b7f36e43bab0fa09 \
     --hash=sha256:d2a0e3ab10a209cc79e95e28f2dd54bd4a73fd1998ffe27b7ba0f962b6be9723
     # via taskcluster
-mozilla-version==1.0.1 \
-    --hash=sha256:9d6f50eb0b362106e468ba84cafd683d56cab153e252c2d272b135b5c65da48e \
-    --hash=sha256:eb913cc47fd244e8767d19eb53c68875ea77740eaf1ca518213c3e4b6b2f050b
+mozilla-version==1.1.0 \
+    --hash=sha256:1a56c1ea668ec10e18c0a2e394a79373b5ec0ea25a33d204ac6382f337cb9f8a \
+    --hash=sha256:1fdd9ed90eeec801852b981e98d5b4f6a69efee32eb5f492db86be97393ce4e9
     # via -r requirements/base.in
 multidict==6.0.2 \
     --hash=sha256:0327292e745a880459ef71be14e709aaea2f783f3537588fb4ed09b6c01bca60 \

--- a/bouncerscript/requirements/base.txt
+++ b/bouncerscript/requirements/base.txt
@@ -290,9 +290,9 @@ mohawk==1.1.0 \
     --hash=sha256:3ed296a30453d0b724679e0fd41e4e940497f8e461a9a9c3b7f36e43bab0fa09 \
     --hash=sha256:d2a0e3ab10a209cc79e95e28f2dd54bd4a73fd1998ffe27b7ba0f962b6be9723
     # via taskcluster
-mozilla-version==1.0.1 \
-    --hash=sha256:9d6f50eb0b362106e468ba84cafd683d56cab153e252c2d272b135b5c65da48e \
-    --hash=sha256:eb913cc47fd244e8767d19eb53c68875ea77740eaf1ca518213c3e4b6b2f050b
+mozilla-version==1.1.0 \
+    --hash=sha256:1a56c1ea668ec10e18c0a2e394a79373b5ec0ea25a33d204ac6382f337cb9f8a \
+    --hash=sha256:1fdd9ed90eeec801852b981e98d5b4f6a69efee32eb5f492db86be97393ce4e9
     # via -r requirements/base.in
 multidict==6.0.2 \
     --hash=sha256:0327292e745a880459ef71be14e709aaea2f783f3537588fb4ed09b6c01bca60 \

--- a/pushapkscript/requirements/base.py38.txt
+++ b/pushapkscript/requirements/base.py38.txt
@@ -542,9 +542,9 @@ mozapkpublisher==6.1.1 \
     --hash=sha256:efc5e19ab8f13c65f1f5e583fc3a9bb197d5f2f1fa2c38614ce965bb4262d10a \
     --hash=sha256:f132e4dea3343b7ca648d5f82b019e46cc0d03bb55fc83ebd3493d94cdf573c8
     # via -r requirements/base.in
-mozilla-version==1.0.1 \
-    --hash=sha256:9d6f50eb0b362106e468ba84cafd683d56cab153e252c2d272b135b5c65da48e \
-    --hash=sha256:eb913cc47fd244e8767d19eb53c68875ea77740eaf1ca518213c3e4b6b2f050b
+mozilla-version==1.1.0 \
+    --hash=sha256:1a56c1ea668ec10e18c0a2e394a79373b5ec0ea25a33d204ac6382f337cb9f8a \
+    --hash=sha256:1fdd9ed90eeec801852b981e98d5b4f6a69efee32eb5f492db86be97393ce4e9
     # via mozapkpublisher
 multidict==6.0.2 \
     --hash=sha256:0327292e745a880459ef71be14e709aaea2f783f3537588fb4ed09b6c01bca60 \

--- a/pushapkscript/requirements/base.txt
+++ b/pushapkscript/requirements/base.txt
@@ -538,9 +538,9 @@ mozapkpublisher==6.1.1 \
     --hash=sha256:efc5e19ab8f13c65f1f5e583fc3a9bb197d5f2f1fa2c38614ce965bb4262d10a \
     --hash=sha256:f132e4dea3343b7ca648d5f82b019e46cc0d03bb55fc83ebd3493d94cdf573c8
     # via -r requirements/base.in
-mozilla-version==1.0.1 \
-    --hash=sha256:9d6f50eb0b362106e468ba84cafd683d56cab153e252c2d272b135b5c65da48e \
-    --hash=sha256:eb913cc47fd244e8767d19eb53c68875ea77740eaf1ca518213c3e4b6b2f050b
+mozilla-version==1.1.0 \
+    --hash=sha256:1a56c1ea668ec10e18c0a2e394a79373b5ec0ea25a33d204ac6382f337cb9f8a \
+    --hash=sha256:1fdd9ed90eeec801852b981e98d5b4f6a69efee32eb5f492db86be97393ce4e9
     # via mozapkpublisher
 multidict==6.0.2 \
     --hash=sha256:0327292e745a880459ef71be14e709aaea2f783f3537588fb4ed09b6c01bca60 \

--- a/treescript/requirements/base.py38.txt
+++ b/treescript/requirements/base.py38.txt
@@ -315,9 +315,9 @@ mohawk==1.1.0 \
     --hash=sha256:3ed296a30453d0b724679e0fd41e4e940497f8e461a9a9c3b7f36e43bab0fa09 \
     --hash=sha256:d2a0e3ab10a209cc79e95e28f2dd54bd4a73fd1998ffe27b7ba0f962b6be9723
     # via taskcluster
-mozilla-version==1.0.1 \
-    --hash=sha256:9d6f50eb0b362106e468ba84cafd683d56cab153e252c2d272b135b5c65da48e \
-    --hash=sha256:eb913cc47fd244e8767d19eb53c68875ea77740eaf1ca518213c3e4b6b2f050b
+mozilla-version==1.1.0 \
+    --hash=sha256:1a56c1ea668ec10e18c0a2e394a79373b5ec0ea25a33d204ac6382f337cb9f8a \
+    --hash=sha256:1fdd9ed90eeec801852b981e98d5b4f6a69efee32eb5f492db86be97393ce4e9
     # via -r requirements/base.in
 multidict==6.0.2 \
     --hash=sha256:0327292e745a880459ef71be14e709aaea2f783f3537588fb4ed09b6c01bca60 \

--- a/treescript/requirements/base.txt
+++ b/treescript/requirements/base.txt
@@ -311,9 +311,9 @@ mohawk==1.1.0 \
     --hash=sha256:3ed296a30453d0b724679e0fd41e4e940497f8e461a9a9c3b7f36e43bab0fa09 \
     --hash=sha256:d2a0e3ab10a209cc79e95e28f2dd54bd4a73fd1998ffe27b7ba0f962b6be9723
     # via taskcluster
-mozilla-version==1.0.1 \
-    --hash=sha256:9d6f50eb0b362106e468ba84cafd683d56cab153e252c2d272b135b5c65da48e \
-    --hash=sha256:eb913cc47fd244e8767d19eb53c68875ea77740eaf1ca518213c3e4b6b2f050b
+mozilla-version==1.1.0 \
+    --hash=sha256:1a56c1ea668ec10e18c0a2e394a79373b5ec0ea25a33d204ac6382f337cb9f8a \
+    --hash=sha256:1fdd9ed90eeec801852b981e98d5b4f6a69efee32eb5f492db86be97393ce4e9
     # via -r requirements/base.in
 multidict==6.0.2 \
     --hash=sha256:0327292e745a880459ef71be14e709aaea2f783f3537588fb4ed09b6c01bca60 \


### PR DESCRIPTION
I just updated mozilla-version, although many packages could have been bumped too. We're on a Friday and I'd love to make a staging release[1] fully green. So I'm limiting the risk of regression by just bumping mozilla-version for now.  

[1] Like this one https://firefox-ci-tc.services.mozilla.com/tasks/groups/GPtOmmq5Rk6P0qnN-AG7KQ