### PR TITLE
Bug 1808607 - Add missing `fennec-production-signing` scope to firefo…

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -335,6 +335,12 @@ in:
              {"$eval": "AUTOGRAPH_FENIX_MOZILLA_ONLINE_PASSWORD"},
              ["autograph_apk_mozillaonline"]
             ]
+        project:mobile:firefox-android:releng:signing:cert:fennec-production-signing:
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},
+             {"$eval": "AUTOGRAPH_FENNEC_RELEASE_PASSWORD"},
+             ["autograph_apk"]
+            ]
         project:mobile:firefox-tv:releng:signing:cert:production-signing:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_FIREFOX_TV_USERNAME"},


### PR DESCRIPTION
…x-android`

Fixes[1]:

```
2023-02-14 15:39:05,301 - signingscript.sign - DEBUG - sign_file_with_autograph took 0.00s; RSS:53260 (+0)
2023-02-14 15:39:05,302 - scriptworker.client - ERROR - Failed to run async_main
Traceback (most recent call last):
  File "/app/lib/python3.9/site-packages/scriptworker/client.py", line 205, in _handle_asyncio_loop
    await async_main(context)
  File "/app/lib/python3.9/site-packages/signingscript/script.py", line 42, in async_main
    output_files = await sign(context, os.path.join(work_dir, path), path_dict["formats"], authenticode_comment=path_dict.get("comment"))
  File "/app/lib/python3.9/site-packages/signingscript/task.py", line 157, in sign
    output = await signing_func(context, output, fmt, **kwargs)
  File "/app/lib/python3.9/site-packages/signingscript/sign.py", line 167, in sign_file
    await sign_file_with_autograph(context, from_, fmt, to=to)
  File "/app/lib/python3.9/site-packages/signingscript/sign.py", line 96, in wrapped
    return await f(*args, **kwargs)
  File "/app/lib/python3.9/site-packages/signingscript/sign.py", line 1057, in sign_file_with_autograph
    a = get_autograph_config(context.autograph_configs, cert_type, [fmt], raise_on_empty=True)
  File "/app/lib/python3.9/site-packages/signingscript/sign.py", line 144, in get_autograph_config
    raise SigningScriptError(f"No autograph config found with cert type {cert_type} and formats {signing_formats}")
signingscript.exceptions.SigningScriptError: No autograph config found with cert type project:mobile:firefox-android:releng:signing:cert:fennec-production-signing and formats ['autograph_apk']
exit code: 5

```

Similar fix to https://phabricator.services.mozilla.com/D169813.


[1] https://firefox-ci-tc.services.mozilla.com/tasks/YIkbaaHoTkiGz70z57mt3g/runs/0/logs/public/logs/live_backing.log