### PR TITLE
treescript: add support for fetching l10n revisions in a github repo

### DIFF
--- a/treescript/docker.d/init_worker.sh
+++ b/treescript/docker.d/init_worker.sh
@@ -29,6 +29,7 @@ case $COT_PRODUCT in
     test_var_set 'SSH_USER'
     test_var_set 'SSH_KEY'
     export NEEDS_HG="1"
+    export NEEDS_GIT="1"
     export TRUST_DOMAIN="gecko"
     export UPSTREAM_REPO="https://hg.mozilla.org/mozilla-unified"
     ;;

--- a/treescript/docker.d/init_worker.sh
+++ b/treescript/docker.d/init_worker.sh
@@ -21,24 +21,27 @@ test_var_set 'PROJECT_NAME'
 export MERGE_DAY_CLOBBER_FILE="CLOBBER"
 
 
+export NEEDS_HG="0"
+export NEEDS_GIT="0"
+
 case $COT_PRODUCT in
   firefox)
     test_var_set 'SSH_USER'
     test_var_set 'SSH_KEY'
-    export REPO_TYPE="hg"
+    export NEEDS_HG="1"
     export TRUST_DOMAIN="gecko"
     export UPSTREAM_REPO="https://hg.mozilla.org/mozilla-unified"
     ;;
   mobile)
     test_var_set 'GITHUB_PRIVKEY'
-    export REPO_TYPE="git"
+    export NEEDS_GIT="1"
     export TRUST_DOMAIN="mobile"
     export UPSTREAM_REPO=""
     ;;
   thunderbird)
     test_var_set 'SSH_USER'
     test_var_set 'SSH_KEY'
-    export REPO_TYPE="hg"
+    export NEEDS_HG="1"
     export TRUST_DOMAIN="comm"
     export UPSTREAM_REPO="https://hg.mozilla.org/comm-unified"
     export MERGE_DAY_CLOBBER_FILE=""
@@ -48,7 +51,7 @@ case $COT_PRODUCT in
     ;;
 esac
 
-if [ "$REPO_TYPE" == "hg" ]; then
+if [ "$NEEDS_HG" == "1" ]; then
   export HG_SHARE_BASE_DIR=/tmp/share_base
   export SSH_KEY_PATH="$CONFIG_DIR/ssh_key_$SSH_USER"
   echo "$SSH_KEY" | base64 -d > "$SSH_KEY_PATH"
@@ -69,7 +72,8 @@ if [ "$REPO_TYPE" == "hg" ]; then
 hg.mozilla.org,63.245.215.25 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDEsS2fK+TVkHl4QvvOHB6R5xxngsSYJR+pA4+xDhw4mZT9tgCRU9BBG3LazSLp6PUxnpfok78475/tx6Z8QwbTyUTmLElZ9Z9eJzjaGz/olHzQSWv0VB3kT+VZt0LK7pEuaG+Ph/qwxbtUZZOApYLEvu8uctDlS66doofxZylbsgl1kpRQ5HNu+/DgVo9K9dyMOm9OLoy4tXHSE5pofn4tKYdFRa2lt6OVtIP5/hKNb2i0+JmgM8C3bJTPvzJ4C8p2h83ro29XPUkNAfWrgD5CmAPPqHFXyefDCfdefcvI8B8Za9v4j4LynBDZHsGfII+wIfzyLIxy9K6Op6nqDZgCciBRdgxh4uZQINEhB/JJP03Pxo42ExdG28oU3aL8kRRTORT5ehFtImFfr9QESHaUnbVzBbU5DmOB5voYDMle3RgyY+RXJ7+4OxjLRnJvGks9QCn8QrIvabs/PTCnenI8+yDhMlLUkWTiR4JK8vDBYB2Rm++EmVsN9WjllfDNg3Aj1aYe8XiBD4tS+lg7Ur4rJL8X20H4yMvq56sQ0qfH8PCIQGyGL725E7Yuwj/MHvou5xrPM/Lqo/MtX5T2njrzkeaBmI/zFJaLwbphdrwmrzepbcim7OYJFF2pz8u56KDPD1pUQ7C1gEIAx/4mHiDOGCYooSvyfD+JRdjkZUZMiQ==
 hg.mozilla.org,63.245.215.102 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDEsS2fK+TVkHl4QvvOHB6R5xxngsSYJR+pA4+xDhw4mZT9tgCRU9BBG3LazSLp6PUxnpfok78475/tx6Z8QwbTyUTmLElZ9Z9eJzjaGz/olHzQSWv0VB3kT+VZt0LK7pEuaG+Ph/qwxbtUZZOApYLEvu8uctDlS66doofxZylbsgl1kpRQ5HNu+/DgVo9K9dyMOm9OLoy4tXHSE5pofn4tKYdFRa2lt6OVtIP5/hKNb2i0+JmgM8C3bJTPvzJ4C8p2h83ro29XPUkNAfWrgD5CmAPPqHFXyefDCfdefcvI8B8Za9v4j4LynBDZHsGfII+wIfzyLIxy9K6Op6nqDZgCciBRdgxh4uZQINEhB/JJP03Pxo42ExdG28oU3aL8kRRTORT5ehFtImFfr9QESHaUnbVzBbU5DmOB5voYDMle3RgyY+RXJ7+4OxjLRnJvGks9QCn8QrIvabs/PTCnenI8+yDhMlLUkWTiR4JK8vDBYB2Rm++EmVsN9WjllfDNg3Aj1aYe8XiBD4tS+lg7Ur4rJL8X20H4yMvq56sQ0qfH8PCIQGyGL725E7Yuwj/MHvou5xrPM/Lqo/MtX5T2njrzkeaBmI/zFJaLwbphdrwmrzepbcim7OYJFF2pz8u56KDPD1pUQ7C1gEIAx/4mHiDOGCYooSvyfD+JRdjkZUZMiQ==
 EOF
-elif [ "$REPO_TYPE" == "git" ]; then
+fi
+if [ "$NEEDS_GIT" == "1" ]; then
   export GITHUB_PRIVKEY_FILE="$CONFIG_DIR/github_privkey"
   echo "$GITHUB_PRIVKEY" | base64 -d > "$GITHUB_PRIVKEY_FILE"
   chmod 400 "$GITHUB_PRIVKEY_FILE"

--- a/treescript/docker.d/worker.yml
+++ b/treescript/docker.d/worker.yml
@@ -6,13 +6,13 @@ verbose: {"$eval": "VERBOSE == 'true'"}
 treestatus_base_url: https://treestatus.mozilla-releng.net
 hg: 'hg'
 hg_share_base_dir:
-  $if: 'REPO_TYPE == "hg"'
+  $if: 'NEEDS_HG == "1"'
   then: {"$eval": "HG_SHARE_BASE_DIR"}
   else: ""
 upstream_repo: {"$eval": "UPSTREAM_REPO"}
 merge_day_clobber_file: {"$eval": "MERGE_DAY_CLOBBER_FILE"}
 hg_ssh_config:
-  $if: 'REPO_TYPE == "hg"'
+  $if: 'NEEDS_HG == "1"'
   then:
     $merge:
       - default:
@@ -25,7 +25,7 @@ hg_ssh_config:
             keyfile: {"$eval": "SSH_MERGE_KEY_PATH"}
   else: {}
 github_config:
-  $if: 'REPO_TYPE == "git"'
+  $if: 'NEEDS_GIT == "1"'
   then:
     app_id:
       $if: 'ENV == "prod"'

--- a/treescript/src/treescript/data/treescript_task_schema.json
+++ b/treescript/src/treescript/data/treescript_task_schema.json
@@ -265,6 +265,9 @@
                             "l10n_repo_url": {
                                 "type": "string"
                             },
+                            "l10n_repo_target_branch": {
+                                "type": "string"
+                            },
                             "ignore_config": {
                                 "type": "object"
                             },
@@ -317,6 +320,7 @@
                             "tag",
                             "version_bump",
                             "l10n_bump",
+                            "l10n_bump_github",
                             "merge_day",
                             "android_l10n_import",
                             "android_l10n_sync",

--- a/treescript/src/treescript/gecko/__init__.py
+++ b/treescript/src/treescript/gecko/__init__.py
@@ -27,7 +27,13 @@ async def perform_merge_actions(config, task, actions, repo_path):
         repo_path (str): the source directory to use.
     """
     log.info("Starting merge day operations")
-    push_activity = await do_merge(config, task, repo_path)
+
+    l10n_bump_action = ""
+
+    if "l10n_bump" in actions:
+        l10n_bump_action = "l10n_bump"
+
+    push_activity = await do_merge(config, task, repo_path, l10n_bump_action)
 
     if should_push(task, actions) and push_activity:
         log.info("%d branches to push", len(push_activity))

--- a/treescript/src/treescript/gecko/l10n.py
+++ b/treescript/src/treescript/gecko/l10n.py
@@ -300,15 +300,10 @@ async def l10n_bump_github(config: dict, task: dict, repo_path: str) -> int:
     """
     log.info("Preparing to bump l10n changesets.")
 
-    ignore_closed_tree = get_ignore_closed_tree(task)
-    if not ignore_closed_tree and not task["payload"].get("dry_run", False):
-        if not await check_treestatus(config, task):
-            log.info("Treestatus is closed; skipping l10n bump.")
-            return 0
-
     dontbuild = get_dontbuild(task)
     l10n_bump_info = get_l10n_bump_info(task)
     changes = 0
+    ignore_closed_tree = False
 
     for bump_config in l10n_bump_info:
         l10n_repo_url = bump_config.get("l10n_repo_url")

--- a/treescript/src/treescript/gecko/merges.py
+++ b/treescript/src/treescript/gecko/merges.py
@@ -10,7 +10,8 @@ import attr
 from mozilla_version.gecko import GeckoVersion
 
 from scriptworker_client.utils import makedirs
-from treescript.gecko.l10n import l10n_bump
+from treescript.exceptions import TreeScriptError
+from treescript.gecko.l10n import l10n_bump, l10n_bump_github
 from treescript.gecko.mercurial import commit, get_revision, run_hg_command
 from treescript.gecko.versionmanip import do_bump_version, get_version
 from treescript.util.task import get_merge_config, get_metadata_source_repo
@@ -277,6 +278,12 @@ async def do_merge(config, task, repo_path, l10n_bump_action):
 async def _bump_l10n(config, task, repo_path, l10n_bump_action):
     if l10n_bump_action == "l10n_bump":
         await l10n_bump(config, task, repo_path)
+    elif l10n_bump_action == "l10n_bump_github":
+        await l10n_bump_github(config, task, repo_path)
+    else:
+        # This should be unreachable as we validate this before we get here,
+        # but that may change in the future...
+        raise TreeScriptError(f"Unknown l10n_bump_action: '{l10n_bump_action}'")
 
     output = await run_hg_command(config, "log", "--patch", "--verbose", "-r", ".", repo_path=repo_path, return_output=True, expected_exit_codes=(0, 1))
     path = os.path.join(config["artifact_dir"], "public", "logs", "l10n_bump.diff")

--- a/treescript/src/treescript/util/task.py
+++ b/treescript/src/treescript/util/task.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 # human reference.
 VALID_ACTIONS = {
     "comm": {"tag", "version_bump", "l10n_bump", "push", "merge_day"},
-    "gecko": {"tag", "version_bump", "l10n_bump", "push", "merge_day", "android_l10n_import", "android_l10n_sync"},
+    "gecko": {"tag", "version_bump", "l10n_bump", "l10n_bump_github", "push", "merge_day", "android_l10n_import", "android_l10n_sync"},
     "mobile": {"version_bump"},
 }
 
@@ -273,6 +273,7 @@ def task_action_types(config, task):
             raise TaskVerificationError(f"No action scopes match '{prefix[:-1]}':\n  {scope_str}")
 
     log.info(f"Action requests: {actions}")
+    log.info(f"Valid actions: {VALID_ACTIONS[config['trust_domain']]}")
     invalid_actions = actions - VALID_ACTIONS[config["trust_domain"]]
     if len(invalid_actions) > 0:
         raise TaskVerificationError(f"Task specified invalid actions for '{config['trust_domain']}: {invalid_actions}")

--- a/treescript/tests/test_config.py
+++ b/treescript/tests/test_config.py
@@ -3,6 +3,7 @@ import os
 
 import jsone
 import jsonschema
+import pytest
 import yaml
 
 
@@ -27,20 +28,48 @@ def _validate_config(context):
     jsonschema.validate(config, schema)
 
 
-def test_config():
+@pytest.mark.parametrize(
+    "needs_hg,needs_git",
+    (
+        pytest.param(
+            "1",
+            "0",
+            id="hg_only",
+        ),
+        pytest.param(
+            "0",
+            "1",
+            id="git_only",
+        ),
+        pytest.param(
+            "1",
+            "1",
+            id="hg_and_git",
+        ),
+    )
+)
+def test_config(needs_hg, needs_git):
     context = {
         "WORK_DIR": "",
         "ARTIFACTS_DIR": "",
         "VERBOSE": "true",
-        "HG_SHARE_BASE_DIR": "",
-        "SSH_USER": "",
-        "SSH_KEY_PATH": "",
         "UPSTREAM_REPO": "",
-        "SSH_MERGE_USER": "",
-        "SSH_MERGE_KEY_PATH": "",
         "MERGE_DAY_CLOBBER_FILE": "",
         "COT_PRODUCT": "firefox",
         "TRUST_DOMAIN": "gecko",
-        "REPO_TYPE": "hg",
+        "NEEDS_HG": needs_hg,
+        "NEEDS_GIT": needs_git,
+        "ENV": "prod",
     }
+
+    if needs_hg == "1":
+        context["HG_SHARE_BASE_DIR"] = ""
+        context["SSH_KEY_PATH"] = ""
+        context["SSH_USER"] = ""
+        context["SSH_MERGE_KEY_PATH"] = ""
+        context["SSH_MERGE_USER"] = ""
+
+    if needs_git == "1":
+        context["GITHUB_PRIVKEY_FILE"] = ""
+
     _validate_config(context)

--- a/treescript/tests/test_config.py
+++ b/treescript/tests/test_config.py
@@ -46,7 +46,7 @@ def _validate_config(context):
             "1",
             id="hg_and_git",
         ),
-    )
+    ),
 )
 def test_config(needs_hg, needs_git):
     context = {

--- a/treescript/tests/test_gecko_l10n.py
+++ b/treescript/tests/test_gecko_l10n.py
@@ -215,10 +215,10 @@ async def test_build_revision_dict_github(mocker, aioresponses, client):
     mocker.patch.object(l10n, "build_platform_dict", new=build_platform_dict)
     got = await l10n.build_revision_dict_github(client, bump_config, "")
     assert got == {
-                "one": {"pin": False, "revision": "new_revision", "platforms": ["platform"]},
-                "two": {"pin": False, "revision": "new_revision", "platforms": ["platform"]},
-                "three": {"pin": False, "revision": "new_revision", "platforms": ["platform"]},
-            }
+        "one": {"pin": False, "revision": "new_revision", "platforms": ["platform"]},
+        "two": {"pin": False, "revision": "new_revision", "platforms": ["platform"]},
+        "three": {"pin": False, "revision": "new_revision", "platforms": ["platform"]},
+    }
 
 
 @pytest.mark.asyncio
@@ -246,7 +246,7 @@ async def test_build_revision_dict_github_branch_not_in_repo(mocker, aioresponse
     aioresponses.post(GITHUB_GRAPHQL_ENDPOINT, status=200, payload={"data": {"repository": {"ref": None}}})
 
     mocker.patch.object(l10n, "build_platform_dict", new=build_platform_dict)
-    
+
     with pytest.raises(TreeScriptError, match="branch 'branchy' not found in repo!"):
         await l10n.build_revision_dict_github(client, bump_config, "")
 

--- a/treescript/tests/test_gecko_l10n.py
+++ b/treescript/tests/test_gecko_l10n.py
@@ -3,6 +3,8 @@ import os
 
 import pytest
 from scriptworker_client.utils import makedirs
+from simple_github.client import GITHUB_GRAPHQL_ENDPOINT
+from treescript.exceptions import TaskVerificationError, TreeScriptError
 
 import treescript.gecko.l10n as l10n
 
@@ -197,6 +199,56 @@ async def test_build_revision_dict(mocker, old_contents, expected):
     mocker.patch.object(l10n, "build_platform_dict", new=build_platform_dict)
     mocker.patch.object(l10n, "get_latest_revision", new=get_latest_revision)
     assert await l10n.build_revision_dict(bump_config, "", old_contents) == expected
+
+
+# build_revision_dict_github {{{1
+@pytest.mark.asyncio
+async def test_build_revision_dict_github(mocker, aioresponses, client):
+    platform_dict = {"one": {"platforms": ["platform"]}, "two": {"platforms": ["platform"]}, "three": {"platforms": ["platform"]}}
+    bump_config = {"l10n_repo_target_branch": "branchy"}
+
+    def build_platform_dict(*args):
+        return platform_dict
+
+    aioresponses.post(GITHUB_GRAPHQL_ENDPOINT, status=200, payload={"data": {"repository": {"object": {"oid": "new_revision"}}}})
+
+    mocker.patch.object(l10n, "build_platform_dict", new=build_platform_dict)
+    got = await l10n.build_revision_dict_github(client, bump_config, "")
+    assert got == {
+                "one": {"pin": False, "revision": "new_revision", "platforms": ["platform"]},
+                "two": {"pin": False, "revision": "new_revision", "platforms": ["platform"]},
+                "three": {"pin": False, "revision": "new_revision", "platforms": ["platform"]},
+            }
+
+
+@pytest.mark.asyncio
+async def test_build_revision_dict_github_branch_not_in_config(mocker):
+    platform_dict = {"one": {"platforms": ["platform"]}, "two": {"platforms": ["platform"]}, "three": {"platforms": ["platform"]}}
+    bump_config = {}
+
+    try:
+        await l10n.build_revision_dict_github({}, bump_config, "")
+    except TaskVerificationError as e:
+        assert str(e) == "l10n_repo_target_branch must be present in bump_config!"
+        return
+
+    assert False, "Should've raised TaskVerificationError"
+
+
+@pytest.mark.asyncio
+async def test_build_revision_dict_github_branch_not_in_repo(mocker, aioresponses, client):
+    platform_dict = {"one": {"platforms": ["platform"]}, "two": {"platforms": ["platform"]}, "three": {"platforms": ["platform"]}}
+    bump_config = {"l10n_repo_target_branch": "branchy"}
+
+    def build_platform_dict(*args):
+        return platform_dict
+
+    aioresponses.post(GITHUB_GRAPHQL_ENDPOINT, status=200, payload={"data": {"repository": {"ref": None}}})
+
+    mocker.patch.object(l10n, "build_platform_dict", new=build_platform_dict)
+    
+    with pytest.raises(TreeScriptError, match="branch 'branchy' not found in repo!"):
+        await l10n.build_revision_dict_github(client, bump_config, "")
 
 
 # build_commit_message {{{1


### PR DESCRIPTION
This looks like a bulky patch, but most of it is copy/paste to avoid touching any of the existing l10n bump code paths.

The most notable change in the l10n bumper code is `build_revision_dict_github`, which is vastly simplified compared to its hg compared part. In part this is because we only have one string repo to worry about, but also because @eemeli declared that we don't need to support pinning revisions anymore - so I didn't implement that here. After we cut over to the Github repo and know we aren't going back, we can rip out the hg support.

Most of the rest of this is just wiring in calls to `l10n_bump_github` when appropriate.

This is probably best reviewed commit-by-commit, as the first couple of commits are somewhat unrelated, but necessary, precursors to the core work here (most notably, allowing hg and git to be configured for the same treescript instance).