### PR TITLE
signingscript: fix xpi dep-signing keyids (bug 1916503)

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -104,13 +104,13 @@ in:
              {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_USERNAME"},
              {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_PASSWORD"},
              ["privileged_webextension"],
-             "cas_new_extension_rsa"
+             "extension_rsa_dep_202402"
           ]
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_USERNAME"},
              {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_PASSWORD"},
              ["system_addon"],
-             "cas_new_systemaddon_rsa"
+             "systemaddon_rsa_dep_202402"
           ]
 
       # dep-passwords-mozillavpn.json


### PR DESCRIPTION
The key ids in stage and prod autograph differ, but I missed this when changing the URL in #1068.