### PR TITLE
bug 1879021: Adjust ship it scope prefix for mobile

### DIFF
--- a/shipitscript/docker.d/init_worker.sh
+++ b/shipitscript/docker.d/init_worker.sh
@@ -11,8 +11,11 @@ test_var_set() {
 }
 
 case $COT_PRODUCT in
-  firefox|mobile)
+  firefox)
     export TASKCLUSTER_SCOPE_PREFIX="project:releng:ship-it:"
+    ;;
+  mobile)
+    export TASKCLUSTER_SCOPE_PREFIX="project:mobile:ship-it:"
     ;;
   thunderbird)
     export TASKCLUSTER_SCOPE_PREFIX="project:comm:thunderbird:releng:ship-it:"


### PR DESCRIPTION
I'm looking to simplify and make consistent ship it scope grants in ci-configuration. To support this, I want to put all ship it scopes for GitHub projects behind their `trust_domain`. Currently Firefox Android is the only one not behind this.