### PR TITLE
addonscript: switch to v5 addon submission API (RELENG-935)

### DIFF
--- a/addonscript/src/addonscript/api.py
+++ b/addonscript/src/addonscript/api.py
@@ -4,23 +4,30 @@ from aiohttp.client_exceptions import ClientResponseError
 
 from addonscript.exceptions import AMOConflictError, AuthFailedError, AuthInsufficientPermissionsError, FatalSignatureError, SignatureError
 from addonscript.task import get_channel
-from addonscript.utils import amo_download, amo_get, amo_put, get_api_url
+from addonscript.utils import amo_download, amo_get, amo_post, amo_put, get_api_url
 
-# https://addons-server.readthedocs.io/en/latest/topics/api/signing.html#uploading-a-version
-UPLOAD_VERSION = "api/v4/addons/{id}/versions/{version}/"
+# https://addons-server.readthedocs.io/en/latest/topics/api/addons.html#upload-create
+UPLOAD_CREATE = "api/v5/addons/upload/"
 
-# https://addons-server.readthedocs.io/en/latest/topics/api/signing.html#checking-the-status-of-your-upload
-UPLOAD_STATUS = "api/v4/addons/{id}/versions/{version}/"
-UPLOAD_STATUS_PK = "api/v4/addons/{id}/versions/{version}/uploads/{upload_pk}/"
+# https://addons-server.readthedocs.io/en/latest/topics/api/addons.html#upload-detail
+UPLOAD_DETAIL = "api/v5/addons/upload/{uuid}/"
 
+# https://addons-server.readthedocs.io/en/latest/topics/api/addons.html#versions-list
+VERSION_LIST = "api/v5/addons/addon/{id}/versions/?filter=all_with_unlisted"
 
-# https://addons-server.readthedocs.io/en/latest/topics/api/applications.html
+# https://addons-server.readthedocs.io/en/latest/topics/api/addons.html#version-detail
+VERSION_DETAIL = "api/v5/addons/addon/{id}/versions/{version}/"
+
+# https://addons-server.readthedocs.io/en/latest/topics/api/addons.html#put-create-or-edit
+ADDON_CREATE_OR_EDIT = "api/v5/addons/addon/{id}/"
+
+# https://addons-server.readthedocs.io/en/latest/topics/api/v4_frozen/applications.html
 # XXX when we want to support multiple products, we'll need to unhardcode the
 #     `firefox` below
-ADD_VERSION = "api/v4/applications/firefox/{version}/"
+ADD_APP_VERSION = "api/v4/applications/firefox/{version}/"
 
 
-async def add_version(context, version):
+async def add_app_version(context, version):
     """Add a new version to AMO.
 
     Use the `min_version` here, rather than the string with the buildid etc.
@@ -31,7 +38,7 @@ async def add_version(context, version):
 
 
     """
-    url = get_api_url(context, ADD_VERSION, version=version)
+    url = get_api_url(context, ADD_APP_VERSION, version=version)
 
     try:
         result = await amo_put(context, url, data=None)
@@ -45,29 +52,66 @@ async def add_version(context, version):
     return result
 
 
+async def check_upload(context, uuid):
+    """Check on the status of file upload identified by `uuid`
+
+    Raises:
+        SignatureError: If the upload is awaiting processing
+        FatalSignatureError: If validation errors occurred
+    """
+    url = get_api_url(context, UPLOAD_DETAIL, uuid=uuid)
+    result = await amo_get(context, url)
+    if not result["processed"]:
+        # retry
+        raise SignatureError("upload not yet processed")
+    if not result["valid"]:
+        raise FatalSignatureError(f"Automated validation produced errors: {result['validation']}")
+
+
 async def do_upload(context, locale):
     """Upload the language pack for `locale` to AMO.
 
     Returns the JSON response from AMO
     """
     locale_info = context.locales[locale]
-    langpack_id = locale_info["id"]
-    version = locale_info["version"]
-    url = get_api_url(context, UPLOAD_VERSION, id=langpack_id, version=version)
-    with open(context.locales[locale]["unsigned"], "rb") as file:
+    url = get_api_url(context, UPLOAD_CREATE)
+    with open(locale_info["unsigned"], "rb") as file:
         data = {"channel": get_channel(context.task), "upload": file}
-        try:
-            result = await amo_put(context, url, data)
-        except ClientResponseError as exc:
-            # XXX: .code is deprecated in aiohttp 3.1 in favor of .status
-            if exc.status == 409:
-                raise AMOConflictError("Addon <{}> already present on AMO with version <{}>".format(langpack_id, version))
-            # If response code is not 409 - CONFLICT, bubble the exception
-            raise exc
-        return result
+        return await amo_post(context, url, data)
 
 
-async def get_signed_addon_url(context, locale, pk):
+async def do_create_version(context, locale, upload_uuid):
+    """Create a new version for the `locale` language pack on AMO.
+
+    Returns the version's identifier
+
+    Raises:
+        AMOConflictError: If the version already exists for this addon
+    """
+    locale_info = context.locales[locale]
+    langpack_id = locale_info["id"]
+    url = get_api_url(context, ADDON_CREATE_OR_EDIT, id=langpack_id)
+    data = {
+        "categories": {"firefox": ["general"]},
+        "name": {"en-US": locale_info["name"]},
+        "summary": {"en-US": locale_info["description"]},
+        "version": {
+            "license": "MPL-2.0",
+            "upload": upload_uuid,
+        },
+    }
+    try:
+        result = await amo_put(context, url, json=data)
+    except ClientResponseError as exc:
+        if exc.status in (400, 409):
+            # TODO: check actual response for other errors
+            raise AMOConflictError("Addon <{}> already present on AMO with version <{}>".format(langpack_id, locale_info["version"]))
+        raise
+
+    return result["version"]
+
+
+async def get_signed_addon_url(context, locale, version_id):
     """Query AMO to get the location of the signed XPI.
 
     This function should be called within `scriptworker.utils.retry_async()`.
@@ -83,42 +127,40 @@ async def get_signed_addon_url(context, locale, pk):
 
     """
     # XXX Retry is done at top-level. Avoiding a retry here avoids never-ending retries cascade
-    upload_status = await get_upload_status(context, locale, pk)
+    version_detail = await get_version(context, locale, version_id)
+    status = version_detail["file"]["status"]
 
-    if len(upload_status["files"]) != 1:
-        raise SignatureError("Expected 1 file. Got ({}) full response: {}".format(len(upload_status["files"]), upload_status))
-
-    if upload_status.get("validation_results"):
-        validation_errors = upload_status["validation_results"].get("errors")
-        if validation_errors:
-            raise FatalSignatureError("Automated validation produced errors: {}".format(validation_errors))
-
-    signed_data = upload_status["files"][0]
-
-    if not signed_data.get("signed"):
-        raise SignatureError('Expected XPI "signed" parameter. Got: {}'.format(signed_data))
-
-    if not signed_data.get("download_url"):
-        raise SignatureError('Expected XPI "download_url" parameter. Got: {}'.format(signed_data))
-
-    return signed_data["download_url"]
+    if status == "disabled":
+        raise FatalSignatureError("XPI disabled on AMO")
+    if status != "public":
+        raise SignatureError("XPI not public")
+    return version_detail["file"]["url"]
 
 
-async def get_upload_status(context, locale, upload_pk):
-    """Query AMO for the status of a given upload for `locale`.
+async def get_version(context, locale, version_id):
+    """Query AMO for the status of a given version for `locale`.
+
+    `version_id` can be None, in which case the version is looked up by version
+    number, raising FatalSignatureError if it can't be found.
 
     Returns the JSON response from AMO
     """
     locale_info = context.locales[locale]
     langpack_id = locale_info["id"]
     version = locale_info["version"]
-    if upload_pk:
-        format_string = UPLOAD_STATUS_PK
-    else:
+    if version_id is None:
         # When the addon was already uploaded with this version we don't have
-        # an upload_pk
-        format_string = UPLOAD_STATUS
-    url = get_api_url(context, format_string, id=langpack_id, version=version, upload_pk=upload_pk)
+        # an id, and we can't look it up by version number
+        # See https://github.com/mozilla/addons-server/issues/20388
+        url = get_api_url(context, VERSION_LIST, id=langpack_id)
+        addon_versions = await amo_get(context, url)
+        for v in addon_versions["results"]:
+            if v["version"] == version:
+                return v
+        # TODO: handle pagination?
+        raise FatalSignatureError(f"could not find {langpack_id} version {version}")
+
+    url = get_api_url(context, VERSION_DETAIL, id=langpack_id, version=version_id)
     return await amo_get(context, url)
 
 

--- a/addonscript/src/addonscript/api.py
+++ b/addonscript/src/addonscript/api.py
@@ -103,8 +103,7 @@ async def do_create_version(context, locale, upload_uuid):
     try:
         result = await amo_put(context, url, json=data)
     except ClientResponseError as exc:
-        if exc.status in (400, 409):
-            # TODO: check actual response for other errors
+        if exc.status == 409:
             raise AMOConflictError("Addon <{}> already present on AMO with version <{}>".format(langpack_id, locale_info["version"]))
         raise
 

--- a/addonscript/src/addonscript/api.py
+++ b/addonscript/src/addonscript/api.py
@@ -150,19 +150,9 @@ async def get_version(context, locale, version_id):
     """
     locale_info = context.locales[locale]
     langpack_id = locale_info["id"]
-    version = locale_info["version"]
     if version_id is None:
-        # When the addon was already uploaded with this version we don't have
-        # an id, and we can't look it up by version number
-        # See https://github.com/mozilla/addons-server/issues/20388
-        url = get_api_url(context, VERSION_LIST, id=langpack_id)
-        addon_versions = await amo_get(context, url)
-        for v in addon_versions["results"]:
-            if v["version"] == version:
-                return v
-        # TODO: handle pagination?
-        raise FatalSignatureError(f"could not find {langpack_id} version {version}")
-
+        # use the version number instead
+        version_id = "v" + locale_info["version"]
     url = get_api_url(context, VERSION_DETAIL, id=langpack_id, version=version_id)
     return await amo_get(context, url)
 

--- a/addonscript/src/addonscript/api.py
+++ b/addonscript/src/addonscript/api.py
@@ -90,6 +90,7 @@ async def do_create_version(context, locale, upload_uuid):
 
     Raises:
         AMOConflictError: If the version already exists for this addon
+        FatalSignatureError: If AMO returned a permanent error
     """
     locale_info = context.locales[locale]
     langpack_id = locale_info["id"]
@@ -108,6 +109,8 @@ async def do_create_version(context, locale, upload_uuid):
     except ClientResponseError as exc:
         if exc.status == 409:
             raise AMOConflictError("Addon <{}> already present on AMO with version <{}>".format(langpack_id, locale_info["version"]))
+        if exc.status < 500:
+            raise FatalSignatureError(str(exc))
         raise
 
     return result["version"]

--- a/addonscript/src/addonscript/script.py
+++ b/addonscript/src/addonscript/script.py
@@ -7,7 +7,7 @@ import scriptworker.client
 from aiohttp.client_exceptions import ClientError, ClientResponseError
 from scriptworker.utils import retry_async
 
-from addonscript.api import add_app_version, do_upload, do_create_version, get_signed_addon_url, get_signed_xpi, check_upload
+from addonscript.api import add_app_version, do_upload, do_create_version, get_signed_addon_info, get_signed_xpi, check_upload
 from addonscript.exceptions import AMOConflictError, SignatureError
 from addonscript.task import build_filelist
 from addonscript.xpi import get_langpack_info
@@ -49,8 +49,8 @@ async def sign_addon(context, locale):
         version = {"id": None}
 
     # poll AMO for the the URL that contains the signed langpack
-    signed_addon_url = await retry_async(
-        get_signed_addon_url,
+    signed_addon_info = await retry_async(
+        get_signed_addon_info,
         args=(context, locale, version["id"]),
         attempts=10,  # 10 attempts with default backoff yield around 10 minutes of time
         # Most addons will be signed in less than that.
@@ -60,7 +60,7 @@ async def sign_addon(context, locale):
     # make the signed langpack available in task's artifacts for downstream beetmover
     destination = os.path.join(context.config["artifact_dir"], "public/build/", locale, "target.langpack.xpi")
     os.makedirs(os.path.dirname(destination))
-    await retry_async(get_signed_xpi, args=(context, signed_addon_url, destination))
+    await retry_async(get_signed_xpi, args=(context, signed_addon_info, destination))
 
 
 def build_locales_context(context):

--- a/addonscript/src/addonscript/utils.py
+++ b/addonscript/src/addonscript/utils.py
@@ -62,7 +62,7 @@ async def amo_download(context, url, file):
             file.write(await r.read())
 
 
-async def amo_put(context, url, data):
+async def amo_put(context, url, data=None, json=None):
     """Perform a PUT request against AMO's API.
 
     Automatically fills in the HTTP header with the Authorization token.
@@ -71,13 +71,32 @@ async def amo_put(context, url, data):
     """
     log.debug('Calling amo_put() with URL "{}"'.format(url))
     async with timeout(270):  # 4 minutes, 30 sec.
-        resp = context.session.put(url, headers={"Authorization": "JWT {}".format(generate_JWT(context))}, data=data)
+        resp = context.session.put(url, headers={"Authorization": "JWT {}".format(generate_JWT(context))}, data=data, json=json)
         async with resp as r:
             log.debug('amo_put() for URL "{}" returned HTTP status code: {}'.format(url, r.status))
             # we silence aiohttp in case we have Null returns from AMO API
             returned_value = await r.json(content_type=None)
             log.debug('amo_put() for URL "{}" returned: {}'.format(url, returned_value))
             r.raise_for_status()
+            return returned_value
+
+
+async def amo_post(context, url, data=None, json=None):
+    """Perform a POST request against AMO's API.
+
+    Automatically fills in the HTTP header with the Authorization token.
+    Passes values in the `data` dictionary as FORM data.
+    Assumes request will return a valid json object.
+    """
+    log.debug('Calling amo_post() with URL "{}"'.format(url))
+    async with timeout(270):  # 4 minutes, 30 sec.
+        resp = context.session.post(url, headers={"Authorization": "JWT {}".format(generate_JWT(context))}, data=data, json=json)
+        async with resp as r:
+            log.debug('amo_post() for URL "{}" returned HTTP status code: {}'.format(url, r.status))
+            r.raise_for_status()
+            # we silence aiohttp in case we have Null returns from AMO API
+            returned_value = await r.json(content_type=None)
+            log.debug('amo_post() for URL "{}" returned: {}'.format(url, returned_value))
             return returned_value
 
 

--- a/addonscript/src/addonscript/xpi.py
+++ b/addonscript/src/addonscript/xpi.py
@@ -18,5 +18,7 @@ def get_langpack_info(path):
         "id": browser_specific_settings["gecko"]["id"],
         "unsigned": path,
         "min_version": browser_specific_settings["gecko"]["strict_min_version"],
+        "name": manifest_info["name"],
+        "description": manifest_info["description"],
     }
     return langpack_info

--- a/addonscript/tests/test_api.py
+++ b/addonscript/tests/test_api.py
@@ -85,7 +85,7 @@ async def test_do_upload(fake_session, context, tmpdir, mocker, statuscode, rais
     "statuscode,retval,exception",
     (
         (200, {"id": 1234}, does_not_raise()),
-        (400, None, pytest.raises(aiohttp.client_exceptions.ClientResponseError)),
+        (400, None, pytest.raises(FatalSignatureError)),
         (409, None, pytest.raises(AMOConflictError)),
         (500, None, pytest.raises(aiohttp.client_exceptions.ClientResponseError)),
     ),

--- a/addonscript/tests/test_api.py
+++ b/addonscript/tests/test_api.py
@@ -85,7 +85,8 @@ async def test_do_upload(fake_session, context, tmpdir, mocker, statuscode, rais
     "statuscode,retval,exception",
     (
         (200, {"id": 1234}, does_not_raise()),
-        (400, None, pytest.raises(AMOConflictError)),
+        (400, None, pytest.raises(aiohttp.client_exceptions.ClientResponseError)),
+        (409, None, pytest.raises(AMOConflictError)),
         (500, None, pytest.raises(aiohttp.client_exceptions.ClientResponseError)),
     ),
 )

--- a/addonscript/tests/test_script.py
+++ b/addonscript/tests/test_script.py
@@ -12,8 +12,10 @@ from addonscript.exceptions import AMOConflictError, SignatureError
 async def test_sign_addon(context, mocker, tmpdir):
     context.config["artifact_dir"] = tmpdir
     mocker.patch.object(scriptworker.utils, "_define_sleep_time", return_value=0)
-    mocker.patch.object(script, "do_upload", side_effect=[ClientConnectionError(), {"pk": "pk"}])
-    mocker.patch.object(script, "get_signed_addon_url", side_effect=[SignatureError(), "http://download/this/en-GB.xpi"])
+    mocker.patch.object(script, "do_upload", side_effect=[ClientConnectionError(), {"uuid": "uuid"}])
+    mocker.patch.object(script, "check_upload", side_effect=[SignatureError(), ClientConnectionError(), None])
+    mocker.patch.object(script, "do_create_version", side_effect=[ClientConnectionError(), {"id": 1234}])
+    mocker.patch.object(script, "get_signed_addon_info", side_effect=[SignatureError(), ("http://download/this/en-GB.xpi", 1, "sha256")])
     mocker.patch.object(script, "get_signed_xpi", side_effect=[SignatureError(), None])
 
     await script.sign_addon(context, "en-GB")
@@ -23,8 +25,10 @@ async def test_sign_addon(context, mocker, tmpdir):
 async def test_sign_addon_conflict(context, mocker, tmpdir):
     context.config["artifact_dir"] = tmpdir
     mocker.patch.object(scriptworker.utils, "_define_sleep_time", return_value=0)
-    mocker.patch.object(script, "do_upload", side_effect=[ClientConnectionError(), AMOConflictError("")])
-    mocker.patch.object(script, "get_signed_addon_url", side_effect=[SignatureError(), "http://download/this/en-GB.xpi"])
+    mocker.patch.object(script, "do_upload", side_effect=[ClientConnectionError(), {"uuid": "uuid"}])
+    mocker.patch.object(script, "check_upload", side_effect=[SignatureError(), ClientConnectionError(), None])
+    mocker.patch.object(script, "do_create_version", side_effect=[ClientConnectionError(), AMOConflictError("")])
+    mocker.patch.object(script, "get_signed_addon_info", side_effect=[SignatureError(), ("http://download/this/en-GB.xpi", 1, "sha256")])
     mocker.patch.object(script, "get_signed_xpi", side_effect=[SignatureError(), None])
 
     await script.sign_addon(context, "en-GB")


### PR DESCRIPTION
Replace the v4 flow of:
- upload new version
- poll for validation/signing
- download signed xpi

With:
- upload new xpi
- poll for processing/validation
- create new version using that upload
- poll for signing/publishing
- download signed xpi

This makes it possible to submit entirely new language packs and have them listed on AMO, instead of having to manually go in and add the required metadata.