### PR TITLE
Bug 1832287 - support "buildhub-only" value for aws bucket config

### DIFF
--- a/beetmoverscript/docker.d/worker.yml
+++ b/beetmoverscript/docker.d/worker.yml
@@ -230,7 +230,7 @@ clouds:
         'COT_PRODUCT == "firefox" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: buildhub-only
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -260,7 +260,7 @@ clouds:
         'COT_PRODUCT == "firefox" && ENV == "prod"':
           nightly:
             fail_task_on_error: True
-            enabled: True
+            enabled: buildhub-only
             credentials:
               id: { "$eval": "NIGHTLY_ID" }
               key: { "$eval": "NIGHTLY_KEY" }
@@ -271,7 +271,7 @@ clouds:
               focus:      'net-mozaws-prod-delivery-archive'
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: buildhub-only
             credentials:
               id: { "$eval": "RELEASE_ID" }
               key: { "$eval": "RELEASE_KEY" }
@@ -321,7 +321,7 @@ clouds:
         'COT_PRODUCT == "thunderbird" && (ENV == "dev" || ENV == "fake-prod")':
           dep:
             fail_task_on_error: True
-            enabled: True
+            enabled: buildhub-only
             credentials:
               id: { "$eval": "DEP_ID" }
               key: { "$eval": "DEP_KEY" }
@@ -331,7 +331,7 @@ clouds:
         'COT_PRODUCT == "thunderbird" && ENV == "prod"':
           nightly:
             fail_task_on_error: True
-            enabled: True
+            enabled: buildhub-only
             credentials:
               id: { "$eval": "NIGHTLY_ID" }
               key: { "$eval": "NIGHTLY_KEY" }
@@ -339,7 +339,7 @@ clouds:
               thunderbird: 'net-mozaws-prod-delivery-archive'
           release:
             fail_task_on_error: True
-            enabled: True
+            enabled: buildhub-only
             credentials:
               id: { "$eval": "RELEASE_ID" }
               key: { "$eval": "RELEASE_KEY" }

--- a/beetmoverscript/src/beetmoverscript/data/config_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/config_schema.json
@@ -40,7 +40,7 @@
                 "type": "object",
                 "properties": {
                     "enabled": {
-                        "type": "boolean"
+                        "enum": [true, false, "buildhub-only"]
                     },
                     "credentials": {
                         "type": ["object", "string"],

--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -189,7 +189,7 @@ async def push_to_partner(context):
 
 async def push_to_releases(context):
     # S3 upload
-    if context.config["clouds"]["aws"][context.resource]["enabled"]:
+    if context.config["clouds"]["aws"][context.resource]["enabled"] is True:
         await push_to_releases_s3(context)
 
     # GCS upload
@@ -498,7 +498,7 @@ async def move_partner_beets(context, manifest):
             destination = get_destination_for_partner_repack_path(context, manifest, full_path_artifact, locale)
 
             # S3 upload
-            if context.config["clouds"]["aws"][context.resource]["enabled"]:
+            if context.config["clouds"]["aws"][context.resource]["enabled"] is True:
                 cloud_uploads["aws"].append(asyncio.ensure_future(upload_to_s3(context=context, s3_key=destination, path=source)))
 
             # GCS upload
@@ -656,7 +656,8 @@ async def retry_upload(context, destinations, path):
     #  we don't have that use case right now, but might be worth fixing
     for dest in destinations:
         # S3 upload
-        if is_cloud_enabled(context.config, "aws", context.resource):
+        enabled = is_cloud_enabled(context.config, "aws", context.resource)
+        if enabled is True or (enabled == "buildhub-only" and path.endswith("buildhub.json")):
             cloud_uploads["aws"].append(asyncio.ensure_future(upload_to_s3(context=context, s3_key=dest, path=path)))
 
         # GCS upload


### PR DESCRIPTION
The only thing we still need to upload to the s3
net-mozaws-{stage,prod}-delivery-* buckets is buildhub.json; until buildhub is updated to not need that, skip uploading everything else.