### PR TITLE
Use dev bounceradmin for dev bouncer scriptworkers

### DIFF
--- a/bouncerscript/docker.d/worker.yml
+++ b/bouncerscript/docker.d/worker.yml
@@ -5,9 +5,9 @@ taskcluster_scope_prefix: { "$eval": "TASKCLUSTER_SCOPE_PREFIX" }
 bouncer_config:
   $merge:
     $match:
-      'COT_PRODUCT == "firefox"':
+      'COT_PRODUCT == "firefox" && (ENV == "dev" || ENV == "fake-prod")':
         project:releng:bouncer:server:staging:
-          api_root: 'https://bounceradmin-default.stage.mozaws.net/api'
+          api_root: 'https://dev.bounceradmin.nonprod.webservices.mozgcp.net/api'
           timeout_in_seconds: 60
           username: { "$eval": "BOUNCER_USERNAME" }
           password: { "$eval": "BOUNCER_PASSWORD" }
@@ -19,9 +19,9 @@ bouncer_config:
           username: { "$eval": "BOUNCER_USERNAME" }
           password: { "$eval": "BOUNCER_PASSWORD" }
 
-      'COT_PRODUCT == "thunderbird"':
+      'COT_PRODUCT == "thunderbird" && (ENV == "dev" || ENV == "fake-prod")':
         project:comm:thunderbird:releng:bouncer:server:staging:
-          api_root: 'https://bounceradmin-default.stage.mozaws.net/api'
+          api_root: 'https://dev.bounceradmin.nonprod.webservices.mozgcp.net/api'
           timeout_in_seconds: 60
           username: { "$eval": "BOUNCER_USERNAME" }
           password: { "$eval": "BOUNCER_PASSWORD" }

--- a/bouncerscript/src/bouncerscript/constants.py
+++ b/bouncerscript/src/bouncerscript/constants.py
@@ -154,8 +154,8 @@ BOUNCER_LOCATION_PLATFORMS = ["linux", "linux64", "osx", "win", "win64", "androi
 GO_BOUNCER_URL_TMPL = {
     "project:releng:bouncer:server:production": "https://download.mozilla.org/?product={}&print=yes",
     "project:comm:thunderbird:releng:bouncer:server:production": "https://download.mozilla.org/?product={}&print=yes",
-    "project:releng:bouncer:server:staging": "https://bouncer-bouncer-releng.stage.mozaws.net/?product={}&print=yes",
-    "project:comm:thunderbird:releng:bouncer:server:staging": "https://bouncer-bouncer-releng.stage.mozaws.net/?product={}&print=yes",
+    "project:releng:bouncer:server:staging": "https://dev.bouncer.nonprod.webservices.mozgcp.net/?product={}&print=yes",
+    "project:comm:thunderbird:releng:bouncer:server:staging": "https://dev.bouncer.nonprod.webservices.mozgcp.net/?product={}&print=yes",
 }
 
 NIGHTLY_VERSION_REGEX = r"\d+\.\d+a1"


### PR DESCRIPTION
As part of https://bugzilla.mozilla.org/show_bug.cgi?id=1819405 / https://mozilla-hub.atlassian.net/browse/SVCSE-1186 we are going to make it possible to use the new dev bounceradmin & bouncer instances in staging releases. To this end, we need to point dev bouncerscript instances at dev bounceradmin.

I'm also making the staging entry more explicit here, but that should be a no-op.

@jcristau - I think you had thoughts or concerns about this - so I'm flagging you explictly.