### PR TITLE
Bug 1904738 - "hg add" new android-l10n files

### DIFF
--- a/treescript/src/treescript/gecko/android_l10n.py
+++ b/treescript/src/treescript/gecko/android_l10n.py
@@ -61,7 +61,7 @@ def get_android_l10n_files_toml(toml_path, search_path=None):
 
 
 # copy_android_l10n_files {{{1
-def copy_android_l10n_files(l10n_files, src_repo_path, dest_repo_path):
+async def copy_android_l10n_files(config, l10n_files, src_repo_path, dest_repo_path):
     """Copy localized files in code repository"""
 
     log.info(f"Copying {len(l10n_files)} files:")
@@ -72,9 +72,13 @@ def copy_android_l10n_files(l10n_files, src_repo_path, dest_repo_path):
             src_file = l10n_file["abs_path"]
         dest_file = os.path.join(dest_repo_path, l10n_file["rel_path"])
         log.info(f"  {src_file} -> {dest_file}")
+        dest_existed = os.path.exists(dest_file)
         # Make sure that the folder exists, then copy file as is
         os.makedirs(os.path.dirname(dest_file), exist_ok=True)
         shutil.copy2(src_file, dest_file)
+        if not dest_existed:
+            await vcs.run_hg_command(config, "add", dest_file, repo_path=dest_repo_path)
+            log.info(f"  {dest_file} added to commit")
 
 
 # build_commit_message {{{1
@@ -136,7 +140,7 @@ async def android_l10n_action(config, task, task_info, repo_path, from_repo_path
         else:
             dest_path = repo_path
         os.makedirs(dest_path, exist_ok=True)
-        copy_android_l10n_files(l10n_files, src_path, dest_path)
+        await copy_android_l10n_files(config, l10n_files, src_path, dest_path)
         shutil.copy2(toml_path, dest_path)
 
     changes = 0


### PR DESCRIPTION
Update android-l10n-import and android-l10n-sync such that new files (resource files which exist in the source android-l10n repo but not in the destination mercurial repo) are "hg add"-ed to the commit.