### PR TITLE
addonscript: rely on strict_min_version from the manifest

### DIFF
--- a/addonscript/src/addonscript/exceptions.py
+++ b/addonscript/src/addonscript/exceptions.py
@@ -33,12 +33,6 @@ class FatalSignatureError(ScriptWorkerTaskException):
     pass
 
 
-class BadVersionError(ScriptWorkerTaskException):
-    """Fatal error when XPI's version is invalid against AMO sanity checks."""
-
-    pass
-
-
 class AMOConflictError(Exception):
     """Error when AMO returns 409-Conflict usually from a duplicate version."""
 

--- a/addonscript/src/addonscript/xpi.py
+++ b/addonscript/src/addonscript/xpi.py
@@ -1,26 +1,7 @@
 """Resources that operate on an XPI file."""
 
 import json
-import re
 from zipfile import ZipFile
-
-from addonscript.exceptions import BadVersionError
-
-
-def get_stripped_version(version):
-    """Strip out buildid or other extraneous info from the version.
-
-    Args:
-        version (string): the full version string from manifest.json
-                          e.g. `81.0buildid20200914232702`
-    Returns:
-        string: semver version
-    """
-    m = re.match(r"""[0-9\.]+""", version)
-    if m:
-        return m.group(0)
-    else:
-        raise BadVersionError(f"Can't determine stripped version from `{version}`!")
 
 
 def get_langpack_info(path):
@@ -36,6 +17,6 @@ def get_langpack_info(path):
         "version": manifest_info["version"],
         "id": browser_specific_settings["gecko"]["id"],
         "unsigned": path,
-        "min_version": browser_specific_settings["gecko"].get("strict_min_version", get_stripped_version(manifest_info["version"])),
+        "min_version": browser_specific_settings["gecko"]["strict_min_version"],
     }
     return langpack_info

--- a/addonscript/tests/test_xpi.py
+++ b/addonscript/tests/test_xpi.py
@@ -30,21 +30,6 @@ def fake_xpi_with_bss():
     return make_fake_xpi("fake_target_with_bss.langpack.xpi")
 
 
-@pytest.mark.parametrize(
-    "version,expected_version",
-    (
-        ("81.0buildid20200914232702", "81.0"),
-        ("81.0", "81.0"),
-        ("81.0buildid", "81.0"),
-        ("81.0buildid202009142", "81.0"),
-        ("81.0a1buildid202009142", "81.0"),
-        ("81.0b1buildid202009142", "81.0"),
-    ),
-)
-def test_get_stripped_version(version, expected_version):
-    assert xpi.get_stripped_version(version) == expected_version
-
-
 def test_get_langpack_info(fake_xpi_with_applications):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     path = f"{current_dir}/fake_target.langpack.xpi"


### PR DESCRIPTION
Remove the get_stripped_version fallback, since we expect all langpacks to have strict_min_version set.

Fixes #672