### PR TITLE
Re-backout langpack dep signing changes

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -52,8 +52,7 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
                {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
-               ["autograph_langpack"],
-               "webextensions_rsa_dep_202402"
+               ["autograph_langpack"]
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_FOCUS_USERNAME"},


### PR DESCRIPTION
hawk creds still don't have access to the new keyid