### PR TITLE
Update pkgbuild call to preserve ownership

### DIFF
--- a/iscript/src/iscript/mac.py
+++ b/iscript/src/iscript/mac.py
@@ -1030,6 +1030,8 @@ async def create_pkg_files(config, sign_config, all_paths, requirements_plist_pa
         app.pkg_name = os.path.basename(app.pkg_path)
         cmd = (
             "pkgbuild",
+            "--ownership",
+            "preserve",
             "--install-location",
             "/Applications",
             *cmd_opts,


### PR DESCRIPTION
When pkgbuild runs its recommended ownership, it may set pkg ownership to `root:wheel`. This creates a problem in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1812480) where Firefox installs from .pkg require a password prompt to update. By preserving ownership, we assume that we have started with a clean ownership and will maintain it.