### PR TITLE
Bug 1871138 - Add 'mozillavpn' to shipitscript

### DIFF
--- a/shipitscript/docker.d/init_worker.sh
+++ b/shipitscript/docker.d/init_worker.sh
@@ -26,6 +26,9 @@ case $COT_PRODUCT in
   app-services)
     export TASKCLUSTER_SCOPE_PREFIX="project:app-services:releng:ship-it:"
     ;;
+  mozillavpn)
+    export TASKCLUSTER_SCOPE_PREFIX="project:mozillavpn:releng:ship-it:"
+    ;;
   *)
     exit 1
     ;;

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -202,13 +202,13 @@ def get_expected_return_code(app, product, env):
         if product not in ("mobile", "mozillavpn"):
             return 1
     elif app == "pushflatpak":
-        if product  not in ("firefox", "thunderbird"):
+        if product not in ("firefox", "thunderbird"):
             return 1
     elif app == "pushmsix":
         if product != "firefox":
             return 1
     elif app == "shipit":
-        if product not in ("adhoc", "app-services", "firefox", "mobile", "thunderbird", "xpi"):
+        if product not in ("adhoc", "app-services", "firefox", "mobile", "mozillavpn", "thunderbird", "xpi"):
             return 1
     elif app == "tree":
         if product not in ("firefox", "mobile", "thunderbird"):


### PR DESCRIPTION
This is blocked on updating sops + cloudops-infra