### PR TITLE
Add copy-artifacts action

### DIFF
--- a/beetmoverscript/src/beetmoverscript/constants.py
+++ b/beetmoverscript/src/beetmoverscript/constants.py
@@ -84,6 +84,8 @@ RELEASE_ACTIONS = ("push-to-releases",)
 
 DIRECT_RELEASE_ACTIONS = ("direct-push-to-bucket",)
 
+DIRECT_COPY_ACTIONS = ("copy-artifacts",)
+
 PARTNER_REPACK_ACTIONS = ("push-to-partner",)
 
 MAVEN_ACTIONS = ("push-to-maven",)

--- a/beetmoverscript/src/beetmoverscript/data/copy_artifacts_beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/copy_artifacts_beetmover_task_schema.json
@@ -1,0 +1,68 @@
+{
+  "title": "Taskcluster beetmover copy-artifacts task schema",
+  "type": "object",
+  "properties": {
+    "dependencies": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "product": {
+          "type": "string"
+        },
+        "copy_from": {
+          "type": "string"
+        },
+        "copy_to": {
+          "type": "string"
+        },
+        "exclude_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "maxRunTime": {
+          "type": "number"
+        },
+        "upstreamArtifacts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "taskType": {
+                "type": "string"
+              },
+              "locale": {
+                "type": "string"
+              },
+              "taskId": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": ["taskId", "taskType", "paths"]
+          },
+          "minItems": 0,
+          "uniqueItems": true
+        }
+      },
+      "required": ["product", "copy_from", "copy_to"]
+    }
+  },
+  "required": ["payload", "dependencies"]
+}

--- a/beetmoverscript/src/beetmoverscript/task.py
+++ b/beetmoverscript/src/beetmoverscript/task.py
@@ -26,6 +26,8 @@ def get_schema_key_by_action(context):
         return "maven_schema_file"
     elif utils.is_direct_release_action(action):
         return "artifactMap_schema_file"
+    elif utils.is_copy_artifacts_action(action):
+        return "copy_artifacts_schema_file"
 
     return "schema_file"
 

--- a/beetmoverscript/src/beetmoverscript/utils.py
+++ b/beetmoverscript/src/beetmoverscript/utils.py
@@ -14,6 +14,7 @@ import yaml
 from scriptworker.exceptions import TaskVerificationError
 
 from beetmoverscript.constants import (
+    DIRECT_COPY_ACTIONS,
     DIRECT_RELEASE_ACTIONS,
     HASH_BLOCK_SIZE,
     MAVEN_ACTIONS,
@@ -123,6 +124,10 @@ def is_partner_action(action):
     nightly or something else. Does that by checking the action type.
     """
     return action in PARTNER_REPACK_ACTIONS
+
+
+def is_copy_artifacts_action(action):
+    return action in DIRECT_COPY_ACTIONS
 
 
 def is_maven_action(action):


### PR DESCRIPTION
Adds `copy-artifacts` action to `beetmoverscript` to move away from re-uploading artifacts from builds (useful in projects that don't use balrog and for non-app artifacts)

Like direct-push-to-bucket but it copies.