### PR TITLE
Bug 1812302: fix version bumps on mobile

### DIFF
--- a/treescript/src/treescript/versionmanip.py
+++ b/treescript/src/treescript/versionmanip.py
@@ -147,6 +147,10 @@ async def do_bump_version(config, repo_path, files, next_version, source_repo):
             is_esr = curr_version.is_esr
         except AttributeError:  # Fenix does not expose the is_esr attribute
             is_esr = False
+        else:
+            if not is_esr and next_version.is_esr:
+                # if the file had no esr prefix then don't add it
+                next_version = VersionClass.parse(str(next_version)[:-3])
 
         # XXX In the case of ESR, some files (like version.txt) show version numbers without `esr`
         # at the end. next_version is usually provided without `esr` too.
@@ -162,9 +166,6 @@ async def do_bump_version(config, repo_path, files, next_version, source_repo):
             )
         ):
             next_version = VersionClass.parse("{}esr".format(next_version))
-        if not is_esr and next_version.is_esr:
-            # if the file had no esr prefix then don't add it
-            next_version = VersionClass.parse(str(next_version)[:-3])
 
         if next_version < curr_version:
             log.warning("Version bumping skipped due to conflicting values: " "(next version {} is < current version {})".format(next_version, curr_version))


### PR DESCRIPTION
Don't look at next_version.is_esr unless we're dealing with gecko, since that attribute doesn't exist elsewhere.