### PR TITLE
Bug 1791366 - Temporarily increase treescript timeout to 4 hours

### DIFF
--- a/docker.d/pre-stop.sh
+++ b/docker.d/pre-stop.sh
@@ -13,7 +13,8 @@ SCRIPTWORKER_PID=${SCRIPTWORKER_PID:-1}
 # to let scriptworker upload files and report `worker-shutdown` to Taskcluster.
 case ${PROJECT_NAME} in
     tree)
-        POLL_DURATION=3480
+        # TODO bug 1791366: Reset timeout back to 3490s
+        POLL_DURATION=14280
         ;;
     *)
         POLL_DURATION=1080


### PR DESCRIPTION
Must be merged at the same time as https://github.com/mozilla-services/cloudops-infra/pull/4364