### PR TITLE
fix(treescript): use separate Github apps for prod vs dev

### DIFF
--- a/treescript/docker.d/worker.yml
+++ b/treescript/docker.d/worker.yml
@@ -27,5 +27,9 @@ hg_ssh_config:
 github_config:
   $if: 'REPO_TYPE == "git"'
   then:
+    app_id:
+      $if: 'ENV == "prod"'
+      then: 390757  # https://github.com/apps/releng-treescript
+      else: 909547  # https://github.com/apps/releng-treescript-dev
     privkey_file: {"$eval": "GITHUB_PRIVKEY_FILE"}
   else: {}

--- a/treescript/src/treescript/github/client.py
+++ b/treescript/src/treescript/github/client.py
@@ -14,16 +14,15 @@ from scriptworker_client.utils import retry_async
 
 log = logging.getLogger(__name__)
 
-GITHUB_APP_ID = 390757  # https://github.com/apps/releng-treescript
-
 
 class GithubClient:
     def __init__(self, config, owner, repo):
         with open(config["github_config"]["privkey_file"]) as fh:
             privkey = fh.read()
+        self.app_id = config["github_config"]["app_id"]
         self.owner = owner
         self.repo = repo
-        self._client = AppClient(GITHUB_APP_ID, privkey, owner=owner, repositories=[repo])
+        self._client = AppClient(self.app_id, privkey, owner=owner, repositories=[repo])
 
     async def close(self):
         await self._client.close()

--- a/treescript/tests/conftest.py
+++ b/treescript/tests/conftest.py
@@ -39,7 +39,7 @@ def pubkey(datadir):
 
 @pytest_asyncio.fixture
 async def client(aioresponses, privkey_file):
-    config = {"github_config": {"privkey_file": privkey_file}}
+    config = {"github_config": {"app_id": 12345, "privkey_file": privkey_file}}
     owner = "mozilla-mobile"
     repo = "firefox-android"
     inst_id = 1


### PR DESCRIPTION
Initially I didn't bother splitting these out because I figured they both require the exact same permissions on the repo anyway. So if the dev app secret were compromised, you'd be just as hosed as if the prod app secret were compromised.

However, it didn't occur to me that we might only install the `dev` app on staging repos and that we don't want a bug on treescript-dev to accidentally expose the `prod` app's private key.

To this end, I created a `releng-treescript-dev` app. We should probably avoid installing this app on production repos, and instead only add it to `staging-*` repos. To help with this, I restricted the app to the `mozilla-releng` org.