### PR TITLE
Bug 1799668 - Add Focus dep-signing scope to the firefox-android repo

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -70,6 +70,7 @@ in:
 
       # dep-passwords-mobile.json
       '(ENV == "dev" || ENV == "fake-prod") && COT_PRODUCT == "mobile"':
+        # TODO Bug 1801898: Remove the following mapping
         project:mobile:focus-android:releng:signing:cert:dep-signing:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_FOCUS_USERNAME"},
@@ -107,6 +108,11 @@ in:
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["autograph_gpg"]
+            ]
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_FOCUS_USERNAME"},
+             {"$eval": "AUTOGRAPH_FOCUS_PASSWORD"},
+             ["autograph_focus"]
             ]
 
       # dep-passwords-appsv.json


### PR DESCRIPTION
Fixes[1]:

```
2022-11-22 15:21:23,515 - signingscript.sign - INFO - sign_file(): signing /app/workdir/public/build/focus/arm64-v8a/target.apk with autograph_focus... using autograph /sign/file
2022-11-22 15:21:23,515 - signingscript.sign - DEBUG - sign_file_with_autograph took 0.00s; RSS:53188 (+0)
2022-11-22 15:21:23,515 - scriptworker.client - ERROR - Failed to run async_main
Traceback (most recent call last):
  File "/app/lib/python3.9/site-packages/scriptworker/client.py", line 205, in _handle_asyncio_loop
    await async_main(context)
  File "/app/lib/python3.9/site-packages/signingscript/script.py", line 42, in async_main
    output_files = await sign(context, os.path.join(work_dir, path), path_dict["formats"], authenticode_comment=path_dict.get("comment"))
  File "/app/lib/python3.9/site-packages/signingscript/task.py", line 156, in sign
    output = await signing_func(context, output, fmt, **kwargs)
  File "/app/lib/python3.9/site-packages/signingscript/sign.py", line 168, in sign_file
    await sign_file_with_autograph(context, from_, fmt, to=to)
  File "/app/lib/python3.9/site-packages/signingscript/sign.py", line 97, in wrapped
    return await f(*args, **kwargs)
  File "/app/lib/python3.9/site-packages/signingscript/sign.py", line 1058, in sign_file_with_autograph
    a = get_autograph_config(context.autograph_configs, cert_type, [fmt], raise_on_empty=True)
  File "/app/lib/python3.9/site-packages/signingscript/sign.py", line 145, in get_autograph_config
    raise SigningScriptError(f"No autograph config found with cert type {cert_type} and formats {signing_formats}")
signingscript.exceptions.SigningScriptError: No autograph config found with cert type project:mobile:firefox-android:releng:signing:cert:dep-signing and formats ['autograph_focus']
```

[1] https://firefox-ci-tc.services.mozilla.com/tasks/GPdz3nGbRPukNXXbUEc4Rw/runs/0/logs/public/logs/live_backing.log