### PR TITLE
Bug 1799696 - part 1: Add Focus release-signing scope to the firefox-…

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -279,6 +279,7 @@ in:
 
       # passwords-mobile.json
       'ENV == "prod" && COT_PRODUCT == "mobile"':
+        # TODO Bug 1801898: Remove the following mapping
         project:mobile:focus-android:releng:signing:cert:production-signing:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_FOCUS_USERNAME"},
@@ -332,6 +333,11 @@ in:
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["autograph_gpg"]
+            ]
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_FOCUS_USERNAME"},
+             {"$eval": "AUTOGRAPH_FOCUS_PASSWORD"},
+             ["autograph_focus"]
             ]
         project:mobile:firefox-tv:releng:signing:cert:production-signing:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",


### PR DESCRIPTION
…android repo

WIP. We likely need to green up some release tasks like we did in https://github.com/mozilla-releng/scriptworker-scripts/pull/573

Similar to https://github.com/mozilla-releng/scriptworker-scripts/pull/589 but handles release scope.