### PR TITLE
Bug 1853416 - [treescript] Split hg and git logic apart, r?#releng-re…

### DIFF
--- a/treescript/src/treescript/gecko/__init__.py
+++ b/treescript/src/treescript/gecko/__init__.py
@@ -1,0 +1,78 @@
+import logging
+import os
+
+from treescript.gecko import mercurial as vcs
+from treescript.gecko.l10n import l10n_bump
+from treescript.gecko.merges import do_merge
+from treescript.gecko.versionmanip import bump_version
+from treescript.exceptions import TreeScriptError
+from treescript.util.task import get_source_repo, should_push, task_action_types
+
+log = logging.getLogger(__name__)
+
+
+async def perform_merge_actions(config, task, actions, repo_path):
+    """Perform merge day related actions.
+
+    This has different behaviour to other treescript actions:
+    * Reporting on outgoing changesets has less meaning
+    * Logging outgoing changesets can easily break with the volume and content of the diffs
+    * We need to do more than just |hg push -r .| since we have two branches to update
+
+    Args:
+        config (dict): the running config
+        task (dict): the running task
+        actions (list): the actions to perform
+        repo_path (str): the source directory to use.
+    """
+    log.info("Starting merge day operations")
+    push_activity = await do_merge(config, task, repo_path)
+
+    if should_push(task, actions) and push_activity:
+        log.info("%d branches to push", len(push_activity))
+        for target_repo, revision in push_activity:
+            log.info("pushing %s to %s", revision, target_repo)
+            await vcs.push(config, task, repo_path, target_repo=target_repo, revision=revision)
+
+
+async def do_actions(config, task):
+    """Perform the set of actions that treescript can perform.
+
+    The actions happen in order, tagging, ver bump, then push
+
+    Args:
+        config (dict): the running config
+        task (dict): the running task
+    """
+    work_dir = config["work_dir"]
+    repo_path = os.path.join(work_dir, "src")
+    actions = task_action_types(config, task)
+    await vcs.log_mercurial_version(config)
+    if not await vcs.validate_robustcheckout_works(config):
+        raise TreeScriptError("Robustcheckout can't run on our version of hg, aborting")
+
+    await vcs.checkout_repo(config, task, repo_path)
+
+    # Split the action selection up due to complexity in do_actions
+    # caused by different push behaviour, and action return values.
+    if "merge_day" in actions:
+        await perform_merge_actions(config, task, actions, repo_path)
+        return
+
+    num_changes = 0
+    if "tag" in actions:
+        num_changes += await vcs.do_tagging(config, task, repo_path)
+    if "version_bump" in actions:
+        num_changes += await bump_version(config, task, repo_path)
+    if "l10n_bump" in actions:
+        num_changes += await l10n_bump(config, task, repo_path)
+
+    num_outgoing = await vcs.log_outgoing(config, task, repo_path)
+    if num_outgoing != num_changes:
+        raise TreeScriptError("Outgoing changesets don't match number of expected changesets!" " {} vs {}".format(num_outgoing, num_changes))
+    if should_push(task, actions):
+        if num_changes:
+            await vcs.push(config, task, repo_path, target_repo=get_source_repo(task))
+        else:
+            log.info("No changes; skipping push.")
+    await vcs.strip_outgoing(config, task, repo_path)

--- a/treescript/src/treescript/gecko/l10n.py
+++ b/treescript/src/treescript/gecko/l10n.py
@@ -16,7 +16,8 @@ from scriptworker_client.aio import download_file, retry_async, semaphore_wrappe
 from scriptworker_client.exceptions import DownloadError
 from scriptworker_client.utils import load_json_or_yaml
 
-from treescript.task import CLOSED_TREE_MSG, DONTBUILD_MSG, get_dontbuild, get_ignore_closed_tree, get_l10n_bump_info, get_short_source_repo, get_vcs_module
+from treescript.gecko import mercurial as vcs
+from treescript.util.task import CLOSED_TREE_MSG, DONTBUILD_MSG, get_dontbuild, get_ignore_closed_tree, get_l10n_bump_info, get_short_source_repo
 
 log = logging.getLogger(__name__)
 
@@ -209,7 +210,7 @@ async def check_treestatus(config, task):
 
 
 # l10n_bump {{{1
-async def l10n_bump(config, task, repo_path, repo_type="hg"):
+async def l10n_bump(config, task, repo_path):
     """Perform a l10n revision bump.
 
     This function takes its inputs from task by using the ``get_l10n_bump_info``
@@ -220,7 +221,6 @@ async def l10n_bump(config, task, repo_path, repo_type="hg"):
         config (dict): the running config
         task (dict): the running task
         repo_path (str): the source directory
-        repo_type (str): the repository type
 
     Raises:
         TaskVerificationError: if a file specified is not allowed, or
@@ -230,8 +230,6 @@ async def l10n_bump(config, task, repo_path, repo_type="hg"):
         int: non-zero if there are any changes.
 
     """
-    vcs = get_vcs_module(repo_type)
-
     log.info("Preparing to bump l10n changesets.")
 
     ignore_closed_tree = get_ignore_closed_tree(task)

--- a/treescript/src/treescript/gecko/mercurial.py
+++ b/treescript/src/treescript/gecko/mercurial.py
@@ -7,12 +7,12 @@ import tempfile
 from scriptworker_client.utils import load_json_or_yaml, makedirs, run_command
 
 from treescript.exceptions import CheckoutError, FailedSubprocess, PushError
-from treescript.task import DONTBUILD_MSG, get_branch, get_dontbuild, get_source_repo, get_ssh_user, get_tag_info
+from treescript.util.task import DONTBUILD_MSG, get_branch, get_dontbuild, get_source_repo, get_ssh_user, get_tag_info
 
 # https://www.mercurial-scm.org/repo/hg/file/tip/tests/run-tests.py#l1040
 # For environment vars.
 
-HGRCPATH = os.path.join(os.path.dirname(__file__), "data", "hgrc")
+HGRCPATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "hgrc")
 TAG_MSG = "No bug - Tagging {revision} with {tags} a=release CLOSED TREE"
 
 log = logging.getLogger(__name__)

--- a/treescript/src/treescript/gecko/merges.py
+++ b/treescript/src/treescript/gecko/merges.py
@@ -8,10 +8,10 @@ from datetime import date
 import attr
 from scriptworker_client.utils import makedirs
 
-from treescript.l10n import l10n_bump
-from treescript.mercurial import commit, get_revision, run_hg_command
-from treescript.task import get_l10n_bump_info, get_merge_config, get_metadata_source_repo
-from treescript.versionmanip import do_bump_version, get_version
+from treescript.gecko.l10n import l10n_bump
+from treescript.gecko.mercurial import commit, get_revision, run_hg_command
+from treescript.gecko.versionmanip import do_bump_version, get_version
+from treescript.util.task import get_l10n_bump_info, get_merge_config, get_metadata_source_repo
 
 log = logging.getLogger(__name__)
 
@@ -110,7 +110,7 @@ async def apply_rebranding(config, repo_path, merge_config, source_repo):
 
     if merge_config.get("version_files"):
         for version_config in merge_config["version_files"]:
-            await do_bump_version(config, repo_path, [version_config["filename"]], create_new_version(version_config, repo_path, source_repo), source_repo)
+            await do_bump_version(repo_path, [version_config["filename"]], create_new_version(version_config, repo_path, source_repo), source_repo)
 
     for f in merge_config.get("copy_files", list()):
         shutil.copyfile(os.path.join(repo_path, f[0]), os.path.join(repo_path, f[1]))

--- a/treescript/src/treescript/github/__init__.py
+++ b/treescript/src/treescript/github/__init__.py
@@ -1,0 +1,39 @@
+import logging
+import os
+
+from treescript.github import git as vcs
+from treescript.github.versionmanip import bump_version
+from treescript.exceptions import TreeScriptError
+from treescript.util.task import get_source_repo, should_push, task_action_types
+
+log = logging.getLogger(__name__)
+
+
+async def do_actions(config, task):
+    """Perform the set of actions that treescript can perform.
+
+    The actions happen in order, tagging, ver bump, then push
+
+    Args:
+        config (dict): the running config
+        task (dict): the running task
+    """
+    work_dir = config["work_dir"]
+    repo_path = os.path.join(work_dir, "src")
+    actions = task_action_types(config, task)
+    await vcs.checkout_repo(config, task, repo_path)
+
+    num_changes = 0
+    if "version_bump" in actions:
+        num_changes += await bump_version(config, task, repo_path)
+
+    num_outgoing = await vcs.log_outgoing(config, task, repo_path)
+    if num_outgoing != num_changes:
+        raise TreeScriptError("Outgoing changesets don't match number of expected changesets!" " {} vs {}".format(num_outgoing, num_changes))
+    if should_push(task, actions):
+        if num_changes:
+            await vcs.push(config, task, repo_path, target_repo=get_source_repo(task))
+        else:
+            log.info("No changes; skipping push.")
+    await vcs.strip_outgoing(config, task, repo_path)
+

--- a/treescript/src/treescript/github/git.py
+++ b/treescript/src/treescript/github/git.py
@@ -7,7 +7,7 @@ from scriptworker_client.github import extract_github_repo_ssh_url
 from scriptworker_client.utils import get_single_item_from_sequence, makedirs
 
 from treescript.exceptions import PushError, TaskVerificationError
-from treescript.task import get_branch, get_source_repo, get_ssh_user
+from treescript.util.task import get_branch, get_source_repo, get_ssh_user
 
 log = logging.getLogger(__name__)
 

--- a/treescript/src/treescript/github/versionmanip.py
+++ b/treescript/src/treescript/github/versionmanip.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+"""Treescript version manipulation."""
+
+import logging
+import os
+
+from mozilla_version.gecko import FirefoxVersion, GeckoVersion, ThunderbirdVersion
+from mozilla_version.mobile import MobileVersion
+
+from treescript.github import git as vcs
+from treescript.exceptions import TaskVerificationError, TreeScriptError
+from treescript.util.task import DONTBUILD_MSG, get_dontbuild, get_metadata_source_repo, get_version_bump_info
+
+log = logging.getLogger(__name__)
+
+
+ALLOWED_BUMP_FILES = (
+    "version.txt",
+)
+
+_VERSION_CLASS_PER_BEGINNING_OF_PATH = {
+    "mobile/android/": MobileVersion,
+}
+
+_VERSION_CLASS_PER_END_OF_SOURCE_REPO = {
+    "firefox-android": MobileVersion,
+}
+
+
+def _find_what_version_parser_to_use(file_, source_repo):
+    version_classes = [cls for path, cls in _VERSION_CLASS_PER_BEGINNING_OF_PATH.items() if file_.startswith(path)]
+
+    number_of_version_classes = len(version_classes)
+    if number_of_version_classes > 1:
+        raise TreeScriptError(f'File "{file_}" matched too many classes: {version_classes}')
+    if number_of_version_classes > 0:
+        return version_classes[0]
+
+    log.info("Could not determine version class based on file path. Falling back to source_repo")
+
+    version_classes = [cls for repo_name, cls in _VERSION_CLASS_PER_END_OF_SOURCE_REPO.items() if source_repo.endswith(repo_name)]
+    try:
+        return version_classes[0]
+    except IndexError as exc:
+        raise TreeScriptError(exc) from exc
+
+
+def get_version(file_, parent_directory, source_repo):
+    """Parse the version from file.
+
+    Args:
+        file_ (str): the version file path
+        parent_directory (str): the directory file_ lives under
+
+    Returns:
+        str: the version.
+
+    """
+    abs_path = os.path.join(parent_directory, file_)
+    log.info("Reading {} for version information.".format(abs_path))
+    VersionClass = _find_what_version_parser_to_use(file_, source_repo)
+    with open(abs_path, "r") as f:
+        contents = f.read()
+    log.info("Contents:")
+    for line in contents.splitlines():
+        log.info(" {}".format(line))
+    lines = [line for line in contents.splitlines() if line and not line.startswith("#")]
+    return VersionClass.parse(lines[-1])
+
+
+async def bump_version(config, task, repo_path):
+    """Perform a version bump.
+
+    This function takes its inputs from task by using the ``get_version_bump_info``
+    function from treescript.task. Using `next_version` and `files`, then
+    calls do_version_bump to perform the work.
+
+    Args:
+        config (dict): the running config
+        task (dict): the running task
+        repo_path (str): the source directory
+
+    Returns:
+        int: the number of commits created.
+
+    """
+    bump_info = get_version_bump_info(task)
+    num_commits = 0
+
+    source_repo = get_metadata_source_repo(task)
+    changed = await do_bump_version(repo_path, bump_info["files"], bump_info["next_version"], source_repo)
+    if changed:
+        commit_msg = "Automatic version bump CLOSED TREE NO BUG a=release"
+        if get_dontbuild(task):
+            commit_msg += DONTBUILD_MSG
+        await vcs.commit(config, repo_path, commit_msg)
+        num_commits += 1
+    return num_commits
+
+
+async def do_bump_version(repo_path, files, next_version, source_repo):
+    """Perform a version bump.
+
+    This function takes its inputs from task by using the ``get_version_bump_info``
+    function from treescript.task. Using `next_version` and `files`.
+
+    This function does nothing (but logs) if the current version and next version
+    match, and nothing if the next_version is actually less than current_version.
+
+    Args:
+        config (dict): the running config
+        task (dict): the running task
+        repo_path (str): the source directory
+
+    Raises:
+        TaskverificationError: if a file specified is not allowed, or
+                               if the file is not in the target repository.
+
+    Returns:
+        int: the number of commits created.
+
+    """
+    changed = False
+    saved_next_version = next_version
+
+    for file_ in files:
+        abs_file = os.path.join(repo_path, file_)
+        if file_ not in ALLOWED_BUMP_FILES:
+            raise TaskVerificationError("{} is not in version bump whitelist".format(file_))
+        if not os.path.exists(abs_file):
+            raise TaskVerificationError("{} is not in repo".format(abs_file))
+
+        VersionClass = _find_what_version_parser_to_use(file_, source_repo)
+        curr_version = get_version(file_, repo_path, source_repo)
+        next_version = VersionClass.parse(saved_next_version)
+
+        try:
+            is_esr = curr_version.is_esr
+        except AttributeError:  # Fenix does not expose the is_esr attribute
+            is_esr = False
+
+        # XXX In the case of ESR, some files (like version.txt) show version numbers without `esr`
+        # at the end. next_version is usually provided without `esr` too.
+        # That's why we do this late minute replacement and why we reset `next_version` at every
+        # cycle of the loop
+        if is_esr and not any(
+            (
+                next_version.is_esr,  # No need to append esr again
+                # We don't want XX.Ya1esr nor XX.YbNesr
+                next_version.is_aurora_or_devedition,
+                next_version.is_beta,
+            )
+        ):
+            next_version = VersionClass.parse("{}esr".format(next_version))
+
+        if next_version < curr_version:
+            log.warning("Version bumping skipped due to conflicting values: " "(next version {} is < current version {})".format(next_version, curr_version))
+            continue
+        elif next_version == curr_version:
+            log.info("Version bumping skipped due to unchanged values")
+            continue
+        else:
+            changed = True
+            replace_ver_in_file(abs_file, curr_version, next_version)
+
+    return changed
+
+
+def replace_ver_in_file(file_, curr_version, new_version):
+    """Read in contents of `file` and then update version.
+
+    Implementation detail: replaces instances of `curr_version` with `new_version`
+    using python3 str.replace().
+
+    Args:
+        file_ (str): the path to the file
+        curr_version (str): the current version
+        new_version (str): the version to bump to
+
+    Raises:
+        Exception: if contents before and after match.
+
+    """
+    with open(file_, "r") as f:
+        contents = f.read()
+    new_contents = contents.replace(str(curr_version), str(new_version))
+    if contents == new_contents:
+        raise Exception("Did not expect no changes")
+    with open(file_, "w") as f:
+        f.write(new_contents)

--- a/treescript/src/treescript/util/task.py
+++ b/treescript/src/treescript/util/task.py
@@ -284,29 +284,3 @@ def get_merge_config(task):
         return task.get("payload", {})["merge_info"]
     except KeyError:
         raise TaskVerificationError("Requested merge action with missing merge configuration.")
-
-
-def get_vcs_module(repo_type):
-    """Get the python module that handles VCS operations.
-
-    Args:
-        repo_type (str): the repository type
-
-    Raises:
-        NotImplementedError: if the given repo type is not supported.
-
-    Returns:
-        module: the python module of the corresponding repo_type
-    """
-    if repo_type == "hg":
-        from treescript import mercurial
-
-        vcs = mercurial
-    elif repo_type == "git":
-        from treescript import git
-
-        vcs = git
-    else:
-        raise NotImplementedError('Unsupported repo type "{}"'.format(repo_type))
-
-    return vcs

--- a/treescript/tests/conftest.py
+++ b/treescript/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from treescript.mercurial import HGRCPATH
+from treescript.gecko.mercurial import HGRCPATH
 
 ROBUSTCHECKOUT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "vendored", "robustcheckout.py"))
 HGRC_ROBUSTCHECKOUT = os.path.abspath(os.path.join(os.path.dirname(__file__), "robustcheckout.hgrc"))

--- a/treescript/tests/test_gecko.py
+++ b/treescript/tests/test_gecko.py
@@ -1,0 +1,194 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from treescript import gecko, script
+from treescript.exceptions import TreeScriptError
+
+
+# do_actions {{{1
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "push_scope,push_payload,dry_run,push_expect_called",
+    (
+        (["push"], False, False, False),
+        (["push"], False, True, False),
+        (["push"], True, False, True),
+        (["push"], True, True, False),
+        ([], False, False, False),
+        ([], False, True, False),
+        ([], True, False, True),
+        ([], True, True, False),
+    ),
+)
+async def test_do_actions(mocker, push_scope, push_payload, dry_run, push_expect_called):
+    actions = ["tag", "version_bump", "l10n_bump"]
+    actions += push_scope
+    called = {"version_bump": False, "l10n_bump": False, "merge": False}
+
+    async def mocked_bump(*args, **kwargs):
+        called["version_bump"] = True
+        return 1
+
+    async def mocked_l10n(*args, **kwargs):
+        called["l10n_bump"] = True
+        return 1
+
+    async def mocked_perform_merge_actions(*args, **kwargs):
+        called["merge"] = True
+
+    vcs_mock = AsyncMock()
+    vcs_mock.do_tagging.return_value = 1
+    vcs_mock.log_outgoing.return_value = 3
+
+    mocker.patch.object(gecko, "vcs", new=vcs_mock)
+    mocker.patch.object(gecko, "bump_version", new=mocked_bump)
+    mocker.patch.object(gecko, "l10n_bump", new=mocked_l10n)
+    mocker.patch.object(gecko, "perform_merge_actions", new=mocked_perform_merge_actions)
+
+    task_defn = {
+        "payload": {"push": push_payload, "dry_run": dry_run, "actions": actions},
+        "metadata": {"source": "https://hg.mozilla.org/releases/mozilla-test-source" "/file/1b4ab9a276ce7bb217c02b83057586e7946860f9/taskcluster/ci/foobar"},
+    }
+    await gecko.do_actions({"work_dir": "foo"}, task_defn)
+
+    assert called["merge"] is False
+    vcs_mock.checkout_repo.assert_called_once()
+    vcs_mock.do_tagging.assert_called_once()
+    vcs_mock.log_outgoing.assert_called_once()
+    vcs_mock.strip_outgoing.assert_called_once()
+    if push_expect_called:
+        vcs_mock.push.assert_called_once()
+    else:
+        vcs_mock.push.assert_not_called()
+
+
+# do_actions {{{1
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "push_scope,push_payload,dry_run",
+    (
+        (["push"], False, False),
+        (["push"], False, True),
+        (["push"], True, False),
+        (["push"], True, True),
+        ([], False, False),
+        ([], False, True),
+        ([], True, False),
+        ([], True, True),
+    ),
+)
+async def test_do_actions_merge_tasks(mocker, push_scope, push_payload, dry_run):
+    actions = ["merge_day"]
+    actions += push_scope
+    called = {"version_bump": False, "l10n_bump": False, "merge": False}
+
+    async def mocked_bump(*args, **kwargs):
+        called["version_bump"] = True
+        return 1
+
+    async def mocked_l10n(*args, **kwargs):
+        called["l10n_bump"] = True
+        return 1
+
+    async def mocked_perform_merge_actions(*args, **kwargs):
+        called["merge"] = True
+
+    vcs_mock = AsyncMock()
+    vcs_mock.do_tagging.return_value = 1
+    vcs_mock.log_outgoing.return_value = 0
+
+    mocker.patch.object(gecko, "vcs", new=vcs_mock)
+    mocker.patch.object(gecko, "bump_version", new=mocked_bump)
+    mocker.patch.object(gecko, "l10n_bump", new=mocked_l10n)
+    mocker.patch.object(gecko, "perform_merge_actions", new=mocked_perform_merge_actions)
+
+    task_defn = {
+        "payload": {"push": push_payload, "dry_run": dry_run, "actions": actions},
+        "metadata": {"source": "https://hg.mozilla.org/releases/mozilla-test-source" "/file/1b4ab9a276ce7bb217c02b83057586e7946860f9/taskcluster/ci/foobar"},
+    }
+    await gecko.do_actions({"work_dir": "foo"}, task_defn)
+    for action in ["version_bump", "l10n_bump"]:
+        assert called[action] is False
+    assert called["merge"] is True
+
+    vcs_mock.checkout_repo.assert_called_once()
+    vcs_mock.log_outgoing.assert_not_called()
+    vcs_mock.strip_outgoing.assert_not_called()
+
+
+# do_actions {{{1
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "push_scope,should_push,push_expect_called", ((["push"], False, False), (["push"], True, True), ([], False, False), ([], False, False))
+)
+async def test_perform_merge_actions(mocker, push_scope, should_push, push_expect_called):
+    actions = ["merge_day"]
+    actions += push_scope
+    called = {"merge": False}
+
+    async def mocked_do_merge(*args, **kwargs):
+        called["merge"] = True
+        return [("https://hg.mozilla.org/treescript-test", ".")]
+
+    vcs_mock = AsyncMock()
+
+    mocker.patch.object(gecko, "vcs", new=vcs_mock)
+    mocker.patch.object(gecko, "do_merge", new=mocked_do_merge)
+    mocker.patch.object(gecko, "should_push", return_value=should_push)
+    await gecko.perform_merge_actions({}, {}, actions, "/some/folder/here")
+    assert called["merge"] is True
+    if push_expect_called:
+        vcs_mock.push.assert_called_once()
+    else:
+        vcs_mock.push.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_do_actions_no_changes(mocker):
+    actions = ["push"]
+    called = {"bump": False, "l10n": False}
+
+    async def mocked_bump(*args, **kwargs):
+        called["bump"] = True
+        return 1
+
+    async def mocked_l10n(*args, **kwargs):
+        called["l10n"] = True
+        return 1
+
+    vcs_mock = AsyncMock()
+    vcs_mock.log_outgoing.return_value = 0
+
+    mocker.patch.object(gecko, "vcs", new=vcs_mock)
+    mocker.patch.object(gecko, "bump_version", new=mocked_bump)
+    mocker.patch.object(gecko, "l10n_bump", new=mocked_l10n)
+    await gecko.do_actions({"work_dir": "foo"}, {"metadata": {"source": "https://hg.mozilla.org/file/"}, "payload": {"push": True, "actions": actions}})
+    assert not any(called.values())
+    vcs_mock.checkout_repo.assert_called_once()
+    vcs_mock.do_tagging.assert_not_called()
+    vcs_mock.log_outgoing.assert_called_once()
+    vcs_mock.strip_outgoing.assert_called_once()
+    vcs_mock.push.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_do_actions_mismatch_change_count(mocker):
+    actions = ["tag"]
+
+    async def mocked_bump(*args, **kwargs):
+        return 1
+
+    async def mocked_l10n(*args, **kwargs):
+        return 1
+
+    vcs_mock = AsyncMock()
+    vcs_mock.log_outgoing.return_value = 14
+
+    mocker.patch.object(gecko, "vcs", new=vcs_mock)
+    mocker.patch.object(gecko, "bump_version", new=mocked_bump)
+    mocker.patch.object(gecko, "l10n_bump", new=mocked_l10n)
+    with pytest.raises(TreeScriptError):
+        await gecko.do_actions({"work_dir": "foo"}, {"metadata": {"source": "https://hg.mozilla.org/file/"}, "payload": {"push": False, "actions": actions}})
+
+

--- a/treescript/tests/test_gecko_l10n.py
+++ b/treescript/tests/test_gecko_l10n.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from scriptworker_client.utils import makedirs
 
-import treescript.l10n as l10n
+import treescript.gecko.l10n as l10n
 
 try:
     from unittest.mock import AsyncMock
@@ -264,7 +264,7 @@ async def test_l10n_bump(mocker, ignore_closed_tree, l10n_bump_info, tmpdir, old
     mocker.patch.object(l10n, "load_json_or_yaml", return_value=old_contents)
     mocker.patch.object(l10n, "get_latest_revision", new=noop_async)
     mocker.patch.object(l10n, "build_revision_dict", new=fake_build_revision_dict)
-    mocker.patch.object(l10n, "get_vcs_module", return_value=AsyncMock())
+    mocker.patch.object(l10n, "vcs", new=AsyncMock())
 
     assert await l10n.l10n_bump({}, {}, tmpdir) == changes
 

--- a/treescript/tests/test_gecko_mercurial.py
+++ b/treescript/tests/test_gecko_mercurial.py
@@ -12,10 +12,10 @@ import os
 import pytest
 from scriptworker_client.utils import makedirs
 
-from treescript import mercurial
+from treescript.gecko import mercurial
 from treescript.exceptions import FailedSubprocess, PushError
 from treescript.script import get_default_config
-from treescript.task import DONTBUILD_MSG
+from treescript.util.task import DONTBUILD_MSG
 
 # constants, helpers, fixtures {{{1
 UNEXPECTED_ENV_KEYS = "HG HGPROF CDPATH GREP_OPTIONS http_proxy no_proxy " "HGPLAINEXCEPT EDITOR VISUAL PAGER NO_PROXY CHGDEBUG".split()

--- a/treescript/tests/test_gecko_merges.py
+++ b/treescript/tests/test_gecko_merges.py
@@ -6,8 +6,8 @@ import hglib
 import pytest
 from mozilla_version.gecko import FirefoxVersion
 
-import treescript.merges as merges
 from treescript.exceptions import TaskVerificationError
+from treescript.gecko import merges
 from treescript.script import get_default_config
 
 
@@ -185,7 +185,7 @@ async def test_apply_rebranding(config, repo_context, mocker, merge_config, expe
     called_args = []
 
     async def noop_bump_version(*arguments, **kwargs):
-        called_args.append([arguments[2]])
+        called_args.append([arguments[1]])
 
     def sync_noop(*arguments, **kwargs):
         called_args.extend(arguments)

--- a/treescript/tests/test_gecko_versionmanip.py
+++ b/treescript/tests/test_gecko_versionmanip.py
@@ -5,10 +5,10 @@ import pytest
 from mozilla_version.gecko import FirefoxVersion, GeckoVersion, ThunderbirdVersion
 from mozilla_version.mobile import MobileVersion
 
-import treescript.versionmanip as vmanip
+import treescript.gecko.versionmanip as vmanip
 from treescript.exceptions import TaskVerificationError, TreeScriptError
 from treescript.script import get_default_config
-from treescript.task import DONTBUILD_MSG
+from treescript.util.task import DONTBUILD_MSG
 
 try:
     from unittest.mock import AsyncMock
@@ -119,20 +119,10 @@ async def test_bump_version(mocker, repo_context, new_version, should_append_esr
     mocked_bump_info = mocker.patch.object(vmanip, "get_version_bump_info")
     mocked_bump_info.return_value = bump_info
     vcs_mock = AsyncMock()
-    mocker.patch.object(vmanip, "get_vcs_module", return_value=vcs_mock)
-    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo, repo_type="hg")
+    mocker.patch.object(vmanip, "vcs", new=vcs_mock)
+    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo)
     assert test_version == vmanip.get_version(relative_files[0], repo_context.repo, "https://hg.mozilla.org/repo")
     assert vcs_mock.commit.call_args_list[0][0][2] == "Automatic version bump CLOSED TREE NO BUG a=release"
-
-
-@pytest.mark.asyncio
-async def test_bump_version_mobile(mocker, mobile_repo_context):
-    bump_info = {"files": ["version.txt"], "next_version": "110.1.0"}
-    mocked_bump_info = mocker.patch.object(vmanip, "get_version_bump_info")
-    mocked_bump_info.return_value = bump_info
-    vcs_mock = AsyncMock()
-    mocker.patch.object(vmanip, "get_vcs_module", return_value=vcs_mock)
-    await vmanip.bump_version(mobile_repo_context.config, mobile_repo_context.task, mobile_repo_context.repo, repo_type="git")
 
 
 @pytest.mark.asyncio
@@ -145,8 +135,8 @@ async def test_bump_version_DONTBUILD_true(mocker, repo_context, new_version):
     mocked_dontbuild = mocker.patch.object(vmanip, "get_dontbuild")
     mocked_dontbuild.return_value = True
     vcs_mock = AsyncMock()
-    mocker.patch.object(vmanip, "get_vcs_module", return_value=vcs_mock)
-    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo, repo_type="hg")
+    mocker.patch.object(vmanip, "vcs", new=vcs_mock)
+    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo)
     commit_msg = vcs_mock.commit.call_args_list[0][0][2]
     assert DONTBUILD_MSG in commit_msg
 
@@ -161,8 +151,8 @@ async def test_bump_version_DONTBUILD_false(mocker, repo_context, new_version):
     mocked_dontbuild = mocker.patch.object(vmanip, "get_dontbuild")
     mocked_dontbuild.return_value = False
     vcs_mock = AsyncMock()
-    mocker.patch.object(vmanip, "get_vcs_module", return_value=vcs_mock)
-    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo, repo_type="hg")
+    mocker.patch.object(vmanip, "vcs", new=vcs_mock)
+    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo)
     commit_msg = vcs_mock.commit.call_args_list[0][0][2]
     assert DONTBUILD_MSG not in commit_msg
 
@@ -175,9 +165,9 @@ async def test_bump_version_invalid_file(mocker, repo_context, new_version):
     mocked_bump_info = mocker.patch.object(vmanip, "get_version_bump_info")
     mocked_bump_info.return_value = bump_info
     vcs_mock = AsyncMock()
-    mocker.patch.object(vmanip, "get_vcs_module", return_value=vcs_mock)
+    mocker.patch.object(vmanip, "vcs", new=vcs_mock)
     with pytest.raises(TaskVerificationError):
-        await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo, repo_type="hg")
+        await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo)
     assert repo_context.xtest_version == vmanip.get_version(relative_files[1], repo_context.repo, "https://hg.mozilla.org/repo")
     vcs_mock.commit.assert_not_called()
 
@@ -191,9 +181,9 @@ async def test_bump_version_missing_file(mocker, repo_context, new_version):
     mocked_bump_info = mocker.patch.object(vmanip, "get_version_bump_info")
     mocked_bump_info.return_value = bump_info
     vcs_mock = AsyncMock()
-    mocker.patch.object(vmanip, "get_vcs_module", return_value=vcs_mock)
+    mocker.patch.object(vmanip, "vcs", new=vcs_mock)
     with pytest.raises(TaskVerificationError):
-        await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo, repo_type="hg")
+        await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo)
     assert repo_context.xtest_version == vmanip.get_version(relative_files[1], repo_context.repo, "https://hg.mozilla.org/repo")
     vcs_mock.commit.assert_not_called()
 
@@ -206,8 +196,8 @@ async def test_bump_version_smaller_version(mocker, repo_context, new_version):
     mocked_bump_info = mocker.patch.object(vmanip, "get_version_bump_info")
     mocked_bump_info.return_value = bump_info
     vcs_mock = AsyncMock()
-    mocker.patch.object(vmanip, "get_vcs_module", return_value=vcs_mock)
-    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo, repo_type="hg")
+    mocker.patch.object(vmanip, "vcs", new=vcs_mock)
+    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo)
     assert repo_context.xtest_version == vmanip.get_version(relative_files[0], repo_context.repo, "https://hg.mozilla.org/repo")
     vcs_mock.commit.assert_not_called()
 
@@ -224,8 +214,8 @@ async def test_bump_version_esr(mocker, repo_context, new_version, expect_versio
     mocked_bump_info = mocker.patch.object(vmanip, "get_version_bump_info")
     mocked_bump_info.return_value = bump_info
     vcs_mock = AsyncMock()
-    mocker.patch.object(vmanip, "get_vcs_module", return_value=vcs_mock)
-    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo, repo_type="hg")
+    mocker.patch.object(vmanip, "vcs", new=vcs_mock)
+    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo)
     assert expect_version == vmanip.get_version(relative_files[0], repo_context.repo, "https://hg.mozilla.org/repo")
     vcs_mock.commit.assert_called_once()
 
@@ -249,14 +239,14 @@ async def test_bump_version_esr_dont_bump_non_esr(mocker, config, tmpdir, new_ve
     bump_info = {"files": relative_files, "next_version": new_version}
     mocked_bump_info = mocker.patch.object(vmanip, "get_version_bump_info")
     mocked_bump_info.return_value = bump_info
-    vcs_mock = AsyncMock()
-    mocker.patch.object(vmanip, "get_vcs_module", return_value=vcs_mock)
     task = {
         "metadata": {
             "source": "https://hg.mozilla.org/repo/file/deadb33f/.taskcluster.yml",
         },
     }
-    await vmanip.bump_version(config, task, repo, repo_type="hg")
+    vcs_mock = AsyncMock()
+    mocker.patch.object(vmanip, "vcs", new=vcs_mock)
+    await vmanip.bump_version(config, task, repo)
     assert expect_esr_version == vmanip.get_version(display_version_file, repo, "https://hg.mozilla.org/repo")
     assert new_version == vmanip.get_version(version_file, repo, "https://hg.mozilla.org/repo")
     vcs_mock.commit.assert_called_once()
@@ -269,7 +259,7 @@ async def test_bump_version_same_version(mocker, repo_context):
     mocked_bump_info = mocker.patch.object(vmanip, "get_version_bump_info")
     mocked_bump_info.return_value = bump_info
     vcs_mock = AsyncMock()
-    mocker.patch.object(vmanip, "get_vcs_module", return_value=vcs_mock)
-    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo, repo_type="hg")
+    mocker.patch.object(vmanip, "vcs", new=vcs_mock)
+    await vmanip.bump_version(repo_context.config, repo_context.task, repo_context.repo)
     assert repo_context.xtest_version == vmanip.get_version(relative_files[0], repo_context.repo, "https://hg.mozilla.org/repo")
     vcs_mock.commit.assert_not_called()

--- a/treescript/tests/test_github_git.py
+++ b/treescript/tests/test_github_git.py
@@ -7,7 +7,7 @@ import pytest
 from git import Actor, PushInfo
 from scriptworker_client.utils import makedirs
 
-from treescript import git
+from treescript.github import git
 from treescript.exceptions import PushError
 from treescript.script import get_default_config
 

--- a/treescript/tests/test_github_versionmanip.py
+++ b/treescript/tests/test_github_versionmanip.py
@@ -1,0 +1,37 @@
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+
+from treescript.github import versionmanip as vmanip
+from treescript.script import get_default_config
+
+
+@pytest.fixture(scope="function")
+def config(tmpdir):
+    config_ = get_default_config()
+    config_["work_dir"] = os.path.join(tmpdir, "work")
+    yield config_
+
+
+@pytest.fixture()
+def mobile_repo_context(tmpdir, config, request, mocker):
+    context = mocker.MagicMock()
+    context.repo = os.path.join(tmpdir, "repo")
+    context.task = {"metadata": {"source": "https://github.com/mozilla-mobile/firefox-android/blob/rev/foo"}}
+    context.config = config
+    os.mkdir(context.repo)
+    version_file = os.path.join(context.repo, "version.txt")
+    with open(version_file, "w") as f:
+        f.write("109.0")
+    yield context
+
+
+@pytest.mark.asyncio
+async def test_bump_version_mobile(mocker, mobile_repo_context):
+    bump_info = {"files": ["version.txt"], "next_version": "110.1.0"}
+    mocked_bump_info = mocker.patch.object(vmanip, "get_version_bump_info")
+    mocked_bump_info.return_value = bump_info
+    vcs_mock = AsyncMock()
+    mocker.patch.object(vmanip, "vcs", new=vcs_mock)
+    await vmanip.bump_version(mobile_repo_context.config, mobile_repo_context.task, mobile_repo_context.repo)

--- a/treescript/tests/test_util_task.py
+++ b/treescript/tests/test_util_task.py
@@ -5,8 +5,9 @@ import pytest
 from scriptworker_client.client import verify_task_schema
 from scriptworker_client.exceptions import TaskVerificationError
 
-import treescript.task as ttask
-from treescript import git, mercurial
+from treescript.util import task as ttask
+from treescript.gecko import mercurial
+from treescript.github import git
 from treescript.script import get_default_config
 
 SCRIPT_CONFIG = {"taskcluster_scope_prefix": "project:releng:treescript:"}
@@ -325,12 +326,3 @@ def test_get_ssh_user(task_defn, ssh_user, expected):
     if ssh_user:
         task_defn["payload"]["ssh_user"] = ssh_user
     assert ttask.get_ssh_user(task_defn) == expected
-
-
-@pytest.mark.parametrize(
-    "repo_type, expectation, expected_result",
-    (("hg", does_not_raise(), mercurial), ("git", does_not_raise(), git), ("non-existing-type", pytest.raises(NotImplementedError), None)),
-)
-def test_get_vcs_module(repo_type, expectation, expected_result):
-    with expectation:
-        assert ttask.get_vcs_module(repo_type) == expected_result


### PR DESCRIPTION
…viewers

On the surface, this commit is silly because it is duplicating a lot of logic that was previously refactored.

But this commit is a pre-cursor to later commits that will refactor the Github case to use Github's GraphQL API rather than operating on a local checkout.

By pulling them apart we accomplish a couple things:

1. It will make the follow-up commit easier to review because the refactoring was already done here.
2. By keeping the two use cases distinct, it will make it easier to remove the Mercurial bits when the time comes.

Eventually, there will only be one way of doing things again, at which point we can move the `github` submodules back up to the top-level (if desired).