### PR TITLE
[treescript] add android_nimbus_update action

### DIFF
--- a/treescript/Dockerfile
+++ b/treescript/Dockerfile
@@ -4,7 +4,7 @@ RUN groupadd --gid 10001 app && \
     useradd -g app --uid 10001 --shell /usr/sbin/nologin --create-home --home-dir /app app
 
 RUN apt-get update \
- && apt-get install -y mercurial \
+ && apt-get install -y jq mercurial \
  && apt-get clean \
  && ln -s /app/docker.d/healthcheck /bin/healthcheck
 

--- a/treescript/src/treescript/data/treescript_task_schema.json
+++ b/treescript/src/treescript/data/treescript_task_schema.json
@@ -246,6 +246,38 @@
                         "toml_info"
                     ]
                 },
+                "android_nimbus_update_info": {
+                    "type": "object",
+                    "properties": {
+                        "updates": {
+                            "type": "array",
+                            "minItems": 1,
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "app_name": {
+                                        "type": "string"
+                                    },
+                                    "experiments_path": {
+                                        "type": "string"
+                                    },
+                                    "experiments_url": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "app_name",
+                                    "experiments_path",
+                                    "experiments_url"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "updates"
+                    ]
+                },
                 "l10n_bump_info": {
                     "type": "array",
                     "minItems": 1,
@@ -320,6 +352,7 @@
                             "merge_day",
                             "android_l10n_import",
                             "android_l10n_sync",
+                            "android_nimbus_update",
                             "push"
                         ]
                     }

--- a/treescript/src/treescript/gecko/__init__.py
+++ b/treescript/src/treescript/gecko/__init__.py
@@ -5,6 +5,7 @@ from treescript.gecko import mercurial as vcs
 from treescript.gecko.android_l10n import android_l10n_import, android_l10n_sync
 from treescript.gecko.l10n import l10n_bump
 from treescript.gecko.merges import do_merge
+from treescript.gecko.nimbus import android_nimbus_update
 from treescript.gecko.versionmanip import bump_version
 from treescript.exceptions import TreeScriptError
 from treescript.util.task import get_source_repo, should_push, task_action_types
@@ -71,6 +72,8 @@ async def do_actions(config, task):
         num_changes += await android_l10n_import(config, task, repo_path)
     if "android_l10n_sync" in actions:
         num_changes += await android_l10n_sync(config, task, repo_path)
+    if "android_nimbus_update" in actions:
+        num_changes += await android_nimbus_update(config, task, repo_path)
 
     num_outgoing = await vcs.log_outgoing(config, task, repo_path)
     if num_outgoing != num_changes:

--- a/treescript/src/treescript/gecko/nimbus.py
+++ b/treescript/src/treescript/gecko/nimbus.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+"""Treescript Nimbus support.
+"""
+import logging
+import os
+import subprocess
+
+from scriptworker_client.aio import request
+from treescript.exceptions import CheckoutError
+from treescript.gecko import mercurial as vcs
+from treescript.util.task import CLOSED_TREE_MSG, DONTBUILD_MSG, get_dontbuild, get_ignore_closed_tree, get_android_nimbus_update_info, get_short_source_repo
+from treescript.util.treestatus import check_treestatus
+
+log = logging.getLogger(__name__)
+
+
+# build_commit_message {{{1
+def build_commit_message(description, dontbuild=False, ignore_closed_tree=False):
+    """Build a commit message for nimbus update.
+
+    Args:
+        dontbuild (bool, optional): whether to add ``DONTBUILD`` to the
+            comment. Defaults to ``False``
+        ignore_closed_tree (bool, optional): whether to add ``CLOSED TREE``
+            to the comment. Defaults to ``False``.
+
+    Returns:
+        str: the commit message
+
+    """
+    approval_str = "r=release a=nimbus"
+    if dontbuild:
+        approval_str += DONTBUILD_MSG
+    if ignore_closed_tree:
+        approval_str += CLOSED_TREE_MSG
+    message = f"no bug - {description} {approval_str}\n\n"
+    return message
+
+
+# android_nimbus_update {{{1
+async def android_nimbus_update(config, task, repo_path):
+    """Update a Nimbus experiments.json file.
+    This function takes its inputs from its task.
+    It reads the specified url to get the desired contents of
+    an android project's experiments.json file and updates
+    that file if it has changed.
+
+    Args:
+        config (dict): the running config
+        task (dict): the running task
+        repo_path (str): the source directory
+
+    Returns:
+        int: non-zero if there are any changes.
+
+    """
+    log.info("Preparing to sync android-nimbus changes.")
+
+    task_info = get_android_nimbus_update_info(task)
+
+    ignore_closed_tree = get_ignore_closed_tree(task)
+    if not ignore_closed_tree:
+        if not await check_treestatus(config, task):
+            tree = get_short_source_repo(task)
+            log.info(f"Treestatus reports {tree} is closed; skipping android-nimbus action.")
+            return 0
+
+    dontbuild = get_dontbuild(task)
+
+    changes = 0
+    for update in task_info["updates"]:
+        app_name = update["app_name"]
+        experiments_path = update["experiments_path"]
+        url = update["experiments_url"]
+
+        description = f"Update {app_name} initial experiments JSON for Nimbus"
+        log.info(description)
+
+        response = await request(url, num_attempts=3)
+
+        # Customize the json file by extracting the part matching the app name
+        # (ie, Focus and Fenix usually use the same experiments_url, but require
+        # different json content).
+        cmd = ["jq", f'{{"data":map(select(.appName == "{app_name}"))}}']
+        p = subprocess.run(cmd, stdout=subprocess.PIPE, input=response, text=True)
+        new_contents = p.stdout
+
+        old_contents = ""
+        experiments_path = os.path.join(repo_path, experiments_path)
+        if os.path.exists(experiments_path):
+            with open(experiments_path, "r") as f:
+                old_contents = f.read()
+        else:
+            log.info(f"Experiments-path {experiments_path} not found.")
+            continue
+
+        if old_contents == new_contents:
+            log.info("No changes found.")
+        else:
+            with open(experiments_path, "w") as f:
+                f.write(new_contents)
+            message = build_commit_message(description, dontbuild=dontbuild, ignore_closed_tree=ignore_closed_tree)
+            await vcs.commit(config, repo_path, message)
+            changes += 1
+
+    return changes

--- a/treescript/src/treescript/util/task.py
+++ b/treescript/src/treescript/util/task.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 # human reference.
 VALID_ACTIONS = {
     "comm": {"tag", "version_bump", "l10n_bump", "push", "merge_day"},
-    "gecko": {"tag", "version_bump", "l10n_bump", "push", "merge_day", "android_l10n_import", "android_l10n_sync"},
+    "gecko": {"tag", "version_bump", "l10n_bump", "push", "merge_day", "android_l10n_import", "android_l10n_sync", "android_nimbus_update"},
     "mobile": {"version_bump"},
 }
 
@@ -213,6 +213,26 @@ def get_android_l10n_sync_info(task, raise_on_empty=True):
     if not android_l10n_sync_info and raise_on_empty:
         raise TaskVerificationError("Requested android-l10n sync but no android_l10n_sync_info in payload")
     return android_l10n_sync_info
+
+
+# get_android_nimbus_update_info {{{1
+def get_android_nimbus_update_info(task, raise_on_empty=True):
+    """Get the android nimbus update information from the task metadata.
+
+    Args:
+        task: the task definition.
+
+    Returns:
+        object: the info structure as passed to the task payload.
+
+    Raises:
+        TaskVerificationError: If expected item missing from task definition.
+
+    """
+    android_nimbus_info = task.get("payload", {}).get("android_nimbus_update_info")
+    if not android_nimbus_info and raise_on_empty:
+        raise TaskVerificationError("Requested android nimbus but no android_nimbus_update_info in payload")
+    return android_nimbus_info
 
 
 # get dontbuild {{{1

--- a/treescript/tests/test_gecko_nimbus.py
+++ b/treescript/tests/test_gecko_nimbus.py
@@ -1,0 +1,93 @@
+import os
+import subprocess
+
+import pytest
+
+import scriptworker_client.aio as aio
+import treescript.gecko.nimbus as nimbus
+
+from unittest.mock import AsyncMock
+
+
+# build_commit_message {{{1
+@pytest.mark.parametrize("dontbuild, ignore_closed_tree", ((True, True), (False, False)))
+def test_build_commit_message(dontbuild, ignore_closed_tree):
+    """build_commit_message adds the correct approval strings"""
+    expected = "no bug - DESCRIPTION r=release a=nimbus"
+    if dontbuild:
+        expected += nimbus.DONTBUILD_MSG
+    if ignore_closed_tree:
+        expected += nimbus.CLOSED_TREE_MSG
+    assert nimbus.build_commit_message("DESCRIPTION", dontbuild=dontbuild, ignore_closed_tree=ignore_closed_tree).rstrip() == expected
+
+
+# android_nimbus_update {{{1
+@pytest.mark.parametrize(
+    "ignore_closed_tree, android_nimbus_update_info, old_contents, new_contents, changes",
+    (
+        (
+            True,
+            {"updates": [{"app_name": "fenix", "experiments_path": "app/src/experiments.json", "experiments_url": "https://example.com"}]},
+            "existing experiment contents",
+            "new experiment contents",
+            1,
+        ),
+        (
+            True,
+            {"updates": [{"app_name": "fenix", "experiments_path": "app/src/experiments.json", "experiments_url": "https://example.com"}]},
+            "existing experiment contents",
+            "existing experiment contents",
+            0,
+        ),
+        (
+            False,
+            {"updates": [{"app_name": "fenix", "experiments_path": "app/src/experiments.json", "experiments_url": "https://example.com"}]},
+            "existing experiment contents",
+            "new experiment contents",
+            1,
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_android_nimbus_update(mocker, ignore_closed_tree, android_nimbus_update_info, tmpdir, old_contents, new_contents, changes):
+    """android_nimbus_update flow coverage."""
+
+    async def check_treestatus(*args):
+        return True
+
+    open_mock = mocker.mock_open(read_data=old_contents)
+    mocker.patch("builtins.open", open_mock, create=True)
+    mocker.patch.object(os.path, "exists", return_value=True)
+
+    mocker.patch.object(aio, "request")
+    mocker.patch.object(subprocess, "run", return_value=subprocess.CompletedProcess(args=None, returncode=0, stdout=new_contents))
+    mocker.patch.object(nimbus, "get_dontbuild", return_value=False)
+    mocker.patch.object(nimbus, "get_ignore_closed_tree", return_value=ignore_closed_tree)
+    mocker.patch.object(nimbus, "check_treestatus", new=check_treestatus)
+    mocker.patch.object(nimbus, "get_android_nimbus_update_info", return_value=android_nimbus_update_info)
+    mocker.patch.object(nimbus, "vcs", new=AsyncMock())
+
+    assert await nimbus.android_nimbus_update({}, {}, tmpdir) == changes
+
+
+@pytest.mark.asyncio
+async def test_android_nimbus_update_closed_tree(mocker):
+    """android_nimbus_update should exit if the tree is closed and ignore_closed_tree is
+    False.
+
+    """
+
+    async def check_treestatus(*args):
+        return False
+
+    mocker.patch.object(aio, "request")
+    mocker.patch.object(nimbus, "subprocess")
+    mocker.patch.object(nimbus, "get_dontbuild", return_value=False)
+    mocker.patch.object(nimbus, "get_ignore_closed_tree", return_value=False)
+    mocker.patch.object(nimbus, "get_short_source_repo", return_value="mozilla-central")
+    mocker.patch.object(nimbus, "check_treestatus", new=check_treestatus)
+    # this will [intentionally] break if we fail to exit android_nimbus_update where
+    # we're supposed to
+    mocker.patch.object(nimbus, "get_android_nimbus_update_info", return_value={"from_repo_url": "x"})
+
+    assert await nimbus.android_nimbus_update({}, {}, "") == 0


### PR DESCRIPTION
Here's a treescript action to replace the Nimbus workflows on firefox-android:
https://github.com/mozilla-mobile/firefox-android/blob/main/.github/workflows/fenix-update-nimbus-experiments.yml
https://github.com/mozilla-mobile/firefox-android/blob/main/.github/workflows/focus-update-nimbus-experiments.yml

Basically, these periodically update fenix/app/src/main/res/raw/initial_experiments.json and focus-android/app/src/main/res/raw/initial_experiments.json to keep them in sync with https://experimenter.services.mozilla.com/api/v6/experiments-first-run/ . `jq` is used to filter the downloaded json content by app-name before updating the appropriate file.