### PR TITLE
beetmoverscript: remove unreachable code

### DIFF
--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -354,7 +354,7 @@ def cleanup(context):
 
 
 # move_beets {{{1
-async def move_beets(context, artifacts_to_beetmove, manifest=None, artifact_map=None):
+async def move_beets(context, artifacts_to_beetmove, artifact_map):
     beets = []
 
     for locale in artifacts_to_beetmove:
@@ -388,35 +388,19 @@ async def move_beets(context, artifacts_to_beetmove, manifest=None, artifact_map
                         installer_path=artifacts_to_beetmove[locale][installer_artifact],
                         context=context,
                         locale=locale,
-                        manifest=manifest,
                         artifact_map=artifact_map,
                     ),
                 )
 
-            if artifact_map:
-                task_id = get_taskId_from_full_path(source)
-                # Should only ever be one (taskId, locale) match.
-                map_entry = extract_file_config_from_artifact_map(artifact_map, artifact, task_id, locale)
+            task_id = get_taskId_from_full_path(source)
+            # Should only ever be one (taskId, locale) match.
+            map_entry = extract_file_config_from_artifact_map(artifact_map, artifact, task_id, locale)
 
-                artifact_pretty_name = map_entry["checksums_path"]
-                destinations = map_entry["destinations"]
-                update_balrog_manifest = map_entry.get("update_balrog_manifest", False)
-                balrog_format = map_entry.get("balrog_format", "")
-                from_buildid = map_entry.get("from_buildid")
-            else:
-                artifact_pretty_name = manifest["mapping"][locale][artifact]["s3_key"]
-                destinations = [os.path.join(manifest["s3_bucket_path"], dest) for dest in manifest["mapping"][locale][artifact]["destinations"]]
-                update_balrog_manifest = manifest["mapping"][locale][artifact].get("update_balrog_manifest")
-                # Adjust old template format.
-                # artifact map specifies these separately.
-                # templates say "update_balrog_manifest": true
-                # or "update_balrog_manifest": {"format": mozinfo}
-                if isinstance(update_balrog_manifest, dict):
-                    balrog_format = update_balrog_manifest.get("format")
-                    update_balrog_manifest = True
-                else:
-                    balrog_format = ""
-                from_buildid = manifest["mapping"][locale][artifact].get("from_buildid")
+            artifact_pretty_name = map_entry["checksums_path"]
+            destinations = map_entry["destinations"]
+            update_balrog_manifest = map_entry.get("update_balrog_manifest", False)
+            balrog_format = map_entry.get("balrog_format", "")
+            from_buildid = map_entry.get("from_buildid")
 
             beets.append(
                 asyncio.ensure_future(

--- a/beetmoverscript/src/beetmoverscript/task.py
+++ b/beetmoverscript/src/beetmoverscript/task.py
@@ -217,7 +217,7 @@ def get_release_props(task, platform_mapping=STAGE_PLATFORM_MAP):
     return payload_properties
 
 
-def get_updated_buildhub_artifact(path, installer_artifact, installer_path, context, locale, manifest=None, artifact_map=None):
+def get_updated_buildhub_artifact(path, installer_artifact, installer_path, context, locale, artifact_map):
     """
     Read the file into a dict, alter the fields below, and return the updated dict
     buildhub.json fields that should be changed: download.size, download.date, download.url
@@ -225,13 +225,9 @@ def get_updated_buildhub_artifact(path, installer_artifact, installer_path, cont
     contents = utils.load_json(path)
     url_prefix = utils.get_url_prefix(context)
 
-    if artifact_map:
-        task_id = get_taskId_from_full_path(installer_path)
-        cfg = utils.extract_file_config_from_artifact_map(artifact_map, installer_artifact, task_id, locale)
-        path = urllib.parse.quote(cfg["destinations"][0])
-    else:
-        dest = manifest["mapping"][locale][installer_artifact]["destinations"][0]
-        path = urllib.parse.quote(urllib.parse.urljoin(manifest["s3_bucket_path"], dest))
+    task_id = get_taskId_from_full_path(installer_path)
+    cfg = utils.extract_file_config_from_artifact_map(artifact_map, installer_artifact, task_id, locale)
+    path = urllib.parse.quote(cfg["destinations"][0])
     url = urllib.parse.urljoin(url_prefix, path)
 
     # Update fields

--- a/beetmoverscript/tests/test_script.py
+++ b/beetmoverscript/tests/test_script.py
@@ -234,14 +234,13 @@ def restore_buildhub_file():
 
 # move_beets {{{1
 @pytest.mark.asyncio
-@pytest.mark.parametrize("task_filename", ("task.json", "task_artifact_map.json"))
 @pytest.mark.parametrize("partials", (False, True))
-async def test_move_beets(task_filename, partials, mocker, restore_buildhub_file):
+async def test_move_beets(partials, mocker, restore_buildhub_file):
     mocker.patch("beetmoverscript.utils.JINJA_ENV", get_test_jinja_env())
 
     context = Context()
     context.config = get_fake_valid_config()
-    context.task = get_fake_valid_task(taskjson=task_filename)
+    context.task = get_fake_valid_task(taskjson="task_artifact_map.json")
     context.release_props = context.task["payload"]["releaseProperties"]
     context.release_props["stage_platform"] = context.release_props["platform"]
     context.resource = "nightly"
@@ -249,12 +248,7 @@ async def test_move_beets(task_filename, partials, mocker, restore_buildhub_file
     context.raw_balrog_manifest = dict()
     context.balrog_manifest = list()
     context.artifacts_to_beetmove = get_upstream_artifacts(context)
-    if context.task["payload"].get("artifactMap"):
-        artifact_map = context.task["payload"].get("artifactMap")
-        manifest = None
-    else:
-        artifact_map = None
-        manifest = generate_beetmover_manifest(context)
+    artifact_map = context.task["payload"]["artifactMap"]
 
     expected_sources = [
         os.path.abspath("tests/test_work_dir/cot/eSzfNqMZT_mSiQQXu8hyqg/public/build/target.mozinfo.json"),
@@ -359,7 +353,7 @@ async def test_move_beets(task_filename, partials, mocker, restore_buildhub_file
                 context.raw_balrog_manifest[locale].setdefault("completeInfo", {})[balrog_format] = data
 
     with mock.patch("beetmoverscript.script.move_beet", fake_move_beet):
-        await move_beets(context, context.artifacts_to_beetmove, manifest=manifest, artifact_map=artifact_map)
+        await move_beets(context, context.artifacts_to_beetmove, artifact_map=artifact_map)
 
     assert sorted(expected_sources) == sorted(actual_sources)
     assert sorted(expected_destinations) == sorted(actual_destinations)
@@ -372,12 +366,13 @@ async def test_move_beets(task_filename, partials, mocker, restore_buildhub_file
 
 # move_beets {{{1
 @pytest.mark.asyncio
-async def test_move_beets_raises(mocker):
+@pytest.mark.parametrize("task_filename", ("task.json", "task_missing_installer.json"))
+async def test_move_beets_raises(mocker, task_filename):
     mocker.patch("beetmoverscript.utils.JINJA_ENV", get_test_jinja_env())
 
     context = Context()
     context.config = get_fake_valid_config()
-    context.task = get_fake_valid_task(taskjson="task_missing_installer.json")
+    context.task = get_fake_valid_task(taskjson=task_filename)
     context.release_props = context.task["payload"]["releaseProperties"]
     context.release_props["stage_platform"] = context.release_props["platform"]
     context.resource = "nightly"
@@ -386,8 +381,8 @@ async def test_move_beets_raises(mocker):
     context.balrog_manifest = list()
     context.artifacts_to_beetmove = get_upstream_artifacts(context)
 
-    with pytest.raises(ScriptWorkerTaskException):
-        await move_beets(context, context.artifacts_to_beetmove, manifest=None, artifact_map=None)
+    with pytest.raises(ScriptWorkerTaskException) as excinfo:
+        await move_beets(context, context.artifacts_to_beetmove, artifact_map={})
 
 
 # move_beet {{{1

--- a/beetmoverscript/tests/test_script.py
+++ b/beetmoverscript/tests/test_script.py
@@ -381,7 +381,7 @@ async def test_move_beets_raises(mocker, task_filename):
     context.balrog_manifest = list()
     context.artifacts_to_beetmove = get_upstream_artifacts(context)
 
-    with pytest.raises(ScriptWorkerTaskException) as excinfo:
+    with pytest.raises(ScriptWorkerTaskException):
         await move_beets(context, context.artifacts_to_beetmove, artifact_map={})
 
 


### PR DESCRIPTION
Since the switch to declarative artifacts, move_beets is always called with an artifact_map, not a manifest.