### PR TITLE
bitrisescript: allow specifying artifact_prefix to support public art…

### DIFF
--- a/bitrisescript/src/bitrisescript/data/bitrisescript_task_schema.json
+++ b/bitrisescript/src/bitrisescript/data/bitrisescript_task_schema.json
@@ -13,6 +13,10 @@
         "payload": {
             "type": "object",
             "properties": {
+                "artifact_prefix": {
+                    "description": "Prefix to store task artifacts. Setting this to 'public' will generate public artifacts.",
+                    "type": "string"
+                },
                 "build_params": {
                     "description": "Parameters describing the build context to pass onto Bitrise. All keys are optional but specific workflows may depend on particular keys being set.",
                     "type": "object",

--- a/bitrisescript/src/bitrisescript/script.py
+++ b/bitrisescript/src/bitrisescript/script.py
@@ -6,7 +6,7 @@ import logging
 import os
 
 from bitrisescript.bitrise import BitriseClient, run_build
-from bitrisescript.task import get_bitrise_app, get_bitrise_workflows, get_build_params
+from bitrisescript.task import get_artifact_dir, get_bitrise_app, get_bitrise_workflows, get_build_params
 from scriptworker_client.client import sync_main
 
 log = logging.getLogger(__name__)
@@ -16,12 +16,13 @@ async def async_main(config, task):
     app = get_bitrise_app(config, task)
     log.info(f"Bitrise app: '{app}'")
 
+    artifact_dir = get_artifact_dir(config, task)
     build_params = get_build_params(task)
 
     futures = []
     for workflow in get_bitrise_workflows(config, task):
         build_params["workflow_id"] = workflow
-        futures.append(run_build(config["artifact_dir"], **build_params))
+        futures.append(run_build(artifact_dir, **build_params))
 
     client = None
     try:

--- a/bitrisescript/src/bitrisescript/task.py
+++ b/bitrisescript/src/bitrisescript/task.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 from scriptworker_client.exceptions import TaskVerificationError
@@ -95,3 +96,20 @@ def get_build_params(task: dict[str, Any]) -> dict[str, Any]:
         dict: The bitrise build_params to specify. Empty dict if unspecified.
     """
     return task["payload"].get("build_params", {})
+
+
+def get_artifact_dir(config: dict[str, Any], task: dict[str, Any]) -> str:
+    """Get the directory to store artifacts from the config and task payload.
+
+    Args:
+        task (dict): The task definition.
+
+    Returns:
+        str: The directory to store artifacts.
+    """
+    artifact_prefix = task["payload"].get("artifact_prefix", "")
+    artifact_dir = os.path.normpath(os.path.join(config["artifact_dir"], artifact_prefix))
+    if not artifact_dir.startswith(config["artifact_dir"]):
+        raise TaskVerificationError(f"{artifact_dir} is not a subdirectory of {config['artifact_dir']}!")
+
+    return artifact_dir

--- a/bitrisescript/tests/test_task.py
+++ b/bitrisescript/tests/test_task.py
@@ -126,3 +126,16 @@ def test_get_bitrise_workflows(config, task, expectation, expected):
 )
 def test_get_build_params(task, expected):
     assert task_mod.get_build_params(task) == expected
+
+
+@pytest.mark.parametrize(
+    "task, expectation, expected",
+    (
+        pytest.param({"payload": {}}, does_not_raise(), "work/artifacts", id="no artifact prefix"),
+        pytest.param({"payload": {"artifact_prefix": "public"}}, does_not_raise(), "work/artifacts/public", id="artifact prefix"),
+        pytest.param({"payload": {"artifact_prefix": "../../../etc"}}, pytest.raises(TaskVerificationError), None, id="funny business"),
+    ),
+)
+def test_get_artifact_dir(config, task, expectation, expected):
+    with expectation:
+        assert task_mod.get_artifact_dir(config, task) == expected


### PR DESCRIPTION
…ifacts

This allows you to namespace artifacts under a prefix. By setting this to `public` it makes all artifacts produced by the task public.

Issue: #964