### PR TITLE
fix(signingscript): remove formats no longer referenced in project repositories

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -21,13 +21,12 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
                {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
-               ["autograph_authenticode_sha2", "autograph_authenticode_sha2_stub",
-                "autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
+               ["autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_MAR_USERNAME"},
                {"$eval": "AUTOGRAPH_MAR_PASSWORD"},
-               ["autograph_mar384", "autograph_hash_only_mar384"]
+               ["autograph_hash_only_mar384"]
             ]
             - ["https://autograph-external.stage.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_STAGE_MAR_USERNAME"},
@@ -119,8 +118,7 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
-             ["autograph_authenticode_sha2", "autograph_authenticode_sha2_stub",
-              "autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
+             ["autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
           ]
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_MOZILLAVPN_DEBSIGN_USERNAME"},
@@ -140,13 +138,13 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
-             ["autograph_authenticode_sha2", "autograph_authenticode_sha2_stub", "autograph_authenticode_ev",
+             ["autograph_authenticode_ev",
               "autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
           ]
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_MAR_USERNAME"},
              {"$eval": "AUTOGRAPH_MAR_PASSWORD"},
-             ["autograph_mar384", "autograph_hash_only_mar384"]
+             ["autograph_hash_only_mar384"]
           ]
           - ["https://autograph-external.stage.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_STAGE_MAR_USERNAME"},
@@ -177,13 +175,12 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
                {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
-               ["autograph_authenticode_sha2", "autograph_authenticode_sha2_stub",
-                "autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
+               ["autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_MAR_RELEASE_USERNAME"},
                {"$eval": "AUTOGRAPH_MAR_RELEASE_PASSWORD"},
-               ["autograph_mar384", "autograph_hash_only_mar384"]
+               ["autograph_hash_only_mar384"]
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_GPG_USERNAME"},
@@ -210,13 +207,12 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
                {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
-               ["autograph_authenticode_sha2", "autograph_authenticode_sha2_stub",
-                "autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
+               ["autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_MAR_NIGHTLY_USERNAME"},
                {"$eval": "AUTOGRAPH_MAR_NIGHTLY_PASSWORD"},
-               ["autograph_mar384", "autograph_hash_only_mar384"]
+               ["autograph_hash_only_mar384"]
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_GPG_USERNAME"},
@@ -331,8 +327,7 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
-             ["autograph_authenticode_sha2", "autograph_authenticode_sha2_stub",
-              "autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
+             ["autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
           ]
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_MOZILLAVPN_USERNAME"},
@@ -357,7 +352,7 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
-             ["autograph_authenticode_sha2", "autograph_authenticode_sha2_stub", "autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
+             ["autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
           ]
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_EV_USERNAME"},
@@ -367,7 +362,7 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_MAR_RELEASE_USERNAME"},
              {"$eval": "AUTOGRAPH_MAR_RELEASE_PASSWORD"},
-             ["autograph_mar384", "autograph_hash_only_mar384"]
+             ["autograph_hash_only_mar384"]
           ]
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
@@ -383,11 +378,10 @@ in:
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
-             ["autograph_authenticode_sha2", "autograph_authenticode_sha2_stub",
-              "autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
+             ["autograph_authenticode_202404", "autograph_authenticode_202404_stub"]
           ]
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_MAR_NIGHTLY_USERNAME"},
              {"$eval": "AUTOGRAPH_MAR_NIGHTLY_PASSWORD"},
-             ["autograph_mar384", "autograph_hash_only_mar384"]
+             ["autograph_hash_only_mar384"]
           ]


### PR DESCRIPTION
autograph_authenticode_sha2 was used by now expired authenticode certs autograph_mar384 was used for non-hash mar signing, and is fully deprecated by hash only signing, and no longer even used in an ESR repo