### PR TITLE
bug 1896651: switch langpack signing to new production AMO certificate

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -52,7 +52,8 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
                {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
-               ["autograph_langpack"]
+               ["autograph_langpack"],
+               "webextensions_rsa_dep_202402"
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_FOCUS_USERNAME"},
@@ -233,7 +234,8 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
                {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
-               ["autograph_langpack"]
+               ["autograph_langpack"],
+               "webextensions_rsa_202404"
             ]
           firefox_and_thunderbird_prod_nightly_autograph:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
@@ -265,7 +267,8 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
                {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
-               ["autograph_langpack"]
+               ["autograph_langpack"],
+               "webextensions_rsa_202404"
             ]
         in:
           '${scope_prefix[0]}cert:nightly-signing':


### PR DESCRIPTION
This is waiting on:
1) Confirmation that this is the right keyid to use
2) The hawk id for these can use this keyid
3) For AMO to switch to this keyid as well (planned for Thursday May 16th @ 9am PT)