### PR TITLE
RELENG-11 - Bump Android-Components versions

### DIFF
--- a/bouncerscript/src/bouncerscript/task.py
+++ b/bouncerscript/src/bouncerscript/task.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from mozilla_version.gecko import FennecVersion, FirefoxVersion
+from mozilla_version.gecko import FirefoxVersion
 from scriptworker import client
 from scriptworker.exceptions import ScriptWorkerTaskException, TaskVerificationError
 from scriptworker.utils import retry_request
@@ -18,7 +18,9 @@ from bouncerscript.constants import (
 log = logging.getLogger(__name__)
 
 
-version_map = {"firefox": FirefoxVersion, "fennec": FennecVersion}
+version_map = {
+    "firefox": FirefoxVersion,
+}
 
 
 def get_task_server(task, script_config):
@@ -158,17 +160,6 @@ def check_versions_are_successive(current_version, payload_version, product):
         candidate_version = FirefoxVersion.parse(payload_version)
 
         _successive_sanity(current_bouncer_version.major_number, candidate_version.major_number)
-    elif product == "fennec":
-        # XXX: this will fail for the next ESR cut, on 75, since that will be a
-        # major_number bump, but also a minor_number. But cutting ESR releases
-        # can vary over time (could be 7 releases or 8 like ESR8, etc);
-        # It's unrecommended to hardcode those variable window times here
-        # in order to ensure the check; So for now we leave this code smell here.
-        # Real fix is to centralize this operation and implement it in mozilla-version directly
-        current_bouncer_version = FennecVersion.parse(current_version)
-        candidate_version = FennecVersion.parse(payload_version)
-
-        _successive_sanity(current_bouncer_version.minor_number, candidate_version.minor_number)
     else:
         err_msg = "Unknown product {} in the payload".format(product)
         raise ScriptWorkerTaskException(err_msg)

--- a/bouncerscript/tests/test_task.py
+++ b/bouncerscript/tests/test_task.py
@@ -129,13 +129,6 @@ def test_validate_task_schema(submission_context, schema="submission"):
         ({"firefox-sha1": "Firefox-52.7.2esr-sha1", "firefox-sha1-ssl": "Firefox-70.1.2esr-sha1"}, False),
         ({"firefox-sha1": "Firefox-70.1.0esr", "firefox-sha1-ssl": "Firefox-70.1.2-sha1"}, True),
         ({"firefox-sha1": "Firefox-70.1.0esr", "firefox-sha1-ssl": "Firefox-70.1.2esr-sha1"}, True),
-        ({"fennec-beta-latest": "Fennec-70.0b2"}, False),
-        ({"fennec-latest": "Fennec-70.0"}, False),
-        ({"fennec-beta-latest": "Fennec-70.0"}, True),
-        ({"fennec-latest": "Fennec-70.0.1-SSL"}, True),
-        ({"fennec-beta-latest": "Fennec-70.0.1"}, True),
-        ({"fennec-latest": "Fennec-70.0b1"}, True),
-        ({"fennec-latest": "Fennec-70.0.1"}, False),
         ({"thunderbird-beta-latest": "Thunderbird-70.0b2"}, False),
         ({"thunderbird-beta-latest-ssl": "Thunderbird-70.0b2-SSL"}, False),
         ({"thunderbird-beta-msi-latest-ssl": "Thunderbird-70.0b2-msi-SSL"}, False),
@@ -175,17 +168,6 @@ def test_check_product_names_match_aliases(aliases_context, entries, raises):
         (["a", "b"], {"aaaa": "a", "bbbb": "b"}, False),
         (["a", "b"], {"aaaa": "b", "bbbb": "a"}, False),
         ([], {}, False),
-        (
-            [
-                "/mobile/releases/62.0b10/android-x86/:lang/fennec-62.0b10.:lang.android-i386.apk",
-                "/mobile/releases/62.0b10/android-api-16/:lang/fennec-62.0b10.:lang.android-arm.apk",
-            ],
-            {
-                "android": "/mobile/releases/62.0b10/android-api-16/:lang/fennec-62.0b10.:lang.android-arm.apk",
-                "android-x86": "/mobile/releases/62.0b10/android-x86/:lang/fennec-62.0b10.:lang.android-i386.apk",
-            },
-            False,
-        ),
         (["a"], {"a": "b"}, True),
         ([], {"a": "b"}, True),
     ),
@@ -204,9 +186,6 @@ def test_check_locations_match(locations, product_config, raises):
     (
         (
             ("Firefox-61.0b15-SSL", "/firefox/releases/61.0b15/mac/:lang/Firefox%2061.0b15.dmg", False),
-            ("Fennec-61.0b15", "/mobile/releases/61.0b15/android-x86/:lang/fennec-61.0b15.:lang.android-i386.apk", False),
-            ("Fennec-61.0b15", "/mobile/releases/61.0b15/android-x86/:lang/fennec-61.0b15.:lang.android-i386.apk", False),
-            ("Fennec-61.0b15", "/firefox/releases/61.0b15/update/mac/:lang/firefox-61.0b15-61.0b15.partial.mar", True),
             ("Firefox-61.0b15", "/firefox/releases/61.0b15/linux-x86_64/:lang/firefox-61.0b15.tar.bz2", False),
             ("Firefox-61.0b15", "/firefox/releases/61.0b15/win64/:lang/Firefox%20Setup%2061.0b15.exe", False),
             ("Firefox-65.0b13-msi-SSL", "/firefox/releases/65.0b13/win64/:lang/Firefox%20Setup%2065.0b13.msi", False),
@@ -222,7 +201,6 @@ def test_check_locations_match(locations, product_config, raises):
             ("Firefox-61.0b15-Complete", "/firefox/releases/61.0b15/update/linux-i686/:lang/firefox-61.0b15.complete.mar", False),
             ("Firefox-61.0b15-Complete", "/firefox/releases/61.0b15/update/mac/:lang/firefox-61.0b15.complete.marx", True),
             ("Firefox-61.0b15-Partial-61.0b15", "/firefox/releases/61.0b15/update/linux-x86_64/:lang/firefox-61.0b15-61.0b15.partial.mar", False),
-            ("Firefox-61.0b15-Partial-61.0b15", "/firefox/releases/61.0b15/update/win32/:lang/fennec-61.0b15-61.0b15.partial.mar", True),
             ("Firefox-61.0b15-Partial-61.0b15", "/firefox/releases/61.0b15/update/win64/:lang/firefox-61.0b15-61.0b15.partial.mar", False),
             ("Firefox-61.0b15-SSL", "/firefox/releases/61.0b15/linux-i686/:lang/firefox-61.0b15.tar.bz2", False),
             ("Firefox-61.0b15-SSL", "/firefox/releases/61.0b15/win64/Firefox%20Setup%2061.0b15.exe", True),
@@ -271,17 +249,6 @@ def test_check_path_matches_destination(product_name, path, raises):
     "entries,provided,raises",
     (
         (
-            (
-                {"fennec-beta-latest": "Fennec-62.0b5", "fennec-latest": "Fennec-61.0"},
-                {
-                    ("https://download.mozilla.org/?product=" "fennec-beta-latest&print=yes"): "404 page not found\n",
-                    ("https://download.mozilla.org/?product=" "fennec-latest&print=yes"): "404 page not found\n",
-                    ("https://download.mozilla.org/?product=" "thunderbird-next-latest-ssl&print=yes"): "404 page not found\n",
-                    ("https://download.mozilla.org/?product=" "thunderbird-next-latest&print=yes"): "404 page not found\n",
-                    ("https://download.mozilla.org/?product=" "thunderbird-latest-ssl&print=yes"): "404 page not found\n",
-                },
-                False,
-            ),
             (
                 {"firefox-latest": "Firefox-61.0.1", "firefox-latest-ssl": "Firefox-61.0.1-SSL", "firefox-stub": "Firefox-61.0.1-stub"},
                 {
@@ -388,9 +355,6 @@ async def test_check_aliases_match(aliases_context, mocker, entries, provided, r
             (["firefox-nightly-latest", "firefox-nightly-latest-ssl"], True),
             (["firefox-nightly-latest-l10n", "firefox-nightly-latest-l10n-ssl"], True),
             (["firefox-latest"], True),
-            (["fennec-nightly-latest"], False),
-            (["fennec-nightly-latest", "firefox-latest"], True),
-            (["fennec-nightly-latest", "firefox-nightly-latest", "firefox-nightly-latest-ssl", "firefox-nightly-latest-l10n", "firefox-nightly-latest-l10n-ssl"], True),
         )
     ),
 )
@@ -416,32 +380,6 @@ def test_check_product_names_match_nightly_locations(locations_context, products
             ("63.0", "firefox", (True, ScriptWorkerTaskException)),
             ("ZFJSh389fjSMN<@<Ngv", "firefox", (True, PatternNotMatchedError)),
             ("63", "firefox", (True, PatternNotMatchedError)),
-            ("68.1a1", "fennec", (False, None)),
-            ("68.0b3", "fennec", (True, ScriptWorkerTaskException)),
-            ("68.0b17", "fennec", (True, ScriptWorkerTaskException)),
-            ("68.0", "fennec", (True, ScriptWorkerTaskException)),
-            ("68.0.1", "fennec", (True, ScriptWorkerTaskException)),
-            ("68.1b2", "fennec", (True, ScriptWorkerTaskException)),
-            ("68.1.0", "fennec", (True, ScriptWorkerTaskException)),
-            ("68.1b3", "fennec", (True, ScriptWorkerTaskException)),
-            ("68.1.1", "fennec", (True, ScriptWorkerTaskException)),
-            ("68.2a1", "fennec", (False, None)),
-            ("68.2b1", "fennec", (True, ScriptWorkerTaskException)),
-            ("68.0.1a1", "fennec", (True, PatternNotMatchedError)),
-            ("68.1a1b1", "fennec", (True, PatternNotMatchedError)),
-            ("68.0.1b1", "fennec", (True, PatternNotMatchedError)),
-            ("68.1.0a1", "fennec", (True, PatternNotMatchedError)),
-            ("68.1.0b1", "fennec", (True, PatternNotMatchedError)),
-            ("68.1.1a1", "fennec", (True, PatternNotMatchedError)),
-            ("68.1.1b2", "fennec", (True, PatternNotMatchedError)),
-            ("69.0a1", "fennec", (True, PatternNotMatchedError)),
-            ("69.0b3", "fennec", (True, PatternNotMatchedError)),
-            ("69.0", "fennec", (True, PatternNotMatchedError)),
-            ("69.0.1", "fennec", (True, PatternNotMatchedError)),
-            ("63.0.1", "fennec", (True, ScriptWorkerTaskException)),
-            ("63.0", "fennec", (True, ScriptWorkerTaskException)),
-            ("ZFJSh389fjSMN<@<Ngv", "fennec", (True, PatternNotMatchedError)),
-            ("63", "fennec", (True, PatternNotMatchedError)),
         )
     ),
 )
@@ -516,12 +454,6 @@ def test_check_version_matches_nightly_regex(version, product, raises):
             ("firefox-nightly-latest-l10n", "/firefox/nightly/latest-mozilla-central-l10n/firefox-63.0b1.:lang.linux-x86_64.tar.bz2", True),
             ("firefox-nightly-latest-l10n", "/firefox/nightly/latest-mozilla-central-l10n/firefox-63.0b1.:lang.mac.dmg", True),
             ("firefox-nightly-latest-l10n", "/firefox/nightly/latest-mozilla-central-l10n/firefox-63.0.1.:lang.win64.installer.exe", True),
-            ("fennec-nightly-latest", "/mobile/nightly/latest-mozilla-esr68-android-api-16/fennec-68.1a1.:lang.android-arm.apk", False),
-            ("fennec-nightly-latest", "/mobile/nightly/latest-mozilla-esr68-android-api-16/fennec-68.1a1.:lang.android-arm.apk", False),
-            ("fennec-nightly-latest", "/firefox/nightly/latest-mozilla-central-l10n/firefox-63.0.1.:lang.win64.installer.exe", True),
-            ("fennec-nightly-latest", "/firefox/nightly/latest-mozilla-central-l10n/firefox-63.0.1.:lang.win64.installer.exe", True),
-            ("fennec-nightly-latest", "/mobile/nightly/latest-mozilla-central-l10n/android-api-16/fennec-68.1a1.:lang.android-arm.apk", True),
-            ("fennec-nightly-latest", "/mobile/nightly/latest-mozilla-esr68-android-api-16/fennec-68.1b1.:lang.android-arm.apk", True),
         )
     ),
 )
@@ -542,12 +474,6 @@ def test_check_location_path_matches_destination(product_name, path, raises):
             ("63.0a1", "63.0a1", "firefox", True),
             ("63.0a1", "65.0a1", "firefox", True),
             ("64.0a1", "63.0a1", "firefox", True),
-            ("68.1a1", "68.2a1", "fennec", False),
-            ("68.7a1", "68.8a1", "fennec", False),
-            ("68.7a1", "68.8a1", "fennec", False),
-            ("68.1a1", "68.1a1", "fennec", True),
-            ("68.1a1", "68.3a1", "fennec", True),
-            ("68.2a1", "68.1a1", "fennec", True),
             ("68.2a1", "68.1a1", "VNSJKSGH#(*#HG#LG@()", True),
         )
     ),

--- a/treescript/src/treescript/git.py
+++ b/treescript/src/treescript/git.py
@@ -96,10 +96,11 @@ async def log_outgoing(config, task, repo_path):
     repo = Repo(repo_path)
     branch = get_branch(task, "master")
 
-    upstream_to_local_branch_interval = "{}..{}".format(_get_upstream_branch_name(branch), branch)
+    upstream_branch = _get_upstream_branch_name(branch)
+    upstream_to_local_branch_interval = f"{upstream_branch}..{branch}"
     log.debug("Checking the number of changesets between these 2 references: {}".format(upstream_to_local_branch_interval))
     num_changesets = len(list(repo.iter_commits(upstream_to_local_branch_interval)))
-    diff = repo.git.diff(branch)
+    diff = repo.git.diff(upstream_branch)
 
     if diff:
         path = os.path.join(config["artifact_dir"], "public", "logs", "outgoing.diff")

--- a/treescript/src/treescript/versionmanip.py
+++ b/treescript/src/treescript/versionmanip.py
@@ -5,7 +5,7 @@ import logging
 import os
 
 from mozilla_version.fenix import FenixVersion
-from mozilla_version.gecko import FennecVersion, FirefoxVersion, GeckoVersion, ThunderbirdVersion
+from mozilla_version.gecko import FirefoxVersion, GeckoVersion, ThunderbirdVersion
 
 from treescript.exceptions import TaskVerificationError, TreeScriptError
 from treescript.task import DONTBUILD_MSG, get_dontbuild, get_vcs_module, get_version_bump_info
@@ -25,7 +25,6 @@ ALLOWED_BUMP_FILES = (
 _VERSION_CLASS_PER_BEGINNING_OF_PATH = {
     "browser/": FirefoxVersion,
     "config/milestone.txt": GeckoVersion,
-    "mobile/android/": FennecVersion,
     "mail/": ThunderbirdVersion,
     "version.txt": FenixVersion,
 }

--- a/treescript/tests/test_git.py
+++ b/treescript/tests/test_git.py
@@ -113,7 +113,7 @@ async def test_log_outgoing(config, task, mocker, output):
 
     assert number_of_changesets == 2
     repo_mock.iter_commits.assert_called_once_with("origin/master..master")
-    repo_mock.git.diff.assert_called_once_with("master")
+    repo_mock.git.diff.assert_called_once_with("origin/master")
     if output:
         with open(os.path.join(config["artifact_dir"], "public", "logs", "outgoing.diff"), "r") as fh:
             assert fh.read().rstrip() == output

--- a/treescript/tests/test_merges.py
+++ b/treescript/tests/test_merges.py
@@ -196,7 +196,7 @@ async def test_apply_rebranding(config, repo_context, mocker, merge_config, expe
     def noop_replace(*arguments, **kwargs):
         called_args.append("replace")
 
-    def mocked_get_version(path, repo_path):
+    def mocked_get_version(path, repo_path, source_repo):
         return FirefoxVersion.parse("76.0")
 
     mocker.patch.object(merges, "get_version", new=mocked_get_version)
@@ -205,7 +205,7 @@ async def test_apply_rebranding(config, repo_context, mocker, merge_config, expe
     mocker.patch.object(merges, "replace", new=noop_replace)
     mocker.patch.object(merges, "touch_clobber_file", new=sync_noop)
 
-    await merges.apply_rebranding(config, repo_context.repo, merge_config)
+    await merges.apply_rebranding(config, repo_context.repo, merge_config, "https://hg.mozilla.org/repo")
     assert called_args[0] == expected
 
 
@@ -227,12 +227,12 @@ async def test_apply_rebranding(config, repo_context, mocker, merge_config, expe
     ),
 )
 async def test_create_new_version(config, mocker, version_config, current_version, expected):
-    def mocked_get_version(path, repo_path):
+    def mocked_get_version(path, repo_path, source_repo):
         return current_version
 
     mocker.patch.object(merges, "get_version", new=mocked_get_version)
 
-    result = merges.create_new_version(version_config, repo_path="")  # Dummy repo_path, ignored.
+    result = merges.create_new_version(version_config, repo_path="", source_repo="https://hg.mozilla.org/repo")  # Dummy repo_path, ignored.
     assert result == expected
 
 

--- a/treescript/tests/test_merges.py
+++ b/treescript/tests/test_merges.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 
 import hglib
 import pytest
-from mozilla_version.gecko import FennecVersion, FirefoxVersion
+from mozilla_version.gecko import FirefoxVersion
 
 import treescript.merges as merges
 from treescript.exceptions import TaskVerificationError
@@ -224,10 +224,6 @@ async def test_apply_rebranding(config, repo_context, mocker, merge_config, expe
         # bump_esr
         ({"filename": "browser/config/version.txt", "version_bump": "minor"}, FirefoxVersion.parse("68.1.0"), "68.2.0"),
         ({"filename": "browser/config/version_display.txt", "version_bump": "minor"}, FirefoxVersion.parse("68.1.0esr"), "68.2.0esr"),
-        ({"filename": "mobile/android/config/version-files/beta/version.txt", "version_bump": "minor"}, FennecVersion.parse("68.1"), "68.2"),
-        ({"filename": "mobile/android/config/version-files/beta/version_display.txt", "version_bump": "minor"}, FennecVersion.parse("68.1b9"), "68.2b1"),
-        ({"filename": "mobile/android/config/version-files/nightly/version.txt", "version_bump": "minor"}, FennecVersion.parse("68.1a1"), "68.2a1"),
-        ({"filename": "mobile/android/config/version-files/release/version.txt", "version_bump": "minor"}, FennecVersion.parse("68.6.1"), "68.7.0"),
     ),
 )
 async def test_create_new_version(config, mocker, version_config, current_version, expected):

--- a/treescript/tests/test_versionmanip.py
+++ b/treescript/tests/test_versionmanip.py
@@ -2,7 +2,7 @@ import os
 from contextlib import contextmanager
 
 import pytest
-from mozilla_version.gecko import FennecVersion, FirefoxVersion, GeckoVersion, ThunderbirdVersion
+from mozilla_version.gecko import FirefoxVersion, GeckoVersion, ThunderbirdVersion
 
 import treescript.versionmanip as vmanip
 from treescript.exceptions import TaskVerificationError, TreeScriptError
@@ -81,10 +81,6 @@ def test_replace_ver_in_file_invalid_old_ver(repo_context, new_version):
         ("mail/config/version.txt", does_not_raise(), ThunderbirdVersion),
         ("mail/config/version_display.txt", does_not_raise(), ThunderbirdVersion),
         ("config/milestone.txt", does_not_raise(), GeckoVersion),
-        ("mobile/android/config/version-files/beta/version.txt", does_not_raise(), FennecVersion),
-        ("mobile/android/config/version-files/beta/version_display.txt", does_not_raise(), FennecVersion),
-        ("mobile/android/config/version-files/release/version.txt", does_not_raise(), FennecVersion),
-        ("mobile/android/config/version-files/release/version_display.txt", does_not_raise(), FennecVersion),
         ("some/random/file.txt", pytest.raises(TreeScriptError), None),
     ),
 )


### PR DESCRIPTION
Fixes this error[1]:

```
mozilla_version.errors.PatternNotMatchedError: "104.0.0" does not match the pattern: Minor number and patch number cannot be both equal to 0
```

The error itself is caused by [bug 1777255](https://bugzilla.mozilla.org/show_bug.cgi?id=1777255). However, this is isn't the root cause. Android-Components follow the Maven version number scheme. Thus, I made the changes to follow that. 

Tested at [2]. By the way, `outgoing.diff` is now exposed and contains:

```diff
diff --git a/version.txt b/version.txt
index 18cf10229f..5fa45906ac 100644
--- a/version.txt
+++ b/version.txt
@@ -1 +1 @@
-104.0.0
+104.0.1
```

I also took the liberty of pruning `FennecVersion` since Fennec doesn't exist anymore. 

[1] https://firefox-ci-tc.services.mozilla.com/tasks/fMYm7gRiTgCpGLNzUyo8Xg/runs/0/logs/public/logs/live_backing.log
[2] https://firefox-ci-tc.services.mozilla.com/tasks/I07q0GGOQPSy-KLV5otYtw/runs/2