### PR TITLE
feat(beetmoverscript): Add translations trust domain

### DIFF
--- a/beetmoverscript/docker.d/init_worker.sh
+++ b/beetmoverscript/docker.d/init_worker.sh
@@ -116,6 +116,19 @@ case $COT_PRODUCT in
         ;;
     esac
     ;;
+  translations)
+    case $ENV in
+      dev|fake-prod)
+        test_var_set 'GCS_DEP_CREDS'
+        ;;
+      prod)
+        test_var_set 'GCS_RELEASE_CREDS'
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
   *)
     exit 1
     ;;

--- a/beetmoverscript/docker.d/worker.yml
+++ b/beetmoverscript/docker.d/worker.yml
@@ -19,6 +19,8 @@ taskcluster_scope_prefixes:
         - 'project:xpi:beetmover:'
       'COT_PRODUCT == "mozillavpn"':
         - 'project:mozillavpn:releng:beetmover:'
+      'COT_PRODUCT == "translations"':
+        - 'project:translations:releng:beetmover:'
 verbose: { "$eval": "VERBOSE == 'true'" }
 url_prefix:
   # we need to $merge as $match returns an array
@@ -44,6 +46,10 @@ url_prefix:
         dep: 'https://ftp.stage.mozaws.net'
       'COT_PRODUCT == "mozillavpn" && ENV == "prod"':
         release: 'https://archive.mozilla.org'
+      'COT_PRODUCT == "translations"':
+        # There is no public facing domain for the buckets that we upload
+        # translations artifacts to.
+        dep: 'unused'
 
 clouds:
   gcloud:
@@ -177,6 +183,20 @@ clouds:
             enabled: True
             product_buckets:
               appservices: 'moz-fx-productdelivery-pr-38b5-productdelivery'
+        'COT_PRODUCT == "translations" && (ENV == "dev" || ENV == "fake-prod")':
+          dep:
+            credentials: { "$eval": "GCS_DEP_CREDS" }
+            fail_task_on_error: True
+            enabled: True
+            product_buckets:
+              translations: 'moz-fx-translations-data--5f91-stage-translations-data'
+        'COT_PRODUCT == "translations" && ENV == "prod"':
+          release:
+            credentials: { "$eval": "GCS_RELEASE_CREDS" }
+            fail_task_on_error: True
+            enabled: True
+            product_buckets:
+              translations: 'moz-fx-translations-data--303e-prod-translations-data'
 
   aws:
     $merge:
@@ -359,3 +379,13 @@ clouds:
               key: { "$eval": "RELEASE_KEY" }
             product_buckets:
               vpn: 'net-mozaws-prod-delivery-archive'
+
+        # There are no AWS buckets for translations
+        'COT_PRODUCT == "translations"':
+          dep:
+            fail_task_on_error: True
+            enabled: False
+            credentials:
+              id: 'unused'
+              key: 'unused'
+            product_buckets: {}

--- a/docker.d/init.sh
+++ b/docker.d/init.sh
@@ -86,6 +86,9 @@ case $COT_PRODUCT in
   adhoc)
     export TRUST_DOMAIN=adhoc
     ;;
+  translations)
+    export TRUST_DOMAIN=translations
+    ;;
   *)
     echo "Unknown COT_PRODUCT $COT_PRODUCT"
     exit 1


### PR DESCRIPTION
As noted in a couple of comments, this trust domain is a bit odd right now because production runs at level 1, so we don't have the prod/fake-prod distinction here that we have for other trust domains. We will be remedying this, but we're not blocking adding beetmover tasks on that.