### PR TITLE
iscript: Fix iscript on Python 3.9 due to deprecated readPlist() method

### DIFF
--- a/iscript/src/iscript/mac.py
+++ b/iscript/src/iscript/mac.py
@@ -156,8 +156,8 @@ def get_bundle_executable(appdir):
         KeyError: if the plist doesn't include ``CFBundleIdentifier``
 
     """
-    return plistlib.readPlist(os.path.join(appdir, "Contents", "Info.plist"))["CFBundleExecutable"]
-
+    with open(os.path.join(appdir, "Contents", "Info.plist"), "rb") as fp:
+        return plistlib.load(fp)["CFBundleExecutable"]
 
 # _get_sign_command {{{1
 def _get_sign_command(identity, keychain, sign_config, file_=None, entitlements_path=None):

--- a/iscript/tests/test_mac.py
+++ b/iscript/tests/test_mac.py
@@ -104,10 +104,13 @@ def test_app_path_and_name(mocker):
 
 
 # get_bundle_executable {{{1
-def test_get_bundle_executable(mocker):
+def test_get_bundle_executable(tmpdir):
     """``get_bundle_executable`` returns the CFBundleExecutable."""
-    mocker.patch.object(plistlib, "readPlist", return_value={"CFBundleExecutable": "main"})
-    assert mac.get_bundle_executable("foo") == "main"
+    os.mkdir(os.path.join(tmpdir, "Contents"))
+    with open(os.path.join(tmpdir, "Contents", "Info.plist"), "wb") as fp:
+        plistlib.dump({ "CFBundleExecutable": "main" }, fp)
+
+    assert mac.get_bundle_executable(tmpdir) == "main"
 
 
 # sign_single_files {{{1

--- a/iscript/tox.ini
+++ b/iscript/tox.ini
@@ -8,9 +8,8 @@ usedevelop = false
 depends =
 skip_install = true
 commands =
-# issue with plistlib not having readPList: https://docs.python.org/3.9/whatsnew/3.9.html#removed
-#    docker build --build-arg PYTHON_VERSION=3.9.7 --build-arg PYTHON_REQ_SUFFIX=.py39 -t iscript-{envname}-py39-test -f Dockerfile.test .
-#    docker run --rm -v {toxinidir}/..:/app -v iscript-{envname}-py39-tox:/app/.tox -w /app/iscript iscript-{envname}-py39-test py39
+    docker build --build-arg PYTHON_VERSION=3.9.7 --build-arg PYTHON_REQ_SUFFIX=.py39 -t iscript-{envname}-py39-test -f Dockerfile.test .
+    docker run --rm -v {toxinidir}/..:/app -v iscript-{envname}-py39-tox:/app/.tox -w /app/iscript iscript-{envname}-py39-test py39
     docker build --build-arg PYTHON_VERSION=3.8 -t iscript-{envname}-py38-test -f Dockerfile.test .
     docker run --rm -v {toxinidir}/..:/app -v iscript-{envname}-py38-tox:/app/.tox -w /app/iscript iscript-{envname}-py38-test py38
 


### PR DESCRIPTION
While testing PR #893 I found it easier to fix the broken `test_get_bundle_executable()` test rather than change my local python version, but rather than obfuscate the intent of that work, I have separated the fix into a separate PR.