### PR TITLE
beetmover: disable s3 uploads to net-mozaws-{stage,prod}-delivery-{archive,firefox}

### DIFF
--- a/beetmoverscript/docker.d/worker.yml
+++ b/beetmoverscript/docker.d/worker.yml
@@ -230,7 +230,7 @@ clouds:
         'COT_PRODUCT == "firefox" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -259,7 +259,7 @@ clouds:
         'COT_PRODUCT == "firefox" && ENV == "prod"':
           nightly:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "NIGHTLY_ID" }
               key: { "$eval": "NIGHTLY_KEY" }
@@ -269,7 +269,7 @@ clouds:
               mobile:     'net-mozaws-prod-delivery-archive'
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "RELEASE_ID" }
               key: { "$eval": "RELEASE_KEY" }
@@ -287,7 +287,7 @@ clouds:
               firefox: 'fxpartners-distros'
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -315,7 +315,7 @@ clouds:
         'COT_PRODUCT == "xpi" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -325,7 +325,7 @@ clouds:
         'COT_PRODUCT == "xpi" && ENV == "prod"':
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "RELEASE_ID" }
               key: { "$eval": "RELEASE_KEY" }
@@ -335,7 +335,7 @@ clouds:
         'COT_PRODUCT == "thunderbird" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -345,7 +345,7 @@ clouds:
         'COT_PRODUCT == "thunderbird" && ENV == "prod"':
           nightly:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "NIGHTLY_ID" }
               key: { "$eval": "NIGHTLY_KEY" }
@@ -353,7 +353,7 @@ clouds:
               thunderbird: 'net-mozaws-prod-delivery-archive'
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "RELEASE_ID" }
               key: { "$eval": "RELEASE_KEY" }
@@ -361,7 +361,7 @@ clouds:
               thunderbird: 'net-mozaws-prod-delivery-archive'
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -388,7 +388,7 @@ clouds:
 
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -398,7 +398,7 @@ clouds:
           # TODO: nightly and release will only be used while we test prod with dev workers
           nightly:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -407,7 +407,7 @@ clouds:
               focus: 'net-mozaws-stage-delivery-archive'
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -433,7 +433,7 @@ clouds:
               nightly_components: 'maven-nightly-s3-upload-bucket-d4zm9oo354qe'
           nightly:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "NIGHTLY_ID" }
               key: { "$eval": "NIGHTLY_KEY" }
@@ -442,7 +442,7 @@ clouds:
               focus: 'net-mozaws-prod-delivery-archive'
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "RELEASE_ID" }
               key: { "$eval": "RELEASE_KEY" }
@@ -493,7 +493,7 @@ clouds:
         'COT_PRODUCT == "mozillavpn" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -503,7 +503,7 @@ clouds:
         'COT_PRODUCT == "mozillavpn" && ENV == "prod"':
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "RELEASE_ID" }
               key: { "$eval": "RELEASE_KEY" }


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1832287#c1 we don't need to keep uploading these to s3 in addition to gcs.

Uploads to partner and maven buckets remain enabled at this point.