### PR TITLE
signingscript: pass the signing certificate as authenticode_ca_ev

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -44,7 +44,7 @@ if [ "$ENV" == "prod" ]; then
   export AUTHENTICODE_CERT_PATH_202005=$APP_DIR/signingscript/src/signingscript/data/authenticode_prod_202005.crt
   export AUTHENTICODE_CERT_PATH_EV=$APP_DIR/signingscript/src/signingscript/data/authenticode_prod_ev.crt
   export AUTHENTICODE_CA_PATH=$APP_DIR/signingscript/src/signingscript/data/authenticode_prod_202005.crt
-  export AUTHENTICODE_CA_PATH_EV=$APP_DIR/signingscript/src/signingscript/data/authenticode_prod_ca_ev.crt
+  export AUTHENTICODE_CA_PATH_EV=$APP_DIR/signingscript/src/signingscript/data/authenticode_prod_ev.crt
   export AUTHENTICODE_CA_TIMESTAMP_PATH=/usr/lib/ssl/certs/ca-certificates.crt
 fi
 


### PR DESCRIPTION
This is confusing, because it's called "cafile" in winsign and passed as "-CAfile" to osslsigncode, so you'd expect it to want an actual CA cert, but apparently passing the end entity cert is what we do for the existing authenticode signing, and passing the intermediate CA instead seems to fail.