### PR TITLE
Bug 1889223 - Submit all files to notarization before polling

### DIFF
--- a/signingscript/src/signingscript/script.py
+++ b/signingscript/src/signingscript/script.py
@@ -45,11 +45,16 @@ async def async_main(context):
         context.session = session
         context.autograph_configs = load_autograph_configs(context.config["autograph_configs"])
 
+        # TODO: Make task.sign take in the whole filelist_dict and return a dict of output files.
+        #       That would likely mean changing all behaviors to accept and deal with multiple files at once.
+
         filelist_dict = build_filelist_dict(context)
         for path, path_dict in filelist_dict.items():
             if path_dict["formats"] == ["apple_notarization_stacked"]:
                 # Skip if only format is notarization_stacked - handled below
                 continue
+            if "apple_notarization_stacked" in path_dict["formats"]:
+                raise SigningScriptError("apple_notarization_stacked cannot be mixed with other signing types")
             copy_to_dir(path_dict["full_path"], context.config["work_dir"], target=path)
             log.info("signing %s", path)
             output_files = await sign(context, os.path.join(work_dir, path), path_dict["formats"], authenticode_comment=path_dict.get("comment"))

--- a/signingscript/src/signingscript/script.py
+++ b/signingscript/src/signingscript/script.py
@@ -65,6 +65,7 @@ async def async_main(context):
                 copy_to_dir(context.config["gpg_pubkey"], context.config["artifact_dir"], target="public/build/KEY")
 
         # notarization_stacked is a special format that takes in all files at once instead of sequentially like other formats
+        # Should be fixed in https://github.com/mozilla-releng/scriptworker-scripts/issues/980
         notarization_dict = {path: path_dict for path, path_dict in filelist_dict.items() if "apple_notarization_stacked" in path_dict["formats"]}
         if notarization_dict:
             output_files = await apple_notarize_stacked(context, notarization_dict)

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -1643,7 +1643,7 @@ async def apple_notarize(context, path, *args, **kwargs):
     """
     # Setup workdir
     notarization_workdir = os.path.join(context.config["work_dir"], "apple_notarize")
-    utils.mkdir(notarization_workdir, delete_before_create=True)
+    utils.mkdir(notarization_workdir)
 
     _, extension = os.path.splitext(path)
     if extension == ".pkg":
@@ -1659,7 +1659,8 @@ async def apple_notarize_geckodriver(context, path, *args, **kwargs):
     """
     # Setup workdir
     notarization_workdir = os.path.join(context.config["work_dir"], "apple_notarize")
-    utils.mkdir(notarization_workdir, delete_before_create=True)
+    shutil.rmtree(notarization_workdir, ignore_errors=True)
+    utils.mkdir(notarization_workdir)
 
     return await _notarize_geckodriver(context, path, notarization_workdir)
 
@@ -1681,7 +1682,8 @@ async def apple_notarize_stacked(context, filelist_dict):
         task_index += 1
         relpath_index_map[relpath] = task_index
         notarization_workdir = os.path.join(context.config["work_dir"], f"apple_notarize-{task_index}")
-        utils.mkdir(notarization_workdir, delete_before_create=True)
+        shutil.rmtree(notarization_workdir, ignore_errors=True)
+        utils.mkdir(notarization_workdir)
         _, extension = os.path.splitext(relpath)
         if extension == ".pkg":
             path = os.path.join(notarization_workdir, relpath)

--- a/signingscript/src/signingscript/task.py
+++ b/signingscript/src/signingscript/task.py
@@ -35,9 +35,6 @@ from signingscript.sign import (
 log = logging.getLogger(__name__)
 
 
-async def noop_sign(*args, **kwargs):
-    return []
-
 FORMAT_TO_SIGNING_FUNCTION = immutabledict(
     {
         "autograph_hash_only_mar384": sign_mar384_with_autograph_hash,
@@ -65,7 +62,6 @@ FORMAT_TO_SIGNING_FUNCTION = immutabledict(
         "apple_notarization_geckodriver": apple_notarize_geckodriver,
         # This format is handled in script.py
         # "apple_notarization_stacked": apple_notarize_stacked,
-        "apple_notarization_stacked": noop_sign,
         "default": sign_file,
     }
 )

--- a/signingscript/src/signingscript/task.py
+++ b/signingscript/src/signingscript/task.py
@@ -18,6 +18,7 @@ from scriptworker.utils import get_single_item_from_sequence
 from signingscript.sign import (
     apple_notarize,
     apple_notarize_geckodriver,
+    apple_notarize_stacked,  # noqa: F401
     sign_authenticode,
     sign_debian_pkg,
     sign_file,
@@ -32,6 +33,10 @@ from signingscript.sign import (
 )
 
 log = logging.getLogger(__name__)
+
+
+async def noop_sign(*args, **kwargs):
+    return []
 
 FORMAT_TO_SIGNING_FUNCTION = immutabledict(
     {
@@ -58,6 +63,9 @@ FORMAT_TO_SIGNING_FUNCTION = immutabledict(
         "autograph_rsa": sign_file_detached,
         "apple_notarization": apple_notarize,
         "apple_notarization_geckodriver": apple_notarize_geckodriver,
+        # This format is handled in script.py
+        # "apple_notarization_stacked": apple_notarize_stacked,
+        "apple_notarization_stacked": noop_sign,
         "default": sign_file,
     }
 )

--- a/signingscript/src/signingscript/task.py
+++ b/signingscript/src/signingscript/task.py
@@ -61,6 +61,7 @@ FORMAT_TO_SIGNING_FUNCTION = immutabledict(
         "apple_notarization": apple_notarize,
         "apple_notarization_geckodriver": apple_notarize_geckodriver,
         # This format is handled in script.py
+        # Should be refactored in https://github.com/mozilla-releng/scriptworker-scripts/issues/980
         # "apple_notarization_stacked": apple_notarize_stacked,
         "default": sign_file,
     }

--- a/signingscript/src/signingscript/utils.py
+++ b/signingscript/src/signingscript/utils.py
@@ -6,7 +6,6 @@ import hashlib
 import json
 import logging
 import os
-import shutil
 from asyncio.subprocess import PIPE, STDOUT
 from dataclasses import dataclass
 from shutil import copyfile
@@ -36,15 +35,12 @@ class AppleNotarization:
     private_key: str
 
 
-def mkdir(path, delete_before_create=False):
+def mkdir(path):
     """Equivalent to `mkdir -p`.
 
     Args:
         path (str): the path to mkdir
-        delete_before_create (bool, optional): whether to delete the path before creating it. Defaults to False
     """
-    if delete_before_create:
-        shutil.rmtree(path, ignore_errors=True)
     try:
         os.makedirs(path)
         log.info("mkdir {}".format(path))

--- a/signingscript/src/signingscript/utils.py
+++ b/signingscript/src/signingscript/utils.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 from asyncio.subprocess import PIPE, STDOUT
 from dataclasses import dataclass
 from shutil import copyfile
@@ -35,13 +36,15 @@ class AppleNotarization:
     private_key: str
 
 
-def mkdir(path):
+def mkdir(path, delete_before_create=False):
     """Equivalent to `mkdir -p`.
 
     Args:
         path (str): the path to mkdir
-
+        delete_before_create (bool, optional): whether to delete the path before creating it. Defaults to False
     """
+    if delete_before_create:
+        shutil.rmtree(path, ignore_errors=True)
     try:
         os.makedirs(path)
         log.info("mkdir {}".format(path))

--- a/signingscript/tests/test_script.py
+++ b/signingscript/tests/test_script.py
@@ -111,10 +111,12 @@ async def test_async_main_apple_notarization_stacked(tmpdir, mocker):
 
 
 @pytest.mark.asyncio
-async def test_async_main_apple_notarization_stacked_multi(tmpdir, mocker):
+async def test_async_main_apple_notarization_stacked_mixed_fail(tmpdir, mocker):
     formats = ["autograph_mar", "apple_notarization_stacked"]
     mocker.patch.object(script, "copy_to_dir", new=noop_sync)
-    await async_main_helper(tmpdir, mocker, formats)
+    with pytest.raises(SigningScriptError):
+        await async_main_helper(tmpdir, mocker, formats)
+
 
 @pytest.mark.asyncio
 async def test_async_main_apple_notarization_no_config(tmpdir, mocker):

--- a/signingscript/tests/test_script.py
+++ b/signingscript/tests/test_script.py
@@ -30,6 +30,9 @@ async def async_main_helper(tmpdir, mocker, formats, extra_config={}, server_typ
             assert authenticode_comment == "Some authenticode comment"
         return [val]
 
+    async def fake_notarize_stacked(_, filelist_dict, *args, **kwargs):
+        return filelist_dict.keys()
+
     mocker.patch.object(script, "load_autograph_configs", new=noop_sync)
     mocker.patch.object(script, "load_apple_notarization_configs", new=noop_sync)
     mocker.patch.object(script, "setup_apple_notarization_credentials", new=noop_sync)
@@ -37,6 +40,7 @@ async def async_main_helper(tmpdir, mocker, formats, extra_config={}, server_typ
     mocker.patch.object(script, "task_signing_formats", return_value=formats)
     mocker.patch.object(script, "build_filelist_dict", new=fake_filelist_dict)
     mocker.patch.object(script, "sign", new=fake_sign)
+    mocker.patch.object(script, "apple_notarize_stacked", new=fake_notarize_stacked)
     context = mock.MagicMock()
     context.config = {"work_dir": tmpdir, "artifact_dir": tmpdir, "autograph_configs": {}, "apple_notarization_configs": "fake"}
     context.config.update(extra_config)
@@ -98,6 +102,19 @@ async def test_async_main_apple_notarization(tmpdir, mocker):
     mocker.patch.object(script, "copy_to_dir", new=noop_sync)
     await async_main_helper(tmpdir, mocker, formats)
 
+
+@pytest.mark.asyncio
+async def test_async_main_apple_notarization_stacked(tmpdir, mocker):
+    formats = ["apple_notarization_stacked"]
+    mocker.patch.object(script, "copy_to_dir", new=noop_sync)
+    await async_main_helper(tmpdir, mocker, formats)
+
+
+@pytest.mark.asyncio
+async def test_async_main_apple_notarization_stacked_multi(tmpdir, mocker):
+    formats = ["autograph_mar", "apple_notarization_stacked"]
+    mocker.patch.object(script, "copy_to_dir", new=noop_sync)
+    await async_main_helper(tmpdir, mocker, formats)
 
 @pytest.mark.asyncio
 async def test_async_main_apple_notarization_no_config(tmpdir, mocker):

--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -1495,12 +1495,50 @@ async def test_apple_notarize_stacked(mocker, context):
     mocker.patch.object(sign, "_extract_tarfile", noop_async)
     mocker.patch.object(sign, "_create_tarfile", noop_async)
     mocker.patch.object(sign.os, "listdir", lambda *_: ["/foo.pkg", "/baz.app", "/foobar"])
+    mocker.patch.object(sign.os, "walk", lambda *_: [("/", None, ["foo.pkg", "baz.app"])])
     mocker.patch.object(sign.shutil, "rmtree", noop_sync)
     mocker.patch.object(sign.utils, "mkdir", noop_sync)
     mocker.patch.object(sign.utils, "copy_to_dir", noop_sync)
 
-    await sign.apple_notarize_stacked(context, {"/app.tar.gz": {"full_path": "/app.tar.gz", "formats": ["apple_notarize_stacked"]}})
+    await sign.apple_notarize_stacked(
+        context,
+        {
+            "/app.tar.gz": {"full_path": "/app.tar.gz", "formats": ["apple_notarize_stacked"]},
+            "/app2.pkg": {"full_path": "/app2.pkg", "formats": ["apple_notarize_stacked"]},
+        },
+    )
     # one for each file format
-    assert notarize.await_count == 2
-    assert wait.await_count == 2
-    assert staple.await_count == 2
+    assert notarize.await_count == 3
+    assert wait.await_count == 3
+    assert staple.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_apple_notarize_stacked_unsupported(mocker, context):
+    """Test unsupported file extensions"""
+
+    mocker.patch.object(sign, "_extract_tarfile", noop_async)
+    mocker.patch.object(sign.shutil, "rmtree", noop_sync)
+    mocker.patch.object(sign.utils, "mkdir", noop_sync)
+    mocker.patch.object(sign.utils, "copy_to_dir", noop_sync)
+
+    # Returns unsupported file formats
+    mocker.patch.object(sign.os, "listdir", lambda *_: ["/foo.aaa", "/baz.bbb", "/foobar"])
+
+    with pytest.raises(SigningScriptError):
+        # Main file is supported, contents uses the above os.listdir
+        await sign.apple_notarize_stacked(
+            context,
+            {
+                "/app.tar.gz": {"full_path": "/app.tar.gz", "formats": ["apple_notarize_stacked"]},
+            },
+        )
+
+    with pytest.raises(SigningScriptError):
+        # Main file extension is unsupported
+        await sign.apple_notarize_stacked(
+            context,
+            {
+                "/app.bbb": {"full_path": "/app.bbb", "formats": ["apple_notarize_stacked"]},
+            },
+        )

--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -23,6 +23,7 @@ from scriptworker.utils import makedirs
 
 import signingscript.sign as sign
 import signingscript.utils as utils
+import signingscript.rcodesign as rcodesign
 from signingscript.exceptions import SigningScriptError
 from signingscript.utils import get_hash
 
@@ -1481,3 +1482,29 @@ async def test_apple_notarize_geckodriver(mocker, context):
 
     await sign.apple_notarize_geckodriver(context, "/foo/bar.pkg")
     notarize_geckodriver.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_apple_notarize_stacked(mocker, context):
+    notarize = mock.AsyncMock()
+    mocker.patch.object(sign, "rcodesign_notarize", notarize)
+    wait = mock.AsyncMock()
+    mocker.patch.object(sign, "rcodesign_notary_wait", wait)
+    staple = mock.AsyncMock()
+    mocker.patch.object(sign, "rcodesign_staple", staple)
+
+    mocker.patch.object(sign, "_extract_tarfile", noop_async)
+    mocker.patch.object(sign, "_create_tarfile", noop_async)
+    mocker.patch.object(sign.os, "listdir", lambda *_: ["/foo.pkg", "/baz.app", "/foobar"])
+    mocker.patch.object(sign.shutil, "rmtree", noop_sync)
+    mocker.patch.object(sign.utils, "mkdir", noop_sync)
+    mocker.patch.object(sign.utils, "copy_to_dir", noop_sync)
+
+    await sign.apple_notarize_stacked(
+        context,
+        {"/app.tar.gz": {"full_path": "/app.tar.gz", "formats": ["apple_notarize_stacked"]}}
+        )
+    # one for each file format
+    assert notarize.await_count == 2
+    assert wait.await_count == 2
+    assert staple.await_count == 2

--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -23,7 +23,6 @@ from scriptworker.utils import makedirs
 
 import signingscript.sign as sign
 import signingscript.utils as utils
-import signingscript.rcodesign as rcodesign
 from signingscript.exceptions import SigningScriptError
 from signingscript.utils import get_hash
 
@@ -1500,10 +1499,7 @@ async def test_apple_notarize_stacked(mocker, context):
     mocker.patch.object(sign.utils, "mkdir", noop_sync)
     mocker.patch.object(sign.utils, "copy_to_dir", noop_sync)
 
-    await sign.apple_notarize_stacked(
-        context,
-        {"/app.tar.gz": {"full_path": "/app.tar.gz", "formats": ["apple_notarize_stacked"]}}
-        )
+    await sign.apple_notarize_stacked(context, {"/app.tar.gz": {"full_path": "/app.tar.gz", "formats": ["apple_notarize_stacked"]}})
     # one for each file format
     assert notarize.await_count == 2
     assert wait.await_count == 2

--- a/signingscript/tests/test_task.py
+++ b/signingscript/tests/test_task.py
@@ -151,6 +151,7 @@ async def test_sign(context, mocker, format, filename, post_files):
         ("widevine", stask.sign_widevine),
         ("autograph_authenticode", stask.sign_authenticode),
         ("autograph_authenticode_stub", stask.sign_authenticode),
+        ("apple_notarization", stask.apple_notarize),
         ("default", stask.sign_file),
         # Key id cases
         ("autograph_hash_only_mar384:firefox_20190321_dev", stask.sign_mar384_with_autograph_hash),


### PR DESCRIPTION
This is the first behavior that consumes all files at once, so it's a bit odd how it's being handled in script.py