### PR TITLE
fix: Re-include the content of `docker.d` in treescript image

### DIFF
--- a/taskcluster/docker/treescript/Dockerfile
+++ b/taskcluster/docker/treescript/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update \
 USER app
 WORKDIR /app
 
-RUN python -m venv /app \
+RUN cp -R /app/treescript/docker.d/* /app/docker.d/ \
+ && python -m venv /app \
  && cd /app/scriptworker_client \
  && /app/bin/pip install -r requirements/base.txt \
  && /app/bin/pip install . \


### PR DESCRIPTION
PRs https://github.com/mozilla-releng/scriptworker-scripts/pull/927 and https://github.com/mozilla-releng/scriptworker-scripts/pull/932 introduced new Dockerfiles including specific ones for workers that need to install a system package. The new treescript Dockerfile was missing a copy statement which caused a CrashLoopBackOff with this error:

```
"/app/docker.d/init.sh: line 140: /app/docker.d/init_worker.sh: No such file or directory"
```

I checked no other specific Dockerfiles are missing this statement. 