### PR TITLE
beetmoverscript: turn off s3 uploads to archive.mozilla.org for non-f…

### DIFF
--- a/beetmoverscript/docker.d/worker.yml
+++ b/beetmoverscript/docker.d/worker.yml
@@ -267,7 +267,7 @@ clouds:
         'COT_PRODUCT == "xpi" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -277,7 +277,7 @@ clouds:
         'COT_PRODUCT == "xpi" && ENV == "prod"':
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "RELEASE_ID" }
               key: { "$eval": "RELEASE_KEY" }
@@ -332,7 +332,7 @@ clouds:
 
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -342,7 +342,7 @@ clouds:
           # TODO: nightly and release will only be used while we test prod with dev workers
           nightly:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -351,7 +351,7 @@ clouds:
               focus: 'net-mozaws-stage-delivery-archive'
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -377,7 +377,7 @@ clouds:
               nightly_components: 'maven-nightly-s3-upload-bucket-d4zm9oo354qe'
           nightly:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "NIGHTLY_ID" }
               key: { "$eval": "NIGHTLY_KEY" }
@@ -386,7 +386,7 @@ clouds:
               focus: 'net-mozaws-prod-delivery-archive'
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "RELEASE_ID" }
               key: { "$eval": "RELEASE_KEY" }
@@ -437,7 +437,7 @@ clouds:
         'COT_PRODUCT == "mozillavpn" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -447,7 +447,7 @@ clouds:
         'COT_PRODUCT == "mozillavpn" && ENV == "prod"':
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: False
             credentials:
               id: { "$eval": "RELEASE_ID" }
               key: { "$eval": "RELEASE_KEY" }


### PR DESCRIPTION
…irefox/thunderbird products

This achieves part of https://bugzilla.mozilla.org/show_bug.cgi?id=1832287 and 
unblocks uploading focus APKs to archive
(https://bugzilla.mozilla.org/show_bug.cgi?id=1831168) while not breaking tb/ff
as https://bugzilla.mozilla.org/show_bug.cgi?id=1833603 rides the trains.
