### PR TITLE
Fix GPG pubkey to show expired keys as expired

### DIFF
--- a/signingscript/src/signingscript/data/gpg_pubkey_20230505.asc
+++ b/signingscript/src/signingscript/data/gpg_pubkey_20230505.asc
@@ -12,8 +12,8 @@ pub   rsa4096 2015-07-17 [SC]
 uid           [  full  ] Mozilla Software Releases <release@mozilla.com>
 sub   rsa4096 2015-07-17 [S] [expired: 2017-07-16]
 sub   rsa4096 2017-06-22 [S] [expired: 2019-06-22]
-sub   rsa4096 2019-05-30 [S] [expires: 2021-05-29]
-sub   rsa4096 2021-05-17 [S] [expires: 2023-05-17]
+sub   rsa4096 2019-05-30 [S] [expired: 2021-05-29]
+sub   rsa4096 2021-05-17 [S] [expired: 2023-05-17]
 sub   rsa4096 2023-05-05 [S] [expires: 2025-05-04]
 
 -----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
Someone reported this on Matrix. It's a minor thing, but we may as well adjust it.