### PR TITLE
Only make `k8s_image` tasks depend on `tox` tasks when pushing to production

### DIFF
--- a/taskcluster/scriptworker_taskgraph/parameters.py
+++ b/taskcluster/scriptworker_taskgraph/parameters.py
@@ -17,6 +17,17 @@ PROJECT_SPECIFIC_PREFIXES = {
 
 PUSH_TAGS = ("dev", "production")
 
+
+def get_defaults(_):
+    return {
+        "docker_tag": None,
+        "push_docker_image": False,
+        "script_name": None,
+        "script_revision": None,
+        "shipping_phase": None,
+    }
+
+
 scriptworker_schema = {
     Optional('docker_tag'): Any(str, None),
     Optional('push_docker_image'): Any(True, False, None),
@@ -25,7 +36,7 @@ scriptworker_schema = {
     Optional('shipping_phase'): Any("build", "promote", None),
 }
 
-extend_parameters_schema(scriptworker_schema)
+extend_parameters_schema(scriptworker_schema, defaults_fn=get_defaults)
 
 
 def get_decision_parameters(graph_config, parameters):

--- a/taskcluster/scriptworker_taskgraph/transforms/k8s_image.py
+++ b/taskcluster/scriptworker_taskgraph/transforms/k8s_image.py
@@ -22,6 +22,9 @@ def add_dependencies(config, jobs):
     discrepancies in upstream deps.
 
     """
+    if not config.params.get("push_docker_image") or config.params.get("docker_tag") != "production":
+        yield from jobs
+
     for job in jobs:
         attributes = job["attributes"]
         dependencies = job.setdefault("dependencies", {})

--- a/taskcluster/test/params/production-signingscript-push.yml
+++ b/taskcluster/test/params/production-signingscript-push.yml
@@ -1,0 +1,23 @@
+base_repository: https://github.com/mozilla-releng/scriptworker-scripts
+build_date: 1675450111
+do_not_optimize: []
+docker_tag: production
+existing_tasks: {}
+filters:
+- target_tasks_method
+head_ref: refs/heads/production-signingscript
+head_repository: https://github.com/mozilla-releng/scriptworker-scripts
+head_rev: 808b88258ca0be051c0d505fdc320eb786bd6ba3
+head_tag: ''
+level: '3'
+moz_build_date: '20230203184831'
+optimize_target_tasks: false
+owner: user@example.com
+project: scriptworker-scripts
+push_docker_image: true
+pushdate: 0
+pushlog_id: '0'
+repository_type: git
+script_name: signingscript
+target_tasks_method: docker-hub-push
+tasks_for: github-push

--- a/taskcluster/test/params/pull-request.yml
+++ b/taskcluster/test/params/pull-request.yml
@@ -1,0 +1,21 @@
+base_repository: https://github.com/mozilla-releng/scriptworker-scripts
+build_date: 1675443102
+do_not_optimize: []
+docker_tag: github-pull-request
+existing_tasks: {}
+filters:
+- target_tasks_method
+head_ref: feature_branch
+head_repository: https://github.com/user/scriptworker-scripts
+head_rev: 91c957aaf87d40afe2c21c166fdb8f7e5511e8c4
+head_tag: ''
+level: '1'
+moz_build_date: '20230203165142'
+optimize_target_tasks: true
+owner: user@example.com
+project: scriptworker-scripts
+pushdate: 0
+pushlog_id: '0'
+repository_type: git
+target_tasks_method: default
+tasks_for: github-pull-request


### PR DESCRIPTION
We presumably have this dependency in place to help ensure we aren't pushing busted images to Docker hub. However in the context of PRs, or pushing to `dev` branches, we don't really care as much and this dependency just slows the pipeline down.

Let's only make the image tasks block when they need to.