### PR TITLE
ci: add {dev|prod}-bitrisescript to list of branches that run tasks

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -77,6 +77,7 @@ tasks:
               - addonscript
               - balrogscript
               - beetmoverscript
+              - bitrisescript
               - bouncerscript
               - githubscript
               # - iscript (iscript has special release via ronin_puppet repo)


### PR DESCRIPTION
I missed this in the initial PR that added bitrisescript.