### PR TITLE
Bug 1832546 - require API token for github-based products

### DIFF
--- a/docker.d/init.sh
+++ b/docker.d/init.sh
@@ -23,14 +23,14 @@ test_var_set 'TASKCLUSTER_CLIENT_ID'
 test_var_set 'TASKCLUSTER_ACCESS_TOKEN'
 if [ "$ENV" == "prod" ]; then
   test_var_set 'ED25519_PRIVKEY'
-  case $COT_PRODUCT in
-    firefox|thunderbird)
-      ;;
-    *)
-      test_var_set 'GITHUB_OAUTH_TOKEN'
-      ;;
-  esac
 fi
+case $COT_PRODUCT in
+  firefox|thunderbird)
+    ;;
+  *)
+    test_var_set 'GITHUB_OAUTH_TOKEN'
+    ;;
+esac
 
 #
 # Validate content of certain variables


### PR DESCRIPTION
GITHUB_OAUTH_TOKEN was required in prod workers, but it's actually also used by dev/fake-prod to authenticate requests during CoT verification, and avoid the lower rate limit for unauthenticated requests.