### PR TITLE
fix: Refactor iscript provisioning profile config

### DIFF
--- a/iscript/src/iscript/data/i_task_schema.json
+++ b/iscript/src/iscript/data/i_task_schema.json
@@ -139,11 +139,11 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "name": {
+                  "profile_name": {
                     "description": "Filename of profile in the workers.",
                     "type": "string"
                   },
-                  "path": {
+                  "target_path": {
                     "description": "Relative path to add profile to.",
                     "type": "string"
                   }

--- a/iscript/src/iscript/hardened_sign.py
+++ b/iscript/src/iscript/hardened_sign.py
@@ -80,16 +80,16 @@ def copy_provisioning_profile(pprofile, app_path, config):
     pprofile_source_dir = Path(config["work_dir"]).parent / "provisionprofiles"
 
     # Check if file exists locally
-    source_file = Path(pprofile_source_dir / pprofile["name"]).resolve()
+    source_file = Path(pprofile_source_dir / pprofile["profile_name"]).resolve()
     try:
         source_file.relative_to(pprofile_source_dir)
     except ValueError:
         raise IScriptError("Illegal directory traversal resolving provisioning profile source")
     if not source_file.is_file():
-        raise IScriptError(f"Provisioning profile not found in worker: {pprofile['name']}")
+        raise IScriptError(f"Provisioning profile not found in worker: {pprofile['profile_name']}")
 
     # Adding ./ to destination as workaround for destination starting with /
-    destination = Path(Path(app_path) / ("./" + pprofile["path"])).resolve()
+    destination = Path(Path(app_path) / ("./" + pprofile["target_path"])).resolve()
     # If provided destination is a directory, then use default filename for profiles
     if destination.is_dir():
         destination = destination / "embedded.provisionprofile"

--- a/iscript/tests/test_hardened_sign.py
+++ b/iscript/tests/test_hardened_sign.py
@@ -39,19 +39,19 @@ def test_check_globs():
 
 
 def test_copy_provisioning_profile(tmpdir):
-    pprofile = {"name": "test.profile", "path": "/test.profile"}
+    pprofile = {"profile_name": "test.profile", "target_path": "/test.profile"}
     # Source pprofile
     sourcedir = os.path.join(tmpdir, "provisionprofiles")
     os.mkdir(sourcedir)
-    source_profile = Path(sourcedir) / pprofile["name"]
+    source_profile = Path(sourcedir) / pprofile["profile_name"]
     source_profile.touch()
     config = {"work_dir": os.path.join(tmpdir, "foo")}
     hs.copy_provisioning_profile(pprofile, tmpdir, config)
-    assert (Path(tmpdir) / pprofile["name"]).exists()
+    assert (Path(tmpdir) / pprofile["profile_name"]).exists()
 
 
 def test_copy_provisioning_profile_fail(tmpdir):
-    pprofile = {"name": "test.profile", "path": "/"}
+    pprofile = {"profile_name": "test.profile", "target_path": "/"}
     config = {"work_dir": os.path.join(tmpdir, "foo")}
     sourcedir = os.path.join(tmpdir, "provisionprofiles")
     os.mkdir(sourcedir)
@@ -61,16 +61,16 @@ def test_copy_provisioning_profile_fail(tmpdir):
         hs.copy_provisioning_profile(pprofile, tmpdir, config)
 
     # Illegal source traversal
-    pprofile = {"name": "../test.profile", "path": "/"}
-    source_profile = Path(sourcedir) / pprofile["name"]
+    pprofile = {"profile_name": "../test.profile", "target_path": "/"}
+    source_profile = Path(sourcedir) / pprofile["profile_name"]
     source_profile.touch()
     with pytest.raises(IScriptError):
         hs.copy_provisioning_profile(pprofile, tmpdir, config)
 
     # Illegal destination traversal
-    pprofile = {"name": "test.profile", "path": "../../../"}
+    pprofile = {"profile_name": "test.profile", "target_path": "../../../"}
     sourcedir = os.path.join(tmpdir, "provisionprofiles")
-    source_profile = Path(sourcedir) / pprofile["name"]
+    source_profile = Path(sourcedir) / pprofile["profile_name"]
     source_profile.touch()
     with pytest.raises(IScriptError):
         hs.copy_provisioning_profile(pprofile, tmpdir, config)


### PR DESCRIPTION
Renames the name and path properties to profile_name and target_path