### PR TITLE
Add MIME types for Qt .rcc and .sig files in beetmoverscript

### DIFF
--- a/beetmoverscript/src/beetmoverscript/constants.py
+++ b/beetmoverscript/src/beetmoverscript/constants.py
@@ -18,9 +18,11 @@ MIME_MAP = {
     ".msix": "application/msix",
     ".pkg": "application/x-newton-compatible-pkg",
     ".pom": "application/xml",
+    ".rcc": "application/octet-stream",
     ".sha1": "text/plain",
     ".sha256": "text/plain",
     ".sha512": "text/plain",
+    ".sig": "application/octet-stream",
     ".snap": "application/octet-stream",
     ".xpi": "application/x-xpinstall",
 }


### PR DESCRIPTION
The VPN addons are Qt `.rcc` files ([see](https://doc.qt.io/qtforpython/overviews/resources.html#the-qt-resource-compiler-rcc)) These are compiled binary files so `application/octet-stream` seems appropriate. 

The `.sig` file is the detached signature for the addons manifest. Looking at [@ahal's WIP](https://github.com/mozilla-releng/scriptworker-scripts/commit/7ecceb928257aed0a96ca8f372b3b354885663f7), I think `application/octet-stream` is the right MIME type for that too.