### PR TITLE
iscript/VPN: Disable BundleIsRelocatable in macvpn package.

### DIFF
--- a/iscript/src/iscript/macvpn.py
+++ b/iscript/src/iscript/macvpn.py
@@ -133,7 +133,7 @@ async def _create_pkg_plist(root_path, plist_path, **kwargs):
 
     # Load the plist file.
     with open(plist_path, "rb") as fp:
-        data = plistlib(fp)
+        data = plistlib.load(fp)
 
     # Apply changes.
     for i in range(len(data)):

--- a/iscript/src/iscript/macvpn.py
+++ b/iscript/src/iscript/macvpn.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import plistlib
 from pathlib import Path
 from shutil import copy2, copytree
 
@@ -110,6 +111,41 @@ async def _codesign(sign_config, binary_path):
         retry_exceptions=(IScriptError,),
     )
 
+async def _create_pkg_plist(root_path, plist_path, **kwargs):
+    """Generate the component plist file for a Mac application bundle.
+
+    This runs pkgbuild --analyze to generate a template plist, and then
+    updates it with values provided by the kwargs.
+
+    Args:
+        root_path (str): Root directory tree to be packaged.
+        plist_path (str): File path where the plist should be written.
+        kwargs: Values to be set in the component plist.
+
+    Raises:
+        IScriptError: on failure
+    """
+    # Analyze the root to be packaged to generate a template plist.
+    analyze_cmd = [
+        "pkgbuild",
+        "--analyze",
+        "--root",
+        root_path,
+        plist_path,
+    ]
+    await _retry_async_cmd(analyze_cmd)
+
+    # Load the plist file.
+    with open(plist_path, "rb") as fp:
+        data = plistlib(fp)
+
+    # Apply changes.
+    for i in range(len(data)):
+        data[i].update(kwargs)
+
+    # Write out.
+    with open(plist_path, "wb") as fp:
+        plistlib.dump(data, fp)
 
 async def _create_pkg_files(config, sign_config, app):
     """Create .pkg installer from the .app file.
@@ -145,6 +181,10 @@ async def _create_pkg_files(config, sign_config, app):
 
     copytree(app.app_path, os.path.join(root_path, "Mozilla VPN.app"))
 
+    # Generate the component plist.
+    component_plist_path = os.path.join(config["work_dir"], "component.plist")
+    await _create_pkg_plist(root_path, component_plist_path, BundleIsRelocatable=False)
+
     cmd_opts = []
     if sign_config.get("pkg_cert_id"):
         cmd_opts = ["--keychain", sign_config["signing_keychain"], "--sign", sign_config["pkg_cert_id"]]
@@ -161,6 +201,8 @@ async def _create_pkg_files(config, sign_config, app):
         os.path.join(app.parent_dir, "scripts"),
         "--root",
         root_path,
+        "--component-plist",
+        component_plist_path,
         app.pkg_path,
     )
 

--- a/iscript/src/iscript/macvpn.py
+++ b/iscript/src/iscript/macvpn.py
@@ -126,14 +126,10 @@ async def _create_pkg_plist(root_path, plist_path, **kwargs):
         IScriptError: on failure
     """
     # Analyze the root to be packaged to generate a template plist.
-    analyze_cmd = [
-        "pkgbuild",
-        "--analyze",
-        "--root",
-        root_path,
-        plist_path,
-    ]
-    await _retry_async_cmd(analyze_cmd)
+    await run_command(
+        ["pkgbuild", "--analyze", "--root", root_path, plist_path],
+        exception=IScriptError,
+    )
 
     # Load the plist file.
     with open(plist_path, "rb") as fp:

--- a/iscript/tests/test_macvpn.py
+++ b/iscript/tests/test_macvpn.py
@@ -41,6 +41,7 @@ async def test_create_pkg_files(mocker, tmp_path):
     mocker.patch.object(macvpn, "copy2", new=noop_sync)
     mocker.patch.object(macvpn.os, "remove", new=noop_sync)
     mocker.patch.object(macvpn.os, "mkdir", new=noop_sync)
+    mocker.patch.object(macvpn, "_create_pkg_plist", new=noop_async)
 
     config = {"work_dir": tmp_path}
     sign_config = {"signing_keychain": "1", "base_bundle_id": "1"}


### PR DESCRIPTION
The Mozilla VPN project relies on the installation of a daemon in its `postinstall` script, which requires that the VPN application bundle is installed into a fixed location. This can result in a broken installation if `PackageKit` determines that the bundle has been relocated due to the existence of a `Mozilla VPN.app` literally anywhere else on the user's machine.

Mostly, this is just a developer annoyance that prevents the installer from running successfully due to a dirty build directory, but it would be nice if we could fix this by setting `BundleIsRelocatable` to false when generating the installer package.

This has already been tested out with a local build of the VPN installer in mozilla-mobile/mozilla-vpn-client#8724 this PR attempts to apply the same change during the releng signing task.