### PR TITLE
[flatpakscript] Fix coverage reporting

### DIFF
--- a/pushflatpakscript/tox.ini
+++ b/pushflatpakscript/tox.ini
@@ -14,6 +14,7 @@ commands =
     docker run --rm -v {toxinidir}:/app -v pushflatpakscript-{envname}-py39-tox:/app/.tox pushflatpakscript-{envname}-py39-test py39,check
 
 [testenv]
+depends = clean
 setenv =
     PYTHONDONTWRITEBYTECODE=1
 deps =
@@ -26,6 +27,7 @@ commands=
 
 [testenv:clean]
 skip_install = true
+deps = coverage
 commands = coverage erase
 depends =
 
@@ -40,7 +42,6 @@ skip_install = true
 ignore_errors = true
 commands =
     black --diff --check {toxinidir}
-#    isort --check --diff {toxinidir}
     isort --check --diff {toxinidir}
     pip-compile-multi verify
     flake8 {toxinidir}

--- a/pushflatpakscript/tox.ini
+++ b/pushflatpakscript/tox.ini
@@ -14,6 +14,7 @@ commands =
     docker run --rm -v {toxinidir}:/app -v pushflatpakscript-{envname}-py39-tox:/app/.tox pushflatpakscript-{envname}-py39-test py39,check
 
 [testenv]
+usedevelop = true
 depends = clean
 setenv =
     PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
Running 'tox' locally for flatpakscript was generating a coverage report with all 0%; this sorts it out.