### PR TITLE
[beetmoverscript] Remove "robocop" reference

### DIFF
--- a/beetmoverscript/src/beetmoverscript/constants.py
+++ b/beetmoverscript/src/beetmoverscript/constants.py
@@ -99,7 +99,6 @@ RELEASE_EXCLUDE = (
     r"^.*json$",
     r"^.*/host.*$",
     r"^.*/mar-tools/.*$",
-    r"^.*robocop.apk$",
     r"^.*contrib.*",
     r"^.*/beetmover-checksums/.*$",
     r"^.*\.deb$",


### PR DESCRIPTION
Just tidying up: Robocop was removed in bug 1580832 (in 2019!).