### PR TITLE
Allow dep-signing with the autograph_authenticode_ev format in adhoc

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -33,9 +33,9 @@ export AUTHENTICODE_TIMESTAMP_STYLE=old
 export AUTHENTICODE_TIMESTAMP_URL=http://timestamp.digicert.com
 export AUTHENTICODE_CERT_PATH=$APP_DIR/signingscript/src/signingscript/data/authenticode_dep.crt
 export AUTHENTICODE_CERT_PATH_202005=$APP_DIR/signingscript/src/signingscript/data/authenticode_dep.crt
-export AUTHENTICODE_CERT_PATH_EV=""
+export AUTHENTICODE_CERT_PATH_EV="$AUTHENTICODE_CERT_PATH"
 export AUTHENTICODE_CA_PATH=$APP_DIR/signingscript/src/signingscript/data/authenticode_dep_ca.crt
-export AUTHENTICODE_CA_PATH_EV=""
+export AUTHENTICODE_CA_PATH_EV="$AUTHENTICODE_CA_PATH"
 export AUTHENTICODE_CA_TIMESTAMP_PATH=/usr/lib/ssl/certs/ca-certificates.crt
 export AUTHENTICODE_CROSS_CERT_PATH=$APP_DIR/signingscript/src/signingscript/data/authenticode_stub.crt
 if [ "$ENV" == "prod" ]; then

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -172,7 +172,7 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
-             ["autograph_authenticode_sha2", "autograph_authenticode_sha2_stub"]
+             ["autograph_authenticode_sha2", "autograph_authenticode_sha2_stub", "autograph_authenticode_ev"]
              ]
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_MAR_USERNAME"},


### PR DESCRIPTION
Use the same cert as normal authenticode dep signing.