### PR TITLE
Bug 1933704 - beetmoverscript: fix artifactMap json schema

### DIFF
--- a/beetmoverscript/src/beetmoverscript/data/artifactMap_beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/artifactMap_beetmover_task_schema.json
@@ -102,25 +102,28 @@
                             },
                             "paths": {
                                 "type": "object",
-                                "minItems": 1,
-                                "uniqueItems": true,
-                                "properties": {
-                                    "destinations": {
-                                        "type": "array",
-                                        "minItems": 1,
-                                        "items": {
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "properties": {
+                                        "destinations": {
+                                            "type": "array",
+                                            "minItems": 1,
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "checksums_path": {
                                             "type": "string"
+                                        },
+                                        "expiry": {
+                                            "type": "string",
+                                            "format": "date-time"
                                         }
                                     },
-                                    "checksums_path": {
-                                        "type": "string"
-                                    },
-                                    "expiry": {
-                                        "type": "object",
-                                        "additionalProperties": {
-                                            "type": "string"
-                                        }
-                                    }
+                                    "required": [
+                                        "destinations",
+                                        "checksums_path"
+                                    ]
                                 }
                             }
                         },

--- a/beetmoverscript/tests/__init__.py
+++ b/beetmoverscript/tests/__init__.py
@@ -16,6 +16,7 @@ def get_fake_valid_config():
         "release_schema_file": "src/beetmoverscript/data/release_beetmover_task_schema.json",
         "schema_file": "src/beetmoverscript/data/beetmover_task_schema.json",
         "maven_schema_file": "src/beetmoverscript/data/maven_beetmover_task_schema.json",
+        "artifactMap_schema_file": "src/beetmoverscript/data/artifactMap_beetmover_task_schema.json",
     }
     config.update(load_json(path="tests/fake_config.json"))
     return config

--- a/beetmoverscript/tests/test_task.py
+++ b/beetmoverscript/tests/test_task.py
@@ -96,6 +96,17 @@ def test_validate_task(context):
     validate_task_schema(context)
 
 
+def test_validate_task_invalid(context):
+    context.task = get_fake_valid_task(taskjson="task_artifact_map.json")
+    context.task["scopes"] = ["project:releng:beetmover:action:direct-push-to-bucket"]
+    validate_task_schema(context)
+
+    # expiry should be a date-time string
+    context.task["payload"]["artifactMap"][0]["paths"]["target.apk"]["expiry"] = 0
+    with pytest.raises(Exception):
+        validate_task_schema(context)
+
+
 # get_task_bucket {{{1
 @pytest.mark.parametrize(
     "scopes,expected,raises",


### PR DESCRIPTION
- the payload's `paths` property is an object, not an array, so minItems and uniqueItems don't apply
- its properties are arbitrary paths, with "destinations", "checksums_path" and "expiry" one level down, so declare them under "additionalProperties"
- "expiry" is a date-time string, not an object