### PR TITLE
Bug 1807317 - Page-aligns uncompressed .so files.

### DIFF
--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -47,7 +47,8 @@ sys.path.append(os.path.abspath(os.path.join(os.path.realpath(os.path.dirname(__
 from mozbuild.action.tooltool import safe_extract  # noqa  # isort:skip
 from mozpack import mozjar  # noqa  # isort:skip
 
-_ZIP_ALIGNMENT = "4"  # Value must always be 4, based on https://developer.android.com/studio/command-line/zipalign.html
+_ZIP_ALIGNMENT = "4"  # Value must always be 4, based on https://developer.android.com/tools/zipalign
+_SO_ALIGNMENT = "-p"  # Page-aligns uncompressed .so files, based on https://developer.android.com/tools/zipalign
 
 # Blessed files call the other widevine files.
 _WIDEVINE_BLESSED_FILENAMES = (
@@ -664,7 +665,7 @@ async def zip_align_apk(context, abs_to):
         if context.config["verbose"] is True:
             zipalign_command += ["-v"]
 
-        zipalign_command += [_ZIP_ALIGNMENT, original_apk_location, temp_apk_location]
+        zipalign_command += [_SO_ALIGNMENT, _ZIP_ALIGNMENT, original_apk_location, temp_apk_location]
         await utils.execute_subprocess(zipalign_command)
         shutil.move(temp_apk_location, abs_to)
 

--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -625,11 +625,11 @@ async def test_zip_align_apk(context, monkeypatch, is_verbose):
 
     async def execute_subprocess_mock(command):
         if is_verbose:
-            assert command[0:4] == ["/path/to/android/sdk/zipalign", "-v", "4", abs_to]
-            assert len(command) == 5
+            assert command[0:5] == ["/path/to/android/sdk/zipalign", "-v", "-p", "4", abs_to]
+            assert len(command) == 6
         else:
-            assert command[0:3] == ["/path/to/android/sdk/zipalign", "4", abs_to]
-            assert len(command) == 4
+            assert command[0:4] == ["/path/to/android/sdk/zipalign", "-p", "4", abs_to]
+            assert len(command) == 5
 
     def shutil_mock(_, destination):
         assert destination == abs_to


### PR DESCRIPTION
Add "-p" flag to [Zipalign](https://developer.android.com/tools/zipalign) so we page-aligns uncompressed .so files.  