### PR TITLE
signingscript: fix adhoc webextension dep-signing keyid (bug 1916503)

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -162,7 +162,7 @@ in:
              {"$eval": "AUTOGRAPH_XPI_USERNAME"},
              {"$eval": "AUTOGRAPH_XPI_PASSWORD"},
              ["autograph_xpi", "autograph_xpi_sha1_es256_es384", "autograph_xpi_sha1_es256_ps256", "autograph_xpi_sha1_es256", "autograph_xpi_sha1_ps256"],
-             "cas_new_webextensions_rsa"
+             "webextensions_rsa_dep_202402"
           ]
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_FENIX_USERNAME"},


### PR DESCRIPTION
Missed in #1068.