### PR TITLE
Call pip install with --no-deps

### DIFF
--- a/addonscript/Dockerfile
+++ b/addonscript/Dockerfile
@@ -13,11 +13,11 @@ COPY . /app
 
 RUN python -m venv /app \
  && cd addonscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app
 

--- a/addonscript/Dockerfile.test
+++ b/addonscript/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/balrogscript/Dockerfile
+++ b/balrogscript/Dockerfile
@@ -13,14 +13,14 @@ COPY . /app
 
 RUN python -m venv /app \
  && cd /app/scriptworker_client \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/balrogscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app
 

--- a/balrogscript/Dockerfile.test
+++ b/balrogscript/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/beetmoverscript/Dockerfile
+++ b/beetmoverscript/Dockerfile
@@ -13,11 +13,11 @@ COPY . /app
 RUN python -m venv /app \
  && cd beetmoverscript \
  && /app/bin/pip install --upgrade pip \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install .
 
 USER app

--- a/beetmoverscript/Dockerfile.test
+++ b/beetmoverscript/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/bitrisescript/Dockerfile
+++ b/bitrisescript/Dockerfile
@@ -19,14 +19,14 @@ USER app
 
 RUN python -m venv /app \
  && cd /app/scriptworker_client \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/bitrisescript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app
 

--- a/bitrisescript/Dockerfile.test
+++ b/bitrisescript/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/bouncerscript/Dockerfile
+++ b/bouncerscript/Dockerfile
@@ -12,11 +12,11 @@ COPY . /app
 
 RUN python -m venv /app \
  && cd bouncerscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app
 

--- a/bouncerscript/Dockerfile.test
+++ b/bouncerscript/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/configloader/Dockerfile.test
+++ b/configloader/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/githubscript/Dockerfile
+++ b/githubscript/Dockerfile
@@ -19,14 +19,14 @@ USER app
 
 RUN python -m venv /app \
  && cd /app/scriptworker_client \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/githubscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app
 

--- a/githubscript/Dockerfile.test
+++ b/githubscript/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/iscript/Dockerfile.test
+++ b/iscript/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/notarization_poller/Dockerfile
+++ b/notarization_poller/Dockerfile
@@ -13,11 +13,11 @@ COPY . /app
 
 RUN python -m venv /app \
  && cd notarization_poller \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app
 

--- a/notarization_poller/Dockerfile.test
+++ b/notarization_poller/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/pushapkscript/Dockerfile
+++ b/pushapkscript/Dockerfile
@@ -22,11 +22,11 @@ USER app
 
 RUN python -m venv /app \
  && cd pushapkscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app \
  && curl -L https://github.com/google/bundletool/releases/download/1.15.4/bundletool-all-1.15.4.jar -o /app/bundletool.jar \

--- a/pushapkscript/Dockerfile.test
+++ b/pushapkscript/Dockerfile.test
@@ -17,7 +17,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/pushflatpakscript/Dockerfile
+++ b/pushflatpakscript/Dockerfile
@@ -14,14 +14,14 @@ USER app
 
 RUN python -m venv /app \
  && cd pushflatpakscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && python -m venv /app/flat_manager_venv \
- && /app/flat_manager_venv/bin/pip install -r /app/pushflatpakscript/requirements/flat-manager.txt \
+ && /app/flat_manager_venv/bin/pip install --no-deps -r /app/pushflatpakscript/requirements/flat-manager.txt \
  && curl -Ls \
     https://github.com/flatpak/flat-manager/raw/d9d7972b24de6022c7079f8721fd8335c3319dc5/flat-manager-client | \
     sed -e '1i#!/app/flat_manager_venv/bin/python' -e '1d' > /app/flat_manager_venv/bin/flat-manager-client \

--- a/pushflatpakscript/Dockerfile.test
+++ b/pushflatpakscript/Dockerfile.test
@@ -12,7 +12,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/pushmsixscript/Dockerfile
+++ b/pushmsixscript/Dockerfile
@@ -12,14 +12,14 @@ USER app
 
 RUN python -m venv /app \
  && cd /app/scriptworker_client \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/pushmsixscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app
 

--- a/pushmsixscript/Dockerfile.test
+++ b/pushmsixscript/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/shipitscript/Dockerfile
+++ b/shipitscript/Dockerfile
@@ -13,11 +13,11 @@ COPY . /app
 
 RUN python -m venv /app \
  && cd shipitscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app
 

--- a/shipitscript/Dockerfile.test
+++ b/shipitscript/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/signingscript/Dockerfile
+++ b/signingscript/Dockerfile
@@ -40,11 +40,11 @@ WORKDIR /app
 # Install signingscript + configloader + widevine
 RUN python -m venv /app \
  && cd signingscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && ln -sf /etc/widevine.py $(/app/bin/python -c "import site; print(site.getsitepackages()[0])")/widevine.py \
  && cd /app

--- a/signingscript/Dockerfile.test
+++ b/signingscript/Dockerfile.test
@@ -12,7 +12,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -24,11 +24,11 @@ WORKDIR /app
 # Install scriptworker_client and configloader
 RUN python -m venv /app \
  && cd /app/scriptworker_client \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install .
 
 CMD ["/app/docker.d/init.sh"]

--- a/taskcluster/docker/pushapkscript/Dockerfile
+++ b/taskcluster/docker/pushapkscript/Dockerfile
@@ -17,11 +17,11 @@ USER app
 RUN cp -R /app/pushapkscript/docker.d/* /app/docker.d/ \
  && python -m venv /app \
  && cd pushapkscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app \
  && curl -L https://github.com/google/bundletool/releases/download/1.15.4/bundletool-all-1.15.4.jar -o /app/bundletool.jar \

--- a/taskcluster/docker/pushflatpakscript/Dockerfile
+++ b/taskcluster/docker/pushflatpakscript/Dockerfile
@@ -17,14 +17,14 @@ USER app
 RUN cp -R /app/pushflatpakscript/docker.d/* /app/docker.d/ \
  && python -m venv /app \
  && cd pushflatpakscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && python -m venv /app/flat_manager_venv \
- && /app/flat_manager_venv/bin/pip install -r /app/pushflatpakscript/requirements/flat-manager.txt \
+ && /app/flat_manager_venv/bin/pip install --no-deps -r /app/pushflatpakscript/requirements/flat-manager.txt \
  && curl -Ls \
     https://github.com/flatpak/flat-manager/raw/d9d7972b24de6022c7079f8721fd8335c3319dc5/flat-manager-client | \
     sed -e '1i#!/app/flat_manager_venv/bin/python' -e '1d' > /app/flat_manager_venv/bin/flat-manager-client \

--- a/taskcluster/docker/pushmsixscript/Dockerfile
+++ b/taskcluster/docker/pushmsixscript/Dockerfile
@@ -10,12 +10,12 @@ ADD --chown=app:app topsrcdir/pushmsixscript /app/pushmsixscript
 RUN cp -R /app/pushmsixscript/docker.d/* /app/docker.d/ \
  && python -m venv /app \
  && cd /app/scriptworker_client \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/pushmsixscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install .

--- a/taskcluster/docker/script/Dockerfile
+++ b/taskcluster/docker/script/Dockerfile
@@ -10,5 +10,5 @@ ADD --chown=app:app topsrcdir/$SCRIPT_NAME /app/$SCRIPT_NAME
 
 RUN cd /app/$SCRIPT_NAME \
  && ([ -d docker.d ] && cp -R docker.d/* /app/docker.d/) \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install .

--- a/taskcluster/docker/signingscript/Dockerfile
+++ b/taskcluster/docker/signingscript/Dockerfile
@@ -40,10 +40,10 @@ WORKDIR /app
 RUN cp -R /app/signingscript/docker.d/* /app/docker.d/ \
  && python -m venv /app \
  && cd signingscript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && ln -sf /etc/widevine.py $(/app/bin/python -c "import site; print(site.getsitepackages()[0])")/widevine.py

--- a/taskcluster/docker/treescript/Dockerfile
+++ b/taskcluster/docker/treescript/Dockerfile
@@ -20,14 +20,14 @@ WORKDIR /app
 RUN cp -R /app/treescript/docker.d/* /app/docker.d/ \
  && python -m venv /app \
  && cd /app/scriptworker_client \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/treescript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app \
  && hg clone -r 0180a71f29b2f71113665cf9425fd73693d0265c https://hg.mozilla.org/hgcustom/version-control-tools /app/version-control-tools

--- a/treescript/Dockerfile
+++ b/treescript/Dockerfile
@@ -15,14 +15,14 @@ COPY . /app
 
 RUN python -m venv /app \
  && cd /app/scriptworker_client \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && cd /app/treescript \
- && /app/bin/pip install -r requirements/base.txt \
+ && /app/bin/pip install --no-deps -r requirements/base.txt \
  && /app/bin/pip install . \
  && python -m venv /app/configloader_venv \
  && cd /app/configloader \
- && /app/configloader_venv/bin/pip install -r requirements/base.txt \
+ && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app \
  && hg clone -r 0180a71f29b2f71113665cf9425fd73693d0265c https://hg.mozilla.org/hgcustom/version-control-tools /app/version-control-tools

--- a/treescript/Dockerfile.test
+++ b/treescript/Dockerfile.test
@@ -8,7 +8,7 @@ COPY MANIFEST.in setup.py tox.ini /app/
 COPY requirements/ /app/requirements/
 
 ARG PYTHON_REQ_SUFFIX
-RUN pip install -r requirements/local${PYTHON_REQ_SUFFIX}.txt
+RUN pip install --no-deps -r requirements/local${PYTHON_REQ_SUFFIX}.txt
 
 COPY src/ /app/src/
 


### PR DESCRIPTION
The dependency resolution happens when generating the requirements files, so no need to do that again (and risk breaking things) at install time.