### PR TITLE
beetmoverscript: check destination path in push-to-maven

### DIFF
--- a/beetmoverscript/src/beetmoverscript/constants.py
+++ b/beetmoverscript/src/beetmoverscript/constants.py
@@ -113,6 +113,14 @@ PRODUCT_TO_PATH = {
     "vpn": "pub/vpn/",
 }
 
+MAVEN_PRODUCT_TO_PATH = {
+    "appservices": "maven2/org/mozilla/appservices/",
+    "components": "maven2/org/mozilla/components/",
+    "nightly_components": "maven2/org/mozilla/components/",
+    "geckoview": "maven2/org/mozilla/geckoview/",
+    "telemetry": "maven2/org/mozilla/telemetry/",
+}
+
 PARTNER_REPACK_PUBLIC_PREFIX_TMPL = "pub/firefox/candidates/{version}-candidates/build{build_number}/"
 PARTNER_REPACK_PRIVATE_REGEXES = (
     r"^(?P<partner>[^\/%]+)\/{version}-{build_number}\/(?P<subpartner>[^\/%]+)\/(mac|win32|win64(|-aarch64)|linux-i686|linux-x86_64)\/(?P<locale>[^\/%]+)$",

--- a/beetmoverscript/src/beetmoverscript/task.py
+++ b/beetmoverscript/src/beetmoverscript/task.py
@@ -13,7 +13,7 @@ from scriptworker import client
 from scriptworker.exceptions import ScriptWorkerTaskException
 
 from beetmoverscript import utils
-from beetmoverscript.constants import CHECKSUMS_CUSTOM_FILE_NAMING, STAGE_PLATFORM_MAP
+from beetmoverscript.constants import CHECKSUMS_CUSTOM_FILE_NAMING, STAGE_PLATFORM_MAP, MAVEN_PRODUCT_TO_PATH
 
 log = logging.getLogger(__name__)
 
@@ -140,10 +140,13 @@ def get_maven_version(context):
 
 
 def check_maven_artifact_map(context, version):
-    """Check that versions in artifact map are consistent with a given version"""
+    """Check that paths in artifact map are consistent with a given product and version"""
+    product = utils.get_product_name(context.task, context.config).lower()
     for artifact_dict in context.task["payload"]["artifactMap"]:
         for dest_dict in artifact_dict["paths"].values():
             for dest in dest_dict["destinations"]:
+                if not dest.startswith(MAVEN_PRODUCT_TO_PATH[product]):
+                    raise ScriptWorkerTaskException(f"Destination path '{dest}' does not match bucket '{product}'")
                 dest_folder, dest_file = os.path.split(dest)
                 last_folder = os.path.basename(dest_folder)
                 if version != last_folder:


### PR DESCRIPTION
`check_maven_artifact_map` now verifies that the product name in the task payload matches the destination paths we're told to upload to.

This should prevent uploads to the wrong place because product names need to match entries in the product_buckets config, as a secondary protection to the permissions granted to cloud credentials.