### PR TITLE
fix: use fennec secrets for apk signing on adhoc trust domain

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -237,8 +237,8 @@ case $ENV in
         test_var_set 'AUTOGRAPH_AUTHENTICODE_EV_USERNAME'
         test_var_set 'AUTOGRAPH_MAR_RELEASE_PASSWORD'
         test_var_set 'AUTOGRAPH_MAR_RELEASE_USERNAME'
-        test_var_set 'AUTOGRAPH_FENIX_PASSWORD'
-        test_var_set 'AUTOGRAPH_FENIX_USERNAME'
+        test_var_set 'AUTOGRAPH_FENNEC_RELEASE_PASSWORD'
+        test_var_set 'AUTOGRAPH_FENNEC_RELEASE_USERNAME'
         ;;
     esac
     ;;

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -369,8 +369,8 @@ in:
              ["autograph_gpg"]
           ]
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
-             {"$eval": "AUTOGRAPH_FENIX_USERNAME"},
-             {"$eval": "AUTOGRAPH_FENIX_PASSWORD"},
+             {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},
+             {"$eval": "AUTOGRAPH_FENNEC_RELEASE_PASSWORD"},
              ["autograph_apk"]
           ]
         '${scope_prefix[0]}cert:nightly-signing':


### PR DESCRIPTION
This allows us to sign Fenix/Firefox with the same certificates as production builds. See https://bugzilla.mozilla.org/show_bug.cgi?id=1912260 for more context.