### PR TITLE
bug 1896651: Backout langpack cert change

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -52,8 +52,7 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
                {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
-               ["autograph_langpack"],
-               "webextensions_rsa_dep_202402"
+               ["autograph_langpack"]
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_FOCUS_USERNAME"},


### PR DESCRIPTION
The hawk credentials for dep signing don't have access to the necessary keyid; need to wait on an autograph deploy to fix this.