### PR TITLE
bouncerscript: don't require successive nightly versions outside of prod

### DIFF
--- a/bouncerscript/docker.d/worker.yml
+++ b/bouncerscript/docker.d/worker.yml
@@ -2,6 +2,7 @@ work_dir: { "$eval": "WORK_DIR" }
 artifact_dir: { "$eval": "ARTIFACTS_DIR" }
 verbose: { "$eval": "VERBOSE == 'true'" }
 taskcluster_scope_prefix: { "$eval": "TASKCLUSTER_SCOPE_PREFIX" }
+require_successive_versions: { "$eval": "ENV == 'prod'" }
 bouncer_config:
   $merge:
     $match:

--- a/bouncerscript/examples/config.example.json
+++ b/bouncerscript/examples/config.example.json
@@ -2,6 +2,7 @@
         "work_dir": "some/work/dir/",
         "verbose": true,
         "taskcluster_scope_prefix": "project:releng:bouncer:",
+        "require_successive_versions": true,
         "bouncer_config": {
             "project:releng:bouncer:server:staging": {
                 "api_root": "some-root",

--- a/bouncerscript/src/bouncerscript/constants.py
+++ b/bouncerscript/src/bouncerscript/constants.py
@@ -78,19 +78,19 @@ PRODUCT_TO_DESTINATIONS_REGEXES = {
 
 _BOUNCER_PATH_REGEXES_PER_PRODUCT_DEFAULT = {
     "firefox-nightly-latest": (
-        r"^(/firefox/nightly/latest-mozilla-central-l10n/firefox-\d+\.0a1\.:lang\."
+        r"^(/firefox/nightly/latest-(mozilla-central|try)-l10n/firefox-\d+\.0a1\.:lang\."
         r"(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe|win64-aarch64\.installer\.exe))$"
     ),
     "firefox-nightly-latest-ssl": (
-        r"^(/firefox/nightly/latest-mozilla-central/firefox-\d+\.0a1\.en-US\."
+        r"^(/firefox/nightly/latest-(mozilla-central|try)/firefox-\d+\.0a1\.en-US\."
         r"(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe|win64-aarch64\.installer\.exe))$"
     ),
     "firefox-nightly-latest-l10n": (
-        r"^(/firefox/nightly/latest-mozilla-central-l10n/firefox-\d+\.0a1\.:lang\."
+        r"^(/firefox/nightly/latest-(mozilla-central|try)-l10n/firefox-\d+\.0a1\.:lang\."
         r"(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe|win64-aarch64\.installer\.exe))$"
     ),
     "firefox-nightly-latest-l10n-ssl": (
-        r"^(/firefox/nightly/latest-mozilla-central-l10n/firefox-\d+\.0a1\.:lang\."
+        r"^(/firefox/nightly/latest-(mozilla-central|try)-l10n/firefox-\d+\.0a1\.:lang\."
         r"(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe|win64-aarch64\.installer\.exe))$"
     ),
 }
@@ -98,19 +98,19 @@ _BOUNCER_PATH_REGEXES_PER_PRODUCT_DEFAULT = {
 _BOUNCER_PATH_REGEXES_PER_ALTERNATIVE_PACKAGE_FORMAT = {
     **_BOUNCER_PATH_REGEXES_PER_PRODUCT_DEFAULT,
     "firefox-nightly-msi-latest-ssl": (
-        r"^(/firefox/nightly/latest-mozilla-central/firefox-\d+\.0a1\.en-US\." r"(?:win32\.installer\.msi|win64(?:|-aarch64)\.installer\.msi))$"
+        r"^(/firefox/nightly/latest-(mozilla-central|try)/firefox-\d+\.0a1\.en-US\." r"(?:win32\.installer\.msi|win64(?:|-aarch64)\.installer\.msi))$"
     ),
     "firefox-nightly-msi-latest-l10n-ssl": (
-        r"^(/firefox/nightly/latest-mozilla-central-l10n/firefox-\d+\.0a1\.:lang\." r"(?:win32\.installer\.msi|win64(?:|-aarch64)\.installer\.msi))$"
+        r"^(/firefox/nightly/latest-(mozilla-central|try)-l10n/firefox-\d+\.0a1\.:lang\." r"(?:win32\.installer\.msi|win64(?:|-aarch64)\.installer\.msi))$"
     ),
-    "firefox-nightly-pkg-latest-ssl": (r"^(/firefox/nightly/latest-mozilla-central/firefox-\d+\.0a1\.en-US\." r"(?:mac\.pkg))$"),
-    "firefox-nightly-pkg-latest-l10n-ssl": (r"^(/firefox/nightly/latest-mozilla-central-l10n/firefox-\d+\.0a1\.:lang\." r"(?:mac\.pkg))$"),
+    "firefox-nightly-pkg-latest-ssl": (r"^(/firefox/nightly/latest-(mozilla-central|try)/firefox-\d+\.0a1\.en-US\." r"(?:mac\.pkg))$"),
+    "firefox-nightly-pkg-latest-l10n-ssl": (r"^(/firefox/nightly/latest-(mozilla-central|try)-l10n/firefox-\d+\.0a1\.:lang\." r"(?:mac\.pkg))$"),
 }
 
 # msix should move up to _BOUNCER_PATH_REGEXES_PER_ALTERNATIVE_PACKAGE_FORMAT once it exists consistently
 _BOUNCER_PATH_REGEXES_PER_ALTERNATIVE_PACKAGE_FORMAT_WITH_MSIX = {
     **_BOUNCER_PATH_REGEXES_PER_ALTERNATIVE_PACKAGE_FORMAT,
-    "firefox-nightly-msix-latest-ssl": (r"^(/firefox/nightly/latest-mozilla-central/firefox-\d+\.0a1\.multi\." r"(?:(win32|win64)\.installer\.msix)$"),
+    "firefox-nightly-msix-latest-ssl": (r"^(/firefox/nightly/latest-(mozilla-central|try)/firefox-\d+\.0a1\.multi\." r"(?:(win32|win64)\.installer\.msix)$"),
 }
 
 _BOUNCER_PATH_REGEXES_PRODUCT_THUNDERBIRD = {

--- a/bouncerscript/src/bouncerscript/data/config_schema.json
+++ b/bouncerscript/src/bouncerscript/data/config_schema.json
@@ -3,11 +3,15 @@
     "type": "object",
     "required": [
         "taskcluster_scope_prefix",
+        "require_successive_versions",
         "bouncer_config"
     ],
     "properties": {
         "taskcluster_scope_prefix": {
             "type": "string"
+        },
+        "require_successive_versions": {
+            "type": "boolean"
         },
         "bouncer_config": {
             "type": "object",

--- a/bouncerscript/src/bouncerscript/script.py
+++ b/bouncerscript/src/bouncerscript/script.py
@@ -104,6 +104,8 @@ async def bouncer_locations(context):
     check_version_matches_nightly_regex(context.task["payload"]["version"], product)
     log.info("In-tree version from payload looks good!")
 
+    require_successive_versions = context.config["require_successive_versions"]
+
     did_bump = False
     payload_version = context.task["payload"]["version"]
 
@@ -124,7 +126,9 @@ async def bouncer_locations(context):
                 log.info("No-op. Nightly version is the same")
                 continue
 
-            check_versions_are_successive(current_version, payload_version, product)
+            if require_successive_versions:
+                check_versions_are_successive(current_version, payload_version, product)
+
             bumped_path = get_version_bumped_path(path, current_version, payload_version)
             log.info("Modifying corresponding path with bumped one {}".format(bumped_path))
             await api_modify_location(context, product_name, platform, bumped_path)

--- a/bouncerscript/tests/fake_config.json
+++ b/bouncerscript/tests/fake_config.json
@@ -2,6 +2,7 @@
         "work_dir": "tests/test_work_dir",
         "verbose": true,
         "taskcluster_scope_prefix": "project:releng:bouncer:",
+        "require_successive_versions": true,
         "bouncer_config": {
             "project:releng:bouncer:server:staging": {
                 "api_root": "some-root",

--- a/bouncerscript/tests/test_task.py
+++ b/bouncerscript/tests/test_task.py
@@ -552,8 +552,16 @@ def test_check_version_matches_nightly_regex(version, product, raises):
             ("thunderbird-nightly-latest", "/thunderbird/nightly/latest-comm-central/thunderbird-63.0a1.en-US.linux-x86_64.tar.bz2", False),
             ("thunderbird-nightly-msi-latest-l10n-ssl", "/thunderbird/nightly/latest-comm-central-l10n/thunderbird-63.0a1.:lang.win64.installer.exe", True),
             ("thunderbird-nightly-latest-l10n", "/thunderbird/nightly/latest-comm-central-l10n/thunderbird-63.0a1.:lang.win32.installer.exe", False),
-            ("thunderbird-nightly-latest-l10n", "/thunderbird/candidates/latest-comm-central-l10n/thunderbird-63.0a1.:lang.win32.installer.exeexe", True),
-            ("thunderbird-nightly-latest-l10n", "/mobile/nightly/latest-comm-central-l10n/thunderbird-63.0a1.:lang.win32.installer.exeexe", True),
+            ("thunderbird-nightly-latest-l10n", "/thunderbird/candidates/latest-comm-central-l10n/thunderbird-63.0a1.:lang.win32.installer.exe", True),
+            ("thunderbird-nightly-latest-l10n", "/mobile/nightly/latest-comm-central-l10n/thunderbird-63.0a1.:lang.win32.installer.exe", True),
+            ("firefox-nightly-latest", "/firefox/nightly/latest-try-l10n/firefox-63.0a1.:lang.linux-i686.tar.bz2", False),
+            ("firefox-nightly-msi-latest-l10n-ssl", "/firefox/nightly/latest-try-l10n/firefox-63.0a1.:lang.win64.installer.msi", False),
+            ("firefox-nightly-msi-latest-ssl", "/firefox/nightly/latest-try/firefox-63.0a1.en-US.win64.installer.msi", False),
+            ("firefox-nightly-pkg-latest-l10n-ssl", "/firefox/nightly/latest-try-l10n/firefox-63.0a1.:lang.mac.pkg", False),
+            ("firefox-nightly-pkg-latest-ssl", "/firefox/nightly/latest-try/firefox-63.0a1.en-US.mac.pkg", False),
+            ("firefox-nightly-latest-l10n-ssl", "/firefox/nightly/latest-try-l10n/firefox-63.0a1.:lang.win64.installer.exe", False),
+            ("firefox-nightly-latest-ssl", "/firefox/nightly/latest-try/firefox-63.0a1.en-US.win32.installer.exe", False),
+            ("firefox-nightly-latest-l10n", "/firefox/nightly/latest-try-l10n/firefox-63.0a1.:lang.win32.installer.exe", False),
         )
     ),
 )

--- a/bouncerscript/tox.ini
+++ b/bouncerscript/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =


### PR DESCRIPTION
This is part of the fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1861749, where we want to make sure we're able to run `bouncer-locations` on Try, and we won't always be guaranteed to run it every cycle.