### PR TITLE
test: initialize `context.task["scopes"]` in the context test fixture

### DIFF
--- a/signingscript/tests/conftest.py
+++ b/signingscript/tests/conftest.py
@@ -19,6 +19,7 @@ def read_file(path):
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 SERVER_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "example_server_config.json")
 DEFAULT_SCOPE_PREFIX = "project:releng:signing:"
+TEST_CERT_TYPE = f"{DEFAULT_SCOPE_PREFIX}cert:dep-signing"
 TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 PUB_KEY_PATH = os.path.join(TEST_DATA_DIR, "id_rsa.pub")
 PUB_KEY = read_file(PUB_KEY_PATH)
@@ -55,6 +56,7 @@ def context(tmpdir):
     context.autograph_configs = load_autograph_configs(SERVER_CONFIG_PATH)
     mkdir(context.config["work_dir"])
     mkdir(context.config["artifact_dir"])
+    context.task = {"scopes": [TEST_CERT_TYPE]}
     yield context
 
 

--- a/signingscript/tests/test_task.py
+++ b/signingscript/tests/test_task.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from conftest import BASE_DIR
+from conftest import DEFAULT_SCOPE_PREFIX, TEST_CERT_TYPE
 from scriptworker.client import validate_task_schema
 from scriptworker.exceptions import ScriptWorkerTaskException, TaskVerificationError
 
@@ -9,9 +9,6 @@ import signingscript.task as stask
 from signingscript.utils import mkdir
 
 # helper constants, fixtures, functions {{{1
-SERVER_CONFIG_PATH = os.path.join(BASE_DIR, "example_server_config.json")
-DEFAULT_SCOPE_PREFIX = "project:releng:signing:"
-TEST_CERT_TYPE = "{}cert:dep-signing".format(DEFAULT_SCOPE_PREFIX)
 TEST_AUTOGRAPH_TYPE = "{}autograph:dep-signing".format(DEFAULT_SCOPE_PREFIX)
 
 


### PR DESCRIPTION
A bunch of tests need this, so might as well do this once and for all.