### PR TITLE
Bug 1886710 - Switch `xpi-t` signing to `cas-new` keyids

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -143,13 +143,13 @@ in:
              {"$eval": "AUTOGRAPH_STAGE_XPI_PRIVILEGED_USERNAME"},
              {"$eval": "AUTOGRAPH_STAGE_XPI_PRIVILEGED_PASSWORD"},
              ["privileged_webextension"],
-             "cas_cur_extension_rsa"
+             "cas_new_extension_rsa"
           ]
           - ["https://autograph-external.stage.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_STAGE_XPI_PRIVILEGED_USERNAME"},
              {"$eval": "AUTOGRAPH_STAGE_XPI_PRIVILEGED_PASSWORD"},
              ["system_addon"],
-             "cas_cur_systemaddon_rsa"
+             "cas_new_systemaddon_rsa"
           ]
 
       # dep-passwords-mozillavpn.json
@@ -209,7 +209,7 @@ in:
              {"$eval": "AUTOGRAPH_STAGE_XPI_USERNAME"},
              {"$eval": "AUTOGRAPH_STAGE_XPI_PASSWORD"},
              ["autograph_xpi", "autograph_xpi_sha1_es256_es384", "autograph_xpi_sha1_es256_ps256", "autograph_xpi_sha1_es256", "autograph_xpi_sha1_ps256"],
-             "cas_cur_webextensions_rsa"
+             "cas_new_webextensions_rsa"
           ]
 
       # passwords.json


### PR DESCRIPTION
See: https://bugzilla.mozilla.org/show_bug.cgi?id=1886710