### PR TITLE
Bug 1882556 - Remove .deb hacks to upload ESR .deb packages to the archive

### DIFF
--- a/beetmoverscript/src/beetmoverscript/constants.py
+++ b/beetmoverscript/src/beetmoverscript/constants.py
@@ -103,7 +103,6 @@ RELEASE_EXCLUDE = (
     r"^.*/mar-tools/.*$",
     r"^.*contrib.*",
     r"^.*/beetmover-checksums/.*$",
-    r"^.*\.deb$",
 )
 
 CACHE_CONTROL_MAXAGE = 3600 * 4


### PR DESCRIPTION
This PR removes the hacky things done to the beetmover script to control which channel .debs would get uploaded to the archive. We want to start publishing these so we need to remove them.