### PR TITLE
Bug 1904738 - use correct repo_path for "hg add"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -162,7 +162,7 @@ deps =
     ruff
 commands =
     ruff --version
-    ruff --verbose {toxinidir}
+    ruff check --verbose {toxinidir}
 
 [testenv:ruff-format]
 deps =

--- a/treescript/src/treescript/gecko/android_l10n.py
+++ b/treescript/src/treescript/gecko/android_l10n.py
@@ -61,23 +61,23 @@ def get_android_l10n_files_toml(toml_path, search_path=None):
 
 
 # copy_android_l10n_files {{{1
-async def copy_android_l10n_files(config, l10n_files, src_repo_path, dest_repo_path):
+async def copy_android_l10n_files(config, l10n_files, repo_path, src_path, dest_path):
     """Copy localized files in code repository"""
 
     log.info(f"Copying {len(l10n_files)} files:")
     for l10n_file in l10n_files:
-        if src_repo_path:
-            src_file = os.path.join(src_repo_path, l10n_file["rel_path"])
+        if src_path:
+            src_file = os.path.join(src_path, l10n_file["rel_path"])
         else:
             src_file = l10n_file["abs_path"]
-        dest_file = os.path.join(dest_repo_path, l10n_file["rel_path"])
+        dest_file = os.path.join(dest_path, l10n_file["rel_path"])
         log.info(f"  {src_file} -> {dest_file}")
         dest_existed = os.path.exists(dest_file)
         # Make sure that the folder exists, then copy file as is
         os.makedirs(os.path.dirname(dest_file), exist_ok=True)
         shutil.copy2(src_file, dest_file)
         if not dest_existed:
-            await vcs.run_hg_command(config, "add", dest_file, repo_path=dest_repo_path)
+            await vcs.run_hg_command(config, "add", dest_file, repo_path=repo_path)
             log.info(f"  {dest_file} added to commit")
 
 
@@ -140,7 +140,7 @@ async def android_l10n_action(config, task, task_info, repo_path, from_repo_path
         else:
             dest_path = repo_path
         os.makedirs(dest_path, exist_ok=True)
-        await copy_android_l10n_files(config, l10n_files, src_path, dest_path)
+        await copy_android_l10n_files(config, l10n_files, repo_path, src_path, dest_path)
         shutil.copy2(toml_path, dest_path)
 
     changes = 0

--- a/treescript/tests/test_gecko_android_l10n.py
+++ b/treescript/tests/test_gecko_android_l10n.py
@@ -66,13 +66,15 @@ async def test_copy_android_l10n_files(mocker):
     async def check_params(*args, **kwargs):
         assert "add" in args
         assert "dest/relsource" in args
+        assert "repo_path" in kwargs
+        assert "repo/path" == kwargs["repo_path"]
 
     mocker.patch.object(mercurial, "run_hg_command", new=check_params)
 
     copy = mocker.patch.object(shutil, "copy2")
-    await android_l10n.copy_android_l10n_files({}, [{"abs_path": "abssource", "rel_path": "relsource"}], None, "dest")
+    await android_l10n.copy_android_l10n_files({}, [{"abs_path": "abssource", "rel_path": "relsource"}], "repo/path", None, "dest")
     copy.assert_called_with("abssource", "dest/relsource")
-    await android_l10n.copy_android_l10n_files({}, [{"abs_path": "abssource", "rel_path": "relsource"}], "src", "dest")
+    await android_l10n.copy_android_l10n_files({}, [{"abs_path": "abssource", "rel_path": "relsource"}], "repo/path", "src", "dest")
     copy.assert_called_with("src/relsource", "dest/relsource")
 
 
@@ -96,10 +98,10 @@ async def test_android_l10n_action(mocker):
 
     # like import
     await android_l10n.android_l10n_action({}, {}, task_info, "repo/path", "fromrepo/path", "", "", None, "dest_path")
-    copy.assert_called_with({}, ["l10n1", "l10n2"], None, "repo/path/x")
+    copy.assert_called_with({}, ["l10n1", "l10n2"], "repo/path", None, "repo/path/x")
     # like sync
     await android_l10n.android_l10n_action({}, {}, task_info, "repo/path", "fromrepo/path", "", "", "srcpath", None)
-    copy.assert_called_with({}, ["l10n1", "l10n2"], "srcpath", "repo/path")
+    copy.assert_called_with({}, ["l10n1", "l10n2"], "repo/path", "srcpath", "repo/path")
 
 
 # android_l10n_import {{{1


### PR DESCRIPTION
My earlier patch added a call to "hg add" for new files imported from the android-l10n repo; that call to `run_hg_command` includes a `repo_path` parameter, but the value of that path is incorrect.

This PR:
 - for clarity, renames `copy_android_l10n_files()` parameters src_repo_path -> src_path and dest_repo_path -> dest_path
 - adds a new `repo_path` parameter to `copy_android_l10n_files()`
 - passes the correct `repo_path` from the script through to `copy_android_l10n_files()` and `run_hg_command`
 - updates test expectations.