### PR TITLE
[signingscript] Bug 1786777 - Add firefox-android scope prefix

### DIFF
--- a/signingscript/docker.d/worker.yml
+++ b/signingscript/docker.d/worker.yml
@@ -15,6 +15,7 @@ taskcluster_scope_prefixes:
         - 'project:mobile:fenix:releng:signing:'
         - 'project:mobile:fennec-profile-manager:releng:signing:'
         - 'project:mobile:firefox-tv:releng:signing:'
+        - 'project:mobile:firefox-android:releng:signing:'
         - 'project:mobile:focus:releng:signing:'
         - 'project:mobile:focus-android:releng:signing:'
         - 'project:mobile:reference-browser:releng:signing:'


### PR DESCRIPTION
Trying to get nightly signing working on staging-firefox-android. This should fix:
https://firefox-ci-tc.services.mozilla.com/tasks/WnXEIAZWT4e7vXmgcWqc6A/runs/0/logs/public/logs/live_backing.log
```
Traceback (most recent call last):
  File "/app/lib/python3.9/site-packages/scriptworker/client.py", line 205, in _handle_asyncio_loop
    await async_main(context)
  File "/app/lib/python3.9/site-packages/signingscript/script.py", line 42, in async_main
    output_files = await sign(context, os.path.join(work_dir, path), path_dict["formats"], authenticode_comment=path_dict.get("comment"))
  File "/app/lib/python3.9/site-packages/signingscript/task.py", line 156, in sign
    output = await signing_func(context, output, fmt, **kwargs)
  File "/app/lib/python3.9/site-packages/signingscript/sign.py", line 97, in wrapped
    return await f(*args, **kwargs)
  File "/app/lib/python3.9/site-packages/signingscript/sign.py", line 1084, in sign_gpg_with_autograph
    cert_type = task.task_cert_type(context)
  File "/app/lib/python3.9/site-packages/signingscript/task.py", line 83, in task_cert_type
    return get_single_item_from_sequence(
  File "/app/lib/python3.9/site-packages/scriptworker/utils.py", line 929, in get_single_item_from_sequence
    raise ErrorClass(error_message)
scriptworker.exceptions.TaskVerificationError: No scope starting with any of these prefixes ['project:mobile:android-components:releng:signing:cert:', 'project:mobile:fenix:releng:signing:cert:', 'project:mobile:fennec-profile-manager:releng:signing:cert:', 'project:mobile:firefox-tv:releng:signing:cert:', 'project:mobile:focus:releng:signing:cert:', 'project:mobile:focus-android:releng:signing:cert:', 'project:mobile:reference-browser:releng:signing:cert:'] found. Given: []
exit code: 3
```