### PR TITLE
Stop requiring autograph stage credentials for adhoc dep signing workers

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -163,14 +163,6 @@ case $ENV in
         test_var_set 'AUTOGRAPH_MAR_USERNAME'
         test_var_set 'AUTOGRAPH_GPG_PASSWORD'
         test_var_set 'AUTOGRAPH_GPG_USERNAME'
-        test_var_set 'AUTOGRAPH_STAGE_FENIX_PASSWORD'
-        test_var_set 'AUTOGRAPH_STAGE_FENIX_USERNAME'
-        test_var_set 'AUTOGRAPH_STAGE_FENIX_V3_PASSWORD'
-        test_var_set 'AUTOGRAPH_STAGE_FENIX_V3_USERNAME'
-        test_var_set 'AUTOGRAPH_STAGE_FOCUS_PASSWORD'
-        test_var_set 'AUTOGRAPH_STAGE_FOCUS_USERNAME'
-        test_var_set 'AUTOGRAPH_STAGE_FOCUS_V3_PASSWORD'
-        test_var_set 'AUTOGRAPH_STAGE_FOCUS_V3_USERNAME'
         test_var_set 'GPG_PUBKEY_PATH'
         ;;
     esac

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -200,26 +200,6 @@ in:
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["autograph_gpg"]
             ]
-          - ["https://autograph-external.stage.autograph.services.mozaws.net",
-             {"$eval": "AUTOGRAPH_STAGE_FOCUS_USERNAME"},
-             {"$eval": "AUTOGRAPH_STAGE_FOCUS_PASSWORD"},
-             ["autograph_stage_focus"]
-            ]
-          - ["https://autograph-external.stage.autograph.services.mozaws.net",
-             {"$eval": "AUTOGRAPH_STAGE_FENIX_USERNAME"},
-             {"$eval": "AUTOGRAPH_STAGE_FENIX_PASSWORD"},
-             ["autograph_stage_apk", "autograph_stage_apk_mozillaonline"]
-            ]
-          - ["https://autograph-external.stage.autograph.services.mozaws.net",
-             {"$eval": "AUTOGRAPH_STAGE_FOCUS_V3_USERNAME"},
-             {"$eval": "AUTOGRAPH_STAGE_FOCUS_V3_PASSWORD"},
-             ["autograph_stage_focus_v3"]
-            ]
-          - ["https://autograph-external.stage.autograph.services.mozaws.net",
-             {"$eval": "AUTOGRAPH_STAGE_FENIX_V3_USERNAME"},
-             {"$eval": "AUTOGRAPH_STAGE_FENIX_V3_PASSWORD"},
-             ["autograph_stage_apk_v3", "autograph_stage_apk_mozillaonline_v3"]
-            ]
 
       # passwords.json
       'ENV == "prod" && (COT_PRODUCT == "firefox" || COT_PRODUCT == "thunderbird")':


### PR DESCRIPTION
Fixes bustage because these credentials aren't currently filled in.