### PR TITLE
signingscript: remove unused my_ip config option

### DIFF
--- a/signingscript/README.md
+++ b/signingscript/README.md
@@ -199,10 +199,6 @@ The config json looks like this (comments are not valid json, but I'm inserting 
       // this should be an absolute path.
       "artifact_dir": "/src/signing/artifact_dir",
 
-      // the IP that docker-signing-server thinks you're coming from.
-      // I got this value from running `docker network inspect bridge` and using the gateway.
-      "my_ip": "172.17.0.1",
-
       // how many seconds should the signing token be valid for?
       "token_duration_seconds": 1200,
 

--- a/signingscript/docker.d/worker.yml
+++ b/signingscript/docker.d/worker.yml
@@ -1,7 +1,6 @@
 work_dir: { "$eval": "WORK_DIR" }
 artifact_dir: { "$eval": "ARTIFACTS_DIR" }
 verbose: { "$eval": "VERBOSE == 'true'" }
-my_ip: { "$eval": "PUBLIC_IP" }
 autograph_configs: { "$eval": "PASSWORDS_PATH" }
 apple_notarization_configs: { "$eval": "APPLE_NOTARIZATION_CREDS_PATH" }
 taskcluster_scope_prefixes:

--- a/signingscript/src/signingscript/data/config_schema.json
+++ b/signingscript/src/signingscript/data/config_schema.json
@@ -3,7 +3,6 @@
     "type": "object",
     "required": [
         "taskcluster_scope_prefixes",
-        "my_ip",
         "autograph_configs"
     ],
     "properties": {
@@ -14,9 +13,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "my_ip": {
-            "type": "string"
         },
         "autograph_configs": {
             "type": "string"

--- a/signingscript/src/signingscript/script.py
+++ b/signingscript/src/signingscript/script.py
@@ -91,7 +91,6 @@ def get_default_config(base_dir=None):
     default_config = {
         "work_dir": os.path.join(base_dir, "work_dir"),
         "artifact_dir": os.path.join(base_dir, "/src/signing/artifact_dir"),
-        "my_ip": "127.0.0.1",
         "schema_file": os.path.join(os.path.dirname(__file__), "data", "signing_task_schema.json"),
         "verbose": True,
         "dmg": "dmg",


### PR DESCRIPTION
This was used in the days of signing servers, and went away with https://github.com/mozilla-releng/scriptworker-scripts/pull/66.