### PR TITLE
bug 1886181: switch dev and -t- xpi signing to cas_cur keyids + autograph stage

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -139,17 +139,17 @@ in:
       # dep-passwords-xpi.json
       '(ENV == "dev" || ENV == "fake-prod") && COT_PRODUCT == "xpi"':
         '${scope_prefix[0]}cert:dep-signing':
-          - ["https://autograph-external.prod.autograph.services.mozaws.net",
-             {"$eval": "AUTOGRAPH_XPI_USERNAME"},
-             {"$eval": "AUTOGRAPH_XPI_PASSWORD"},
+          - ["https://autograph-external.stage.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_XPI_STAGE_USERNAME"},
+             {"$eval": "AUTOGRAPH_XPI_STAGE_PASSWORD"},
              ["privileged_webextension"],
-             "extension_rsa_dep"
+             "cas_cur_extension_rsa"
             ]
-          - ["https://autograph-external.prod.autograph.services.mozaws.net",
-             {"$eval": "AUTOGRAPH_XPI_USERNAME"},
-             {"$eval": "AUTOGRAPH_XPI_PASSWORD"},
+          - ["https://autograph-external.stage.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_XPI_STAGE_USERNAME"},
+             {"$eval": "AUTOGRAPH_XPI_STAGE_PASSWORD"},
              ["system_addon"],
-             "systemaddon_rsa_dep"
+             "cas_cur_systemaddon_rsa"
             ]
 
       # dep-passwords-mozillavpn.json


### PR DESCRIPTION
I think this is going to be a temporary measure while we work on content signing root CA succession. After that, I imagine we'll want all of our signing workers (outside of adhoc) to be pointing at prod?

The dev switch is not strictly necessary, but I don't think it's worth the effort of separating the two out for the period of time this will be live - but I could be convinced otherwise.