### PR TITLE
treescript: update version-control-tools revision

### DIFF
--- a/taskcluster/docker/treescript/Dockerfile
+++ b/taskcluster/docker/treescript/Dockerfile
@@ -30,4 +30,4 @@ RUN cp -R /app/treescript/docker.d/* /app/docker.d/ \
  && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app \
- && hg clone -r 0180a71f29b2f71113665cf9425fd73693d0265c https://hg.mozilla.org/hgcustom/version-control-tools /app/version-control-tools
+ && hg clone -r 90302f015ac8dd8877ef3ee24b5a62541142378b https://hg.mozilla.org/hgcustom/version-control-tools /app/version-control-tools

--- a/treescript/Dockerfile
+++ b/treescript/Dockerfile
@@ -25,7 +25,7 @@ RUN python -m venv /app \
  && /app/configloader_venv/bin/pip install --no-deps -r requirements/base.txt \
  && /app/configloader_venv/bin/pip install . \
  && cd /app \
- && hg clone -r 0180a71f29b2f71113665cf9425fd73693d0265c https://hg.mozilla.org/hgcustom/version-control-tools /app/version-control-tools
+ && hg clone -r 90302f015ac8dd8877ef3ee24b5a62541142378b https://hg.mozilla.org/hgcustom/version-control-tools /app/version-control-tools
 
 COPY treescript/src/treescript/data/hgrc /etc/mercurial/hgrc.d/treescript.rc
 COPY treescript/docker.d/extensions.rc /etc/mercurial/hgrc.d/extensions.rc


### PR DESCRIPTION
Along with the bump to python 3.11, we just upgraded from debian 11 (mercurial 5.6.1) to debian 12 (mercurial 6.3.2), which requires changes to extensions.

This pulls in the following changes for the firefoxtree and robustcheckout extensions:
```
79637068b492    2021-08-24      sheehan firefoxtree: use `utils.urlutil` functions instead of `ui.expandpath` (Bug 1721228) r=zeid
ee5e75accd86    2021-09-02      sheehan firefoxtree: only use `import_module` to access `mercurial.utils.urlutil` (Bug 1727751) r=mhentges
b71246475125    2021-09-07      sheehan robustcheckout: coerce exceptions to `str` and then `pycompat.bytestr` before displaying to screen (Bug 1723985) r=mhentges
24c40cb2395e    2021-09-08      sheehan robustcheckout: reformat with black
f47331584260    2021-11-02      sheehan robustcheckout: add `parentchange` context before calling `_updateconfigandrefreshwdir` (Bug 1738958) r=zeid
0900473a332f    2021-11-02      sheehan robustcheckout: run `black` on hgext/robustcheckout/__init__.py
9f98f1e35f32    2022-03-14      sheehan hg46: resolve `TRACKING` comments (Bug 1757984) r=mhentges
c8e13a0695c3    2022-03-14      sheehan hg47: address remaining `TRACKING` comments for hg47 (Bug 1757984) r=mhentges
b3c262366afd    2022-03-14      sheehan hg48: address remaining `TRACKING hg48` comments (Bug 1757984) r=mhentges
4106010c0942    2022-03-14      sheehan hg50: remove remaining `TRACKING` comments (Bug 1757984) r=mhentges
0739c51de7e7    2022-04-01      sheehan robustcheckout: use pre-Py3.9 `with` syntax for multiple context managers (Bug 1762487)
ed00445326df    2022-05-12      sheehan firefoxtree: remove unused imports
42f185d785a1    2022-10-13      jcristau        robustcheckout: handle share-safe requirement and .hg/store/requires file r=sheehan
72e66f3073da    2023-01-26      sheehan formatting: add black to test requirements and run on all relevant files (Bug 1812139) r=zeid
f13873b78a4d    2023-03-13      jcristau        robustcheckout: set http.timeout config option to avoid hangs (bug 1822044) r=sheehan
46c99d31ab14    2023-03-22      jcristau        robustcheckout: handle socket.timeout exceptions and retry (bug 1823992) r=sheehan
97c4e1397bef    2023-04-04      sheehan firefoxtree: wrap `hg.peer` to try tree shortnames since `_peerorrepo` is deprecated (Bug 1824417) r=dholbert
65ac4b5986df    2023-05-30      mh      Bug 1835706 - Make robustcheckout compatible with mercurial 6.4. r=sheehan
7436689a4095    2023-06-28      jcristau        robustcheckout: retry on HTTP 5xx (Bug 1481291) r=sheehan
6222cdf80016    2023-12-01      sheehan hgext: use `str` in `wrapfunction` and `unwrapfunction` (Bug 1850262) r=zeid
2c0516faa86c    2024-04-25      jcristau        firefoxtree: fix `hg outgoing` with a url r=sheehan
bc4522fbf8de    2024-05-23      jcristau        formatting: merge successive strings on the same line. r=sheehan
f54fd9f1ad75    2024-07-10      jcristau        robustcheckout: fix python regex syntax warning. r=sheehan
```