### PR TITLE
[beetmoverscript] Bug 1786777 - Add firefox-android scope prefix

### DIFF
--- a/beetmoverscript/docker.d/worker.yml
+++ b/beetmoverscript/docker.d/worker.yml
@@ -15,6 +15,7 @@ taskcluster_scope_prefixes:
         - 'project:mobile:android-components:releng:beetmover:'
         - 'project:mobile:focus-android:releng:beetmover:'
         - 'project:mobile:fenix:releng:beetmover:'
+        - 'project:mobile:firefox-android:releng:beetmover:'
       'COT_PRODUCT == "app-services"':
         - 'project:mozilla:app-services:releng:beetmover:'
       'COT_PRODUCT == "glean"':


### PR DESCRIPTION
Trying to get nightly beetmoving working on staging-firefox-android. This should fix:
https://firefox-ci-tc.services.mozilla.com/tasks/a8mMXZ12RcmpDAdrGFGCxg/runs/0/logs/public/logs/live_backing.log