### PR TITLE
bug 1882850: update createprecomplete in iscript and signingscript

### DIFF
--- a/iscript/src/iscript/createprecomplete.py
+++ b/iscript/src/iscript/createprecomplete.py
@@ -21,7 +21,15 @@ def get_build_entries(root_path):
             parent_dir_rel_path = root[len(root_path) + 1 :]
             rel_path_file = os.path.join(parent_dir_rel_path, file_name)
             rel_path_file = rel_path_file.replace("\\", "/")
-            if not (rel_path_file.endswith("channel-prefs.js") or rel_path_file.endswith("update-settings.ini") or rel_path_file.find("distribution/") != -1):
+            if not (
+                rel_path_file.endswith("channel-prefs.js")
+                or rel_path_file.endswith("update-settings.ini")
+                or "/ChannelPrefs.framework/" in rel_path_file
+                or rel_path_file.startswith("ChannelPrefs.framework/")
+                or "/UpdateSettings.framework/" in rel_path_file
+                or rel_path_file.startswith("UpdateSettings.framework/")
+                or "distribution/" in rel_path_file
+            ):
                 rel_file_path_set.add(rel_path_file)
 
         for dir_name in dirs:

--- a/signingscript/src/signingscript/createprecomplete.py
+++ b/signingscript/src/signingscript/createprecomplete.py
@@ -21,7 +21,15 @@ def get_build_entries(root_path):
             parent_dir_rel_path = root[len(root_path) + 1 :]
             rel_path_file = os.path.join(parent_dir_rel_path, file_name)
             rel_path_file = rel_path_file.replace("\\", "/")
-            if not (rel_path_file.endswith("channel-prefs.js") or rel_path_file.endswith("update-settings.ini") or rel_path_file.find("distribution/") != -1):
+            if not (
+                rel_path_file.endswith("channel-prefs.js")
+                or rel_path_file.endswith("update-settings.ini")
+                or "/ChannelPrefs.framework/" in rel_path_file
+                or rel_path_file.startswith("ChannelPrefs.framework/")
+                or "/UpdateSettings.framework/" in rel_path_file
+                or rel_path_file.startswith("UpdateSettings.framework/")
+                or "distribution/" in rel_path_file
+            ):
                 rel_file_path_set.add(rel_path_file)
 
         for dir_name in dirs:


### PR DESCRIPTION
It turns out this is an unmarked vendored version of the version in Gecko. We recently had to update this for some mac changes (https://bugzilla.mozilla.org/show_bug.cgi?id=1882322), and this version needs updating too. The full diff between Gecko and ours is as follows:
```
--- /home/bhearsum/repos/gecko/apple/config/createprecomplete.py	2024-02-29 13:21:34.756098895 -0500
+++ src/iscript/createprecomplete.py	2023-10-16 14:04:21.852109146 -0400
@@ -6,8 +6,8 @@
 # longer present in a complete update. The current working directory is used for
 # the location to enumerate and to create the precomplete file.

-import io
 import os
+import sys

 def get_build_entries(root_path):
@@ -21,15 +21,7 @@
             parent_dir_rel_path = root[len(root_path) + 1 :]
             rel_path_file = os.path.join(parent_dir_rel_path, file_name)
             rel_path_file = rel_path_file.replace("\\", "/")
-            if not (
-                rel_path_file.endswith("channel-prefs.js")
-                or rel_path_file.endswith("update-settings.ini")
-                or "/ChannelPrefs.framework/" in rel_path_file
-                or rel_path_file.startswith("ChannelPrefs.framework/")
-                or "/UpdateSettings.framework/" in rel_path_file
-                or rel_path_file.startswith("UpdateSettings.framework/")
-                or "distribution/" in rel_path_file
-            ):
+            if not (rel_path_file.endswith("channel-prefs.js") or rel_path_file.endswith("update-settings.ini") or rel_path_file.find("distribution/") != -1):
                 rel_file_path_set.add(rel_path_file)

         for dir_name in dirs:
@@ -61,13 +53,13 @@
     precomplete_file_path = os.path.join(root_path, rel_path_precomplete)
     # Open the file so it exists before building the list of files and open it
     # in binary mode to prevent OS specific line endings.
-    precomplete_file = io.open(precomplete_file_path, mode="wt", newline="\n")
+    precomplete_file = open(precomplete_file_path, "wb")
     rel_file_path_list, rel_dir_path_list = get_build_entries(root_path)
     for rel_file_path in rel_file_path_list:
-        precomplete_file.write('remove "' + rel_file_path + '"\n')
+        precomplete_file.write('remove "{}"\n'.format(rel_file_path).encode("utf-8"))

     for rel_dir_path in rel_dir_path_list:
-        precomplete_file.write('rmdir "' + rel_dir_path + '"\n')
+        precomplete_file.write('rmdir "{}"\n'.format(rel_dir_path).encode("utf-8"))

     precomplete_file.close()

```

But what's included here is the only consequential change. (The last two lines look like python2 vs python3 differences - but I don't think we should try to change them as part of this patch to avoid any possible risk.)