### PR TITLE
Bug 1567912 - [pushapkscript] Add config for aab test track

### DIFF
--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -92,6 +92,13 @@ products:
                 default_track: 'production'
                 service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FENIX_NIGHTLY" }
                 credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_NIGHTLY_PATH" }
+            fenix-aab-nightly:
+              package_names: [ "org.mozilla.fenix" ]
+              certificate_alias: 'fenix-nightly'
+              google:
+                default_track: 'aab'
+                service_account: { "$eval": "GOOGLE_PLAY_SERVICE_ACCOUNT_FENIX_NIGHTLY" }
+                credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_NIGHTLY_PATH" }
             fenix-beta:
               package_names: [ "org.mozilla.firefox_beta" ]
               certificate_alias: 'fenix-beta'


### PR DESCRIPTION
Add a push-apk config for Fenix AAB: channel "fenix-aab-nightly" will be pushed to the "aab" test track.

I expect this config to be temporary: Once Fenix is validated on the "aab" track, we'll update the push-aab task to use the normal "fenix-nightly" channel, then revert this change.