### PR TITLE
tests: don't set GPG_PUBKEY in signingscript context

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -81,7 +81,6 @@ CONTEXT = {
         "CLIENT_SECRET": "Zm9vYmFyCg==",
     },
     "signing": {
-        "GPG_PUBKEY": "Zm9vYmFyCg==",
         "PUBLIC_IP": "127.0.0.1",
         "WIDEVINE_CERT": "Zm9vYmFyCg==",
         "AUTOGRAPH_AUTHENTICODE_PASSWORD": "1",


### PR DESCRIPTION
In bug 1832830 it was replaced by GPG_PUBKEY_PATH which is set directly in init_worker.sh.