### PR TITLE
signingscript: remove check for PUBLIC_IP variable

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -18,7 +18,6 @@ test_var_set 'CONFIG_DIR'
 test_var_set 'CONFIG_LOADER'
 test_var_set 'COT_PRODUCT'
 test_var_set 'PROJECT_NAME'
-test_var_set 'PUBLIC_IP'
 test_var_set 'TEMPLATE_DIR'
 
 export DMG_PATH=$APP_DIR/signingscript/files/dmg

--- a/signingscript/tests/test_config.py
+++ b/signingscript/tests/test_config.py
@@ -9,7 +9,6 @@ COMMON_CONTEXT = {
     "WORK_DIR": "",
     "ARTIFACTS_DIR": "",
     "VERBOSE": "true",
-    "PUBLIC_IP": "0.0.0.0",
     "PASSWORDS_PATH": "",
     "APPLE_NOTARIZATION_CREDS_PATH": "",
     "SSL_CERT_PATH": "",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -82,7 +82,6 @@ CONTEXT = {
         "CLIENT_SECRET": "Zm9vYmFyCg==",
     },
     re.compile(r"signing:.*"): {
-        "PUBLIC_IP": "127.0.0.1",
         "WIDEVINE_CERT": "Zm9vYmFyCg==",
         "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD": "1",
         "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME": "1",


### PR DESCRIPTION
This was missing from #1069 and causes a crash loop now that the variable is no longer set.