### PR TITLE
Bug 1828876 - signingscript: remove zipalign from docker image and configs

### DIFF
--- a/signingscript/Dockerfile
+++ b/signingscript/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.9.7
 RUN groupadd --gid 10001 app && \
     useradd -g app --uid 10001 --shell /usr/sbin/nologin --create-home --home-dir /app app && \
     apt-get update && \
-    apt-get install -y zipalign osslsigncode cmake clang && \
+    apt-get install -y osslsigncode cmake clang && \
     apt-get clean && \
     ln -s /app/docker.d/healthcheck /bin/healthcheck
 

--- a/signingscript/README.md
+++ b/signingscript/README.md
@@ -175,9 +175,6 @@ The config json looks like this (comments are not valid json, but I'm inserting 
       // enable debug logging
       "verbose": true,
 
-      // the path to zipalign. This executable is usually present in $ANDROID_SDK_LOCATION/build-tools/$ANDROID_VERSION/zipalign
-      "zipalign": "/absolute/path/to/zipalign",
-
     }
 
 #### directories and file naming

--- a/signingscript/config_example.json
+++ b/signingscript/config_example.json
@@ -6,6 +6,5 @@
     "token_duration_seconds": 1200,
     "verbose": true,
     "dmg": "dmg",
-    "hfsplus": "hfsplus",
-    "zipalign": "zipalign"
+    "hfsplus": "hfsplus"
 }

--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -24,7 +24,6 @@ test_var_set 'TEMPLATE_DIR'
 
 export DMG_PATH=$APP_DIR/signingscript/files/dmg
 export HFSPLUS_PATH=$APP_DIR/signingscript/files/hfsplus
-export ZIPALIGN_PATH=/usr/bin/zipalign
 
 export PASSWORDS_PATH=$CONFIG_DIR/passwords.json
 export APPLE_NOTARIZATION_CREDS_PATH=$CONFIG_DIR/apple_notarization_creds.json

--- a/signingscript/docker.d/worker.yml
+++ b/signingscript/docker.d/worker.yml
@@ -27,7 +27,6 @@ taskcluster_scope_prefixes:
 token_duration_seconds: 7200
 dmg: { "$eval": "DMG_PATH" }
 hfsplus: { "$eval": "HFSPLUS_PATH" }
-zipalign: { "$eval": "ZIPALIGN_PATH" }
 gpg_pubkey: { "$eval": "GPG_PUBKEY_PATH" }
 widevine_cert: { "$eval": "WIDEVINE_CERT_PATH" }
 authenticode_cert: { "$eval": "AUTHENTICODE_CERT_PATH" }

--- a/signingscript/src/signingscript/data/config_schema.json
+++ b/signingscript/src/signingscript/data/config_schema.json
@@ -33,9 +33,6 @@
         "hfsplus": {
             "type": "string"
         },
-        "zipalign": {
-            "type": "string"
-        },
         "gpg_pubkey": {
             "type": "string"
         },

--- a/signingscript/src/signingscript/script.py
+++ b/signingscript/src/signingscript/script.py
@@ -75,7 +75,6 @@ def get_default_config(base_dir=None):
         "my_ip": "127.0.0.1",
         "schema_file": os.path.join(os.path.dirname(__file__), "data", "signing_task_schema.json"),
         "verbose": True,
-        "zipalign": "zipalign",
         "dmg": "dmg",
         "hfsplus": "hfsplus",
         "gpg_pubkey": None,

--- a/signingscript/tests/integration/test_autograph.py
+++ b/signingscript/tests/integration/test_autograph.py
@@ -39,7 +39,6 @@ DEFAULT_CONFIG = {
     "verbose": True,
     "dmg": "dmg",
     "hfsplus": "hfsplus",
-    "zipalign": "zipalign",
 }
 
 


### PR DESCRIPTION
This was only used from sign_jar, but I missed it in #711.