### PR TITLE
Bug 1841055 - [beetmoverscript] add fenix/focus config for AWS/firefox/dev

### DIFF
--- a/beetmoverscript/docker.d/worker.yml
+++ b/beetmoverscript/docker.d/worker.yml
@@ -234,6 +234,8 @@ clouds:
             product_buckets:
               devedition: 'net-mozaws-stage-delivery-archive'
               firefox:    'net-mozaws-stage-delivery-firefox'
+              fenix:      'net-mozaws-stage-delivery-archive'
+              focus:      'net-mozaws-stage-delivery-archive'
           maven-staging:
             fail_task_on_error: True
             enabled: True


### PR DESCRIPTION
I am only adding this to avoid beetmover task failures on oak:
https://firefox-ci-tc.services.mozilla.com/tasks/HY6wFmiCT7ujjNH3RNBxpQ