### PR TITLE
treescript: don't append "esr" to all files on version bump

### DIFF
--- a/treescript/src/treescript/versionmanip.py
+++ b/treescript/src/treescript/versionmanip.py
@@ -162,6 +162,9 @@ async def do_bump_version(config, repo_path, files, next_version, source_repo):
             )
         ):
             next_version = VersionClass.parse("{}esr".format(next_version))
+        if not is_esr and next_version.is_esr:
+            # if the file had no esr prefix then don't add it
+            next_version = VersionClass.parse(str(next_version)[:-3])
 
         if next_version < curr_version:
             log.warning("Version bumping skipped due to conflicting values: " "(next version {} is < current version {})".format(next_version, curr_version))

--- a/treescript/tests/test_versionmanip.py
+++ b/treescript/tests/test_versionmanip.py
@@ -96,11 +96,13 @@ def test_find_what_version_parser_to_use(file, source_repo, expectation, expecte
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("new_version, should_append_esr", (("68.0", True), ("68.0b3", False)))
+@pytest.mark.parametrize("new_version, should_append_esr", (("68.0", True), ("68.0b3", False), ("68.0esr", False)))
 async def test_bump_version(mocker, repo_context, new_version, should_append_esr):
     test_version = new_version
     if repo_context.xtest_version.endswith("esr") and should_append_esr:
         test_version = new_version + "esr"
+    if new_version.endswith("esr") and not repo_context.xtest_version.endswith("esr"):
+        test_version = new_version[:-3]
 
     relative_files = [os.path.join("config", "milestone.txt")]
     bump_info = {"files": relative_files, "next_version": new_version}


### PR DESCRIPTION
On ESR, the display version (in browser/config/version_display.txt) has an "esr" suffix, but the milestone (in config/milestone.txt) and application version (in browser/config/version.txt) don't.  Our post-release version-bump task has a "next_version" with the "esr" suffix, so we were adding it to all version files, and breaking expectations.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1786807