### PR TITLE
feat(beetmover): use new GCS credential env vars

### DIFF
--- a/beetmoverscript/docker.d/init_worker.sh
+++ b/beetmoverscript/docker.d/init_worker.sh
@@ -14,7 +14,7 @@ case $COT_PRODUCT in
   firefox)
     case $ENV in
       dev|fake-prod)
-        test_var_set 'GCS_CREDENTIALS'
+        test_var_set 'GCS_DEP_CREDS'
         test_var_set 'DEP_ID'
         test_var_set 'DEP_KEY'
         test_var_set 'DEP_PARTNER_ID'
@@ -23,7 +23,7 @@ case $COT_PRODUCT in
         test_var_set 'MAVEN_KEY'
         ;;
       prod)
-        test_var_set 'GCS_CREDENTIALS'
+        test_var_set 'GCS_RELEASE_CREDS'
         test_var_set 'NIGHTLY_ID'
         test_var_set 'NIGHTLY_KEY'
         test_var_set 'RELEASE_ID'
@@ -41,12 +41,12 @@ case $COT_PRODUCT in
   xpi)
     case $ENV in
       dev|fake-prod)
-        test_var_set 'GCS_CREDENTIALS'
+        test_var_set 'GCS_DEP_CREDS'
         test_var_set 'DEP_ID'
         test_var_set 'DEP_KEY'
         ;;
       prod)
-        test_var_set 'GCS_CREDENTIALS'
+        test_var_set 'GCS_RELEASE_CREDS'
         test_var_set 'RELEASE_ID'
         test_var_set 'RELEASE_KEY'
         ;;
@@ -58,12 +58,12 @@ case $COT_PRODUCT in
   thunderbird)
     case $ENV in
       dev|fake-prod)
-        test_var_set 'GCS_CREDENTIALS'
+        test_var_set 'GCS_DEP_CREDS'
         test_var_set 'DEP_ID'
         test_var_set 'DEP_KEY'
         ;;
       prod)
-        test_var_set 'GCS_CREDENTIALS'
+        test_var_set 'GCS_RELEASE_CREDS'
         test_var_set 'NIGHTLY_ID'
         test_var_set 'NIGHTLY_KEY'
         test_var_set 'RELEASE_ID'
@@ -77,7 +77,7 @@ case $COT_PRODUCT in
   mobile)
     case $ENV in
       dev|fake-prod)
-        test_var_set 'GCS_CREDENTIALS'
+        test_var_set 'GCS_DEP_CREDS'
         test_var_set 'MAVEN_ID'
         test_var_set 'MAVEN_KEY'
         test_var_set 'MAVEN_NIGHTLY_ID'
@@ -86,7 +86,7 @@ case $COT_PRODUCT in
         test_var_set 'DEP_KEY'
         ;;
       prod)
-        test_var_set 'GCS_CREDENTIALS'
+        test_var_set 'GCS_RELEASE_CREDS'
         test_var_set 'MAVEN_ID'
         test_var_set 'MAVEN_KEY'
         test_var_set 'MAVEN_NIGHTLY_ID'
@@ -125,12 +125,12 @@ case $COT_PRODUCT in
   mozillavpn)
     case $ENV in
       dev|fake-prod)
-        test_var_set 'GCS_CREDENTIALS'
+        test_var_set 'GCS_DEP_CREDS'
         test_var_set 'DEP_ID'
         test_var_set 'DEP_KEY'
         ;;
       prod)
-        test_var_set 'GCS_CREDENTIALS'
+        test_var_set 'GCS_RELEASE_CREDS'
         test_var_set 'RELEASE_ID'
         test_var_set 'RELEASE_KEY'
         ;;

--- a/beetmoverscript/docker.d/worker.yml
+++ b/beetmoverscript/docker.d/worker.yml
@@ -61,7 +61,7 @@ clouds:
       $match:
         'COT_PRODUCT == "firefox" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_DEP_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
@@ -75,14 +75,14 @@ clouds:
                 location: 'us'
                 project: 'moz-fx-productdelivery-no-7d6a'
           dep-partner:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_DEP_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
               firefox: 'mozilla-releng-dep-partner'
         'COT_PRODUCT == "firefox" && ENV == "prod"':
           nightly:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_RELEASE_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
@@ -95,7 +95,7 @@ clouds:
                 location: 'us'
                 project: 'moz-fx-productdelivery-pr-38b5'
           release:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_RELEASE_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
@@ -108,62 +108,62 @@ clouds:
                 location: 'us'
                 project: 'moz-fx-productdelivery-pr-38b5'
           partner:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_RELEASE_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
               firefox: 'fxpartners-distros'
         'COT_PRODUCT == "xpi" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_DEP_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
               xpi: 'moz-fx-productdelivery-no-7d6a-productdelivery'
         'COT_PRODUCT == "xpi" && ENV == "prod"':
           release:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_RELEASE_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
               xpi: 'moz-fx-productdelivery-pr-38b5-productdelivery'
         'COT_PRODUCT == "thunderbird" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_DEP_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
               thunderbird: 'moz-fx-productdelivery-no-7d6a-productdelivery'
         'COT_PRODUCT == "thunderbird" && ENV == "prod"':
           nightly:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_RELEASE_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
               thunderbird: 'moz-fx-productdelivery-pr-38b5-productdelivery'
           release:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_RELEASE_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
               thunderbird: 'moz-fx-productdelivery-pr-38b5-productdelivery'
         'COT_PRODUCT == "mobile" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_DEP_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
               fenix: 'moz-fx-productdelivery-no-7d6a-productdelivery'
               focus: 'moz-fx-productdelivery-no-7d6a-productdelivery'
           nightly:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_DEP_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
               fenix: 'moz-fx-productdelivery-no-7d6a-productdelivery'
               focus: 'moz-fx-productdelivery-no-7d6a-productdelivery'
           release:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_DEP_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
@@ -171,14 +171,14 @@ clouds:
               focus: 'moz-fx-productdelivery-no-7d6a-productdelivery'
         'COT_PRODUCT == "mobile" && ENV == "prod"':
           nightly:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_RELEASE_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
               fenix: 'moz-fx-productdelivery-pr-38b5-productdelivery'
               focus: 'moz-fx-productdelivery-pr-38b5-productdelivery'
           release:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_RELEASE_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
@@ -186,14 +186,14 @@ clouds:
               focus: 'moz-fx-productdelivery-pr-38b5-productdelivery'
         'COT_PRODUCT == "mozillavpn" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_DEP_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:
               vpn: 'moz-fx-productdelivery-no-7d6a-productdelivery'
         'COT_PRODUCT == "mozillavpn" && ENV == "prod"':
           release:
-            credentials: { "$eval": "GCS_CREDENTIALS" }
+            credentials: { "$eval": "GCS_RELEASE_CREDS" }
             fail_task_on_error: True
             enabled: True
             product_buckets:

--- a/beetmoverscript/tests/test_config.py
+++ b/beetmoverscript/tests/test_config.py
@@ -34,7 +34,8 @@ def test_firefox_fake_prod():
     context = {
         "COT_PRODUCT": "firefox",
         "ENV": "fake-prod",
-        "GCS_CREDENTIALS": "",
+        "GCS_DEP_CREDS": "",
+        "GCS_RELEASE_CREDS": "",
         "DEP_ID": "",
         "DEP_KEY": "",
         "DEP_PARTNER_ID": "",
@@ -49,7 +50,8 @@ def test_firefox_prod():
     context = {
         "COT_PRODUCT": "firefox",
         "ENV": "prod",
-        "GCS_CREDENTIALS": "",
+        "GCS_DEP_CREDS": "",
+        "GCS_RELEASE_CREDS": "",
         "NIGHTLY_ID": "",
         "NIGHTLY_KEY": "",
         "RELEASE_ID": "",
@@ -70,7 +72,8 @@ def test_thunderbird_fake_prod():
     context = {
         "COT_PRODUCT": "thunderbird",
         "ENV": "fake-prod",
-        "GCS_CREDENTIALS": "",
+        "GCS_DEP_CREDS": "",
+        "GCS_RELEASE_CREDS": "",
         "DEP_ID": "",
         "DEP_KEY": "",
     }
@@ -81,7 +84,8 @@ def test_thunderbird_prod():
     context = {
         "COT_PRODUCT": "thunderbird",
         "ENV": "prod",
-        "GCS_CREDENTIALS": "",
+        "GCS_DEP_CREDS": "",
+        "GCS_RELEASE_CREDS": "",
         "NIGHTLY_ID": "",
         "NIGHTLY_KEY": "",
         "RELEASE_ID": "",
@@ -96,7 +100,8 @@ def test_mobile_fake_prod():
     context = {
         "COT_PRODUCT": "mobile",
         "ENV": "fake-prod",
-        "GCS_CREDENTIALS": "",
+        "GCS_DEP_CREDS": "",
+        "GCS_RELEASE_CREDS": "",
         "DEP_ID": "",
         "DEP_KEY": "",
         "MAVEN_ID": "",
@@ -111,7 +116,8 @@ def test_mobile_prod():
     context = {
         "COT_PRODUCT": "mobile",
         "ENV": "prod",
-        "GCS_CREDENTIALS": "",
+        "GCS_DEP_CREDS": "",
+        "GCS_RELEASE_CREDS": "",
         "DEP_ID": "",
         "DEP_KEY": "",
         "NIGHTLY_ID": "",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -30,7 +30,6 @@ CONTEXT = {
         "DEP_KEY": "1",
         "DEP_PARTNER_ID": "1",
         "DEP_PARTNER_KEY": "1",
-        "GCS_CREDENTIALS": "1",
         "GCS_DEP_CREDS": "1",
         "GCS_RELEASE_CREDS": "1",
         "MAVEN_ID": "1",


### PR DESCRIPTION
This uses the new format that separates env vars for prod vs dep.

Bug: 1832307