### PR TITLE
Bug 1891815 - Increase bitrise MAX_TASK_TIMEOUT to 2 hours

### DIFF
--- a/bitrisescript/docker.d/init_worker.sh
+++ b/bitrisescript/docker.d/init_worker.sh
@@ -10,6 +10,8 @@ test_var_set() {
   fi
 }
 
+export TASK_MAX_TIMEOUT=7200
+
 case $COT_PRODUCT in
   mobile)
     case $ENV in

--- a/docker.d/scriptworker.yml
+++ b/docker.d/scriptworker.yml
@@ -6,11 +6,8 @@ worker_id: { "$eval": "WORKER_ID" }
 credentials:
     clientId: { "$eval": "TASKCLUSTER_CLIENT_ID" }
     accessToken: { "$eval": "TASKCLUSTER_ACCESS_TOKEN" }
-# XXX: there is no string to int conversion in json-e so we are hardcoding for now
-# artifact_upload_timeout: { "$eval": "ARTIFACT_UPLOAD_TIMEOUT" }
-# task_max_timeout: { "$eval": "TASK_MAX_TIMEOUT" }
-artifact_upload_timeout: 1200
-task_max_timeout: 3600
+artifact_upload_timeout: { "$eval": ARTIFACT_UPLOAD_TIMEOUT }
+task_max_timeout: { "$eval": TASK_MAX_TIMEOUT }
 task_script:
     - { "$eval": "TASK_SCRIPT" }
     - { "$eval": "TASK_CONFIG" }


### PR DESCRIPTION
I don't think the comment about json-e not supporting integers is valid anymore. I tested in the playground and integer context values get passed on as integers by $eval.