### PR TITLE
fix: pick up new version of flat-manager-client

### DIFF
--- a/pushflatpakscript/Dockerfile
+++ b/pushflatpakscript/Dockerfile
@@ -23,10 +23,10 @@ RUN python -m venv /app \
  && python -m venv /app/flat_manager_venv \
  && /app/flat_manager_venv/bin/pip install --no-deps -r /app/pushflatpakscript/requirements/flat-manager.txt \
  && curl -Ls \
-    https://github.com/flatpak/flat-manager/raw/13841c5a6667d6ab9d0849523c9e49ad5f34dda8/flat-manager-client | \
+    https://github.com/flatpak/flat-manager/raw/100d44f761ba765552d2a799b5b7254b6a8b1e38/flat-manager-client | \
     sed -e '1i#!/app/flat_manager_venv/bin/python' -e '1d' > /app/flat_manager_venv/bin/flat-manager-client \
  && chmod 755 /app/flat_manager_venv/bin/flat-manager-client \
- && echo "e246baafc6311b2c867af6838b1eaf0869643032143caab1ec4bf59ed7e9c79a /app/flat_manager_venv/bin/flat-manager-client" | sha256sum -c \
+ && echo "2e55c0d3797f948b5b2eb86b897d42ce318b829749a23b903d8a9ed7b3bcea59 /app/flat_manager_venv/bin/flat-manager-client" | sha256sum -c \
  && cd /app
 
 

--- a/taskcluster/docker/pushflatpakscript/Dockerfile
+++ b/taskcluster/docker/pushflatpakscript/Dockerfile
@@ -26,7 +26,7 @@ RUN cp -R /app/pushflatpakscript/docker.d/* /app/docker.d/ \
  && python -m venv /app/flat_manager_venv \
  && /app/flat_manager_venv/bin/pip install --no-deps -r /app/pushflatpakscript/requirements/flat-manager.txt \
  && curl -Ls \
-    https://github.com/flatpak/flat-manager/raw/d9d7972b24de6022c7079f8721fd8335c3319dc5/flat-manager-client | \
+    https://github.com/flatpak/flat-manager/raw/100d44f761ba765552d2a799b5b7254b6a8b1e38/flat-manager-client | \
     sed -e '1i#!/app/flat_manager_venv/bin/python' -e '1d' > /app/flat_manager_venv/bin/flat-manager-client \
  && chmod 755 /app/flat_manager_venv/bin/flat-manager-client \
- && echo "5024c853d7529e82fc4a9fb9b982e561598df033545187238c9be8c791a6797c /app/flat_manager_venv/bin/flat-manager-client" | sha256sum -c
+ && echo "2e55c0d3797f948b5b2eb86b897d42ce318b829749a23b903d8a9ed7b3bcea59 /app/flat_manager_venv/bin/flat-manager-client" | sha256sum -c


### PR DESCRIPTION
This is to grab https://github.com/flatpak/flat-manager/pull/139, which ought to fix the bustage we saw in https://bugzilla.mozilla.org/show_bug.cgi?id=1932766 caused by an upgrade to aiohttp.