### PR TITLE
bug 1881039: stop calling flat-manager-client purge

### DIFF
--- a/pushflatpakscript/src/pushflatpakscript/flathub.py
+++ b/pushflatpakscript/src/pushflatpakscript/flathub.py
@@ -198,6 +198,3 @@ def push(context, flatpak_file_path, channel):
 
     log.info(f"Publishing the flatpak to the associated {publish_build_output}")
     run_flat_manager_client_process(context, token_args + ["publish", "--wait", publish_build_output])
-
-    log.info(f"Cleaning up byt purging {publish_build_output}")
-    run_flat_manager_client_process(context, token_args + ["purge", publish_build_output])


### PR DESCRIPTION
We've been told to this; I haven't been able to find any supporting documentation or evidence that this won't have downsides though.