### PR TITLE
fix(beetmover): configure app-services for GCS rather than S3

### DIFF
--- a/beetmoverscript/docker.d/worker.yml
+++ b/beetmoverscript/docker.d/worker.yml
@@ -198,6 +198,20 @@ clouds:
             enabled: True
             product_buckets:
               vpn: 'moz-fx-productdelivery-pr-38b5-productdelivery'
+        'COT_PRODUCT == "app-services" && (ENV == "dev" || ENV == "fake-prod")':
+          dep:
+            credentials: { "$eval": "GCS_DEP_CREDS" }
+            fail_task_on_error: True
+            enabled: True
+            product_buckets:
+              appservices: 'moz-fx-productdelivery-no-7d6a-productdelivery'
+        'COT_PRODUCT == "app-services" && ENV == "prod"':
+          release:
+            credentials: { "$eval": "GCS_RELEASE_CREDS" }
+            fail_task_on_error: True
+            enabled: True
+            product_buckets:
+              appservices: 'moz-fx-productdelivery-pr-38b5-productdelivery'
 
   aws:
     $merge:
@@ -400,12 +414,6 @@ clouds:
               focus: 'net-mozaws-prod-delivery-archive'
 
         'COT_PRODUCT == "app-services" && (ENV == "dev" || ENV == "fake-prod")':
-          dep:
-            credentials: { "$eval": "GCS_DEP_CREDS" }
-            fail_task_on_error: True
-            enabled: True
-            product_buckets:
-              appservices: 'moz-fx-productdelivery-no-7d6a-productdelivery'
           maven-staging:
             fail_task_on_error: True
             enabled: True
@@ -416,12 +424,6 @@ clouds:
               appservices: 'maven-default-s3-upload-bucket-13gy5ufwa3qv'
 
         'COT_PRODUCT == "app-services" && ENV == "prod"':
-          release:
-            credentials: { "$eval": "GCS_RELEASE_CREDS" }
-            fail_task_on_error: True
-            enabled: True
-            product_buckets:
-              appservices: 'moz-fx-productdelivery-pr-38b5-productdelivery'
           maven-production:
             fail_task_on_error: True
             enabled: True


### PR DESCRIPTION
I accidentally configured these for S3 (I put them next to the maven configs without noticing it was under the `aws` cloud config).