### PR TITLE
revert #569

### DIFF
--- a/treescript/src/treescript/versionmanip.py
+++ b/treescript/src/treescript/versionmanip.py
@@ -147,10 +147,6 @@ async def do_bump_version(config, repo_path, files, next_version, source_repo):
             is_esr = curr_version.is_esr
         except AttributeError:  # Fenix does not expose the is_esr attribute
             is_esr = False
-        else:
-            if not is_esr and next_version.is_esr:
-                # if the file had no esr prefix then don't add it
-                next_version = VersionClass.parse(str(next_version)[:-3])
 
         # XXX In the case of ESR, some files (like version.txt) show version numbers without `esr`
         # at the end. next_version is usually provided without `esr` too.

--- a/treescript/tests/test_versionmanip.py
+++ b/treescript/tests/test_versionmanip.py
@@ -107,13 +107,11 @@ def test_find_what_version_parser_to_use(file, source_repo, expectation, expecte
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("new_version, should_append_esr", (("68.0", True), ("68.0b3", False), ("68.0esr", False)))
+@pytest.mark.parametrize("new_version, should_append_esr", (("68.0", True), ("68.0b3", False)))
 async def test_bump_version(mocker, repo_context, new_version, should_append_esr):
     test_version = new_version
     if repo_context.xtest_version.endswith("esr") and should_append_esr:
         test_version = new_version + "esr"
-    if new_version.endswith("esr") and not repo_context.xtest_version.endswith("esr"):
-        test_version = new_version[:-3]
 
     relative_files = [os.path.join("config", "milestone.txt")]
     bump_info = {"files": relative_files, "next_version": new_version}


### PR DESCRIPTION
Revert #569 , https://github.com/mozilla-releng/scriptworker-scripts/commit/85a2f882c1d7db1b9c87f7d5b33b318d0762c2db . It causes a release-to-esr failure: https://firefox-ci-tc.services.mozilla.com/tasks/Gc_k1BQoSyWe3_vWleBZ5w