### PR TITLE
bug 1896651: Reland langpack dep signing change to 202402 keyid

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -52,7 +52,8 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
                {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
-               ["autograph_langpack"]
+               ["autograph_langpack"],
+               "webextensions_rsa_dep_202402"
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_FOCUS_USERNAME"},


### PR DESCRIPTION
Requires an autograph deploy before we can merge and deploy this