### PR TITLE
signingscript: autograph gcp migration step 2: test against gcp prod

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -81,6 +81,56 @@ in:
                "dummyapp_android",
             ]
 
+            # GCP Autograph prod
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
+               {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
+               ["gcp_prod_autograph_authenticode_202404", "gcp_prod_autograph_authenticode_202404_stub"],
+               "authenticode_dep_sha256"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_MAR_USERNAME"},
+               {"$eval": "AUTOGRAPH_MAR_PASSWORD"},
+               ["gcp_prod_autograph_hash_only_mar384"],
+               "firefox_dep1",
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+               {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+               ["gcp_prod_autograph_gpg"],
+               "release_at_mozilla_rel_pgp_dep"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_WIDEVINE_USERNAME"},
+               {"$eval": "AUTOGRAPH_WIDEVINE_PASSWORD"},
+               ["gcp_prod_autograph_widevine"],
+               "widevine_dep1"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_OMNIJA_USERNAME"},
+               {"$eval": "AUTOGRAPH_OMNIJA_PASSWORD"},
+               ["gcp_prod_autograph_omnija"],
+               "systemaddon_rsa_dep"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
+               {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
+               ["gcp_prod_autograph_langpack"],
+               "webextensions_rsa_dep_202402"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_FOCUS_USERNAME"},
+               {"$eval": "AUTOGRAPH_FOCUS_PASSWORD"},
+               ["gcp_prod_autograph_focus"],
+               "focus_dep_apk"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_FENIX_USERNAME"},
+               {"$eval": "AUTOGRAPH_FENIX_PASSWORD"},
+               ["gcp_prod_autograph_apk", "gcp_prod_autograph_apk_mozillaonline"],
+               "fenix_dep_apk"
+            ]
+
             # AWS Autograph; to be removed when production is switched over to GCP by default.
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
@@ -140,6 +190,21 @@ in:
              "dummyapp_android"
           ]
 
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_USERNAME"},
+             {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_PASSWORD"},
+             ["gcp_prod_autograph_apk"],
+             "geckoview_reference_browser_dep_apk"
+          ]
+
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_USERNAME"},
+             {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_PASSWORD"},
+             ["gcp_prod_autograph_aab"],
+             "geckoview_reference_browser_dep_apk_v3"
+          ]
+
           # AWS Autograph; to be removed when production is switched over to GCP by default.
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_USERNAME"},
@@ -158,6 +223,14 @@ in:
              "dummy_gpg2"
           ]
 
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+             {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+             ["gcp_prod_autograph_gpg"],
+             "release_at_mozilla_rel_pgp_dep"
+          ]
+
           # AWS Autograph; to be removed when production is switched over to GCP by default.
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
@@ -174,6 +247,14 @@ in:
              {"$eval": "AUTOGRAPH_STAGE_GPG_PASSWORD"},
              ["stage_autograph_gpg"],
              "dummy_gpg2"
+          ]
+
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+             {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+             ["gcp_prod_autograph_gpg"],
+             "release_at_mozilla_rel_pgp_dep"
           ]
 
           # AWS Autograph; to be removed when production is switched over to GCP by default.
@@ -198,6 +279,20 @@ in:
              {"$eval": "AUTOGRAPH_STAGE_XPI_PRIVILEGED_PASSWORD"},
              ["stage_system_addon"],
              "cas_new_systemaddon_rsa"
+          ]
+
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_USERNAME"},
+             {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_PASSWORD"},
+             ["gcp_prod_privileged_webextension"],
+             "extension_rsa_dep_202402"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_USERNAME"},
+             {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_PASSWORD"},
+             ["gcp_prod_system_addon"],
+             "systemaddon_rsa_dep_202402"
           ]
 
           # AWS Autograph; to be removed when production is switched over to GCP by default.
@@ -232,6 +327,26 @@ in:
              # that signing works with a certificate with similar properties to the production
              # one; stage does not have a specific vpn addon signing certificate though.
              "authenticode_dep_sha256",
+          ]
+
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
+             ["gcp_prod_autograph_authenticode_202404", "gcp_prod_autograph_authenticode_202404_stub"],
+             "authenticode_dep_sha256"
+          ]
+          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+             {"$eval": "AUTOGRAPH_MOZILLAVPN_USERNAME"},
+             {"$eval": "AUTOGRAPH_MOZILLAVPN_PASSWORD"},
+             ["gcp_prod_autograph_apk"],
+             "geckoview_reference_browser_dep_apk"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_MOZILLAVPN_ADDONS_USERNAME"},
+             {"$eval": "AUTOGRAPH_MOZILLAVPN_ADDONS_PASSWORD"},
+             ["gcp_prod_autograph_rsa"],
+             "vpn_addons_dep_2022"
           ]
 
           # AWS Autograph; to be removed when production is switched over to GCP by default.
@@ -282,6 +397,41 @@ in:
              {"$eval": "AUTOGRAPH_STAGE_FENIX_PASSWORD"},
              ["stage_autograph_apk"],
              "dummyapp_android"
+          ]
+
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
+             ["gcp_prod_autograph_authenticode_ev",
+              "gcp_prod_autograph_authenticode_202404", "gcp_prod_autograph_authenticode_202404_stub"],
+             "authenticode_dep_sha256"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_MAR_USERNAME"},
+             {"$eval": "AUTOGRAPH_MAR_PASSWORD"},
+             ["gcp_prod_autograph_hash_only_mar384"],
+             "firefox_dep1"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+             {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+             ["gcp_prod_autograph_gpg"],
+             "release_at_mozilla_rel_pgp_dep"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_XPI_USERNAME"},
+             {"$eval": "AUTOGRAPH_XPI_PASSWORD"},
+             ["gcp_prod_autograph_xpi", "gcp_prod_autograph_xpi_sha1_es256_es384",
+              "gcp_prod_autograph_xpi_sha1_es256_ps256", "gcp_prod_autograph_xpi_sha1_es256",
+              "gcp_prod_autograph_xpi_sha1_ps256"],
+             "webextensions_rsa_dep_202402"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_FENIX_USERNAME"},
+             {"$eval": "AUTOGRAPH_FENIX_PASSWORD"},
+             ["gcp_prod_autograph_apk"],
+             "fenix_dep_apk"
           ]
 
           # AWS Autograph; to be removed when production is switched over to GCP by default.

--- a/signingscript/src/signingscript/script.py
+++ b/signingscript/src/signingscript/script.py
@@ -27,13 +27,13 @@ async def async_main(context):
     work_dir = context.config["work_dir"]
     async with aiohttp.ClientSession() as session:
         all_signing_formats = task_signing_formats(context)
-        if {"autograph_gpg", "stage_autograph_gpg"}.intersection(all_signing_formats):
+        if {"autograph_gpg", "gcp_prod_autograph_gpg", "stage_autograph_gpg"}.intersection(all_signing_formats):
             if not context.config.get("gpg_pubkey"):
                 raise Exception("GPG format is enabled but gpg_pubkey is not defined")
             if not os.path.exists(context.config["gpg_pubkey"]):
                 raise Exception("gpg_pubkey ({}) doesn't exist!".format(context.config["gpg_pubkey"]))
 
-        if {"autograph_widevine", "stage_autograph_widevine"}.intersection(all_signing_formats):
+        if {"autograph_widevine", "gcp_prod_autograph_widevine", "stage_autograph_widevine"}.intersection(all_signing_formats):
             if not context.config.get("widevine_cert"):
                 raise Exception("Widevine format is enabled, but widevine_cert is not defined")
 
@@ -61,7 +61,7 @@ async def async_main(context):
             for source in output_files:
                 source = os.path.relpath(source, work_dir)
                 copy_to_dir(os.path.join(work_dir, source), context.config["artifact_dir"], target=source)
-            if {"autograph_gpg", "stage_autograph_gpg"}.intersection(set(path_dict["formats"])):
+            if {"autograph_gpg", "gcp_prod_autograph_gpg", "stage_autograph_gpg"}.intersection(set(path_dict["formats"])):
                 copy_to_dir(context.config["gpg_pubkey"], context.config["artifact_dir"], target="public/build/KEY")
 
         # notarization_stacked is a special format that takes in all files at once instead of sequentially like other formats

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -89,6 +89,12 @@ _DEFAULT_MAR_VERIFY_KEYS = {
         "nightly-signing": "nightly_aurora_level3_primary.pem",
         "dep-signing": "dep1.pem",
     },
+    "gcp_prod_autograph_stage_mar384": {"dep-signing": "autograph_stage.pem"},
+    "gcp_prod_autograph_hash_only_mar384": {
+        "release-signing": "release_primary.pem",
+        "nightly-signing": "nightly_aurora_level3_primary.pem",
+        "dep-signing": "dep1.pem",
+    },
 }
 
 # Langpacks expect the following re to match for addon id
@@ -875,9 +881,16 @@ def b64encode(input_bytes):
 def _is_xpi_format(fmt):
     if "omnija" in fmt or "langpack" in fmt:
         return True
-    if fmt in ("privileged_webextension", "system_addon", "stage_privileged_webextension", "stage_system_addon"):
+    if fmt in (
+        "privileged_webextension",
+        "system_addon",
+        "gcp_prod_privileged_webextension",
+        "gcp_prod_system_addon",
+        "stage_privileged_webextension",
+        "stage_system_addon",
+    ):
         return True
-    if fmt.startswith(("autograph_xpi", "stage_autograph_xpi")):
+    if fmt.startswith(("autograph_xpi", "gcp_prod_autograph_xpi", "stage_autograph_xpi")):
         return True
     return False
 
@@ -1348,10 +1361,10 @@ async def sign_authenticode_file(context, orig_path, fmt, *, authenticode_commen
     cafile_key = "authenticode_ca"
     cert_key = "authenticode_cert"
 
-    if fmt in ("autograph_authenticode_ev", "stage_autograph_authenticode_ev"):
+    if fmt in ("autograph_authenticode_ev", "gcp_prod_autograph_authenticode_ev", "stage_autograph_authenticode_ev"):
         cafile_key = f"{cafile_key}_ev"
         cert_key = f"{cert_key}_ev"
-    elif fmt.startswith(("autograph_authenticode_202404", "stage_autograph_authenticode_202404")):
+    elif fmt.startswith(("autograph_authenticode_202404", "gcp_prod_autograph_authenticode_202404", "stage_autograph_authenticode_202404")):
         cafile_key += "_202404"
         cert_key += "_202404"
 
@@ -1366,7 +1379,11 @@ async def sign_authenticode_file(context, orig_path, fmt, *, authenticode_commen
         certs = load_pem_certs(open(context.config[cert_key], "rb").read())
 
     url = context.config["authenticode_url"]
-    if fmt in ("autograph_authenticode_sha2_rfc3161_stub", "stage_autograph_authenticode_sha2_rfc3161_stub"):
+    if fmt in (
+        "autograph_authenticode_sha2_rfc3161_stub",
+        "gcp_prod_autograph_authenticode_sha2_rfc3161_stub",
+        "stage_autograph_authenticode_sha2_rfc3161_stub",
+    ):
         fmt = fmt.removesuffix("_rfc3161_stub")
         timestamp_style = "rfc3161"
     else:

--- a/signingscript/src/signingscript/task.py
+++ b/signingscript/src/signingscript/task.py
@@ -165,11 +165,11 @@ async def sign(context, path, signing_formats, **kwargs):
 def _get_signing_function_from_format(fmt_and_key_id):
     fmt, _ = split_autograph_format(fmt_and_key_id)
 
-    if fmt.startswith(("autograph_xpi", "stage_autograph_xpi")):
+    if fmt.startswith(("autograph_xpi", "gcp_prod_autograph_xpi", "stage_autograph_xpi")):
         return sign_xpi
     if fn := FORMAT_TO_SIGNING_FUNCTION.get(fmt):
         return fn
-    if fn := FORMAT_TO_SIGNING_FUNCTION.get(fmt.removeprefix("stage_")):
+    if fn := FORMAT_TO_SIGNING_FUNCTION.get(fmt.removeprefix("stage_").removeprefix("gcp_prod_")):
         return fn
 
     return FORMAT_TO_SIGNING_FUNCTION["default"]
@@ -194,13 +194,17 @@ def _sort_formats(formats):
     for fmt in (
         "widevine",
         "autograph_widevine",
+        "gcp_prod_autograph_widevine",
         "stage_autograph_widevine",
         "autograph_omnija",
+        "gcp_prod_autograph_omnija",
         "stage_autograph_omnija",
         "macapp",
         "autograph_rsa",
+        "gcp_prod_autograph_rsa",
         "stage_autograph_rsa",
         "autograph_gpg",
+        "gcp_prod_autograph_gpg",
         "stage_autograph_gpg",
     ):
         if fmt in formats:

--- a/signingscript/src/signingscript/utils.py
+++ b/signingscript/src/signingscript/utils.py
@@ -213,8 +213,17 @@ def is_apk_autograph_signing_format(format_):
     # TODO Remove autograph_focus once format is migrated
     return (
         format_
-        and format_.startswith(("autograph_apk_", "stage_autograph_apk_"))
-        or format_ in ("autograph_focus", "autograph_stage_aab", "autograph_aab", "stage_autograph_focus", "stage_autograph_aab")
+        and format_.startswith(("autograph_apk_", "gcp_prod_autograph_apk_", "stage_autograph_apk_"))
+        or format_
+        in (
+            "autograph_focus",
+            "autograph_stage_aab",
+            "autograph_aab",
+            "gcp_prod_autograph_focus",
+            "gcp_prod_autograph_aab",
+            "stage_autograph_focus",
+            "stage_autograph_aab",
+        )
     )
 
 

--- a/signingscript/tests/test_task.py
+++ b/signingscript/tests/test_task.py
@@ -152,7 +152,18 @@ async def test_sign(context, mocker, format, filename, post_files):
         ("autograph_authenticode_sha2_stub", stask.sign_authenticode),
         ("apple_notarization", stask.apple_notarize),
         ("default", stask.sign_file),
-        # Stage-prefixed cases
+        # GCP prod
+        ("gcp_prod_autograph_hash_only_mar384", stask.sign_mar384_with_autograph_hash),
+        ("gcp_prod_autograph_gpg", stask.sign_gpg_with_autograph),
+        ("gcp_prod_macapp", stask.sign_macapp),
+        ("gcp_prod_widevine", stask.sign_widevine),
+        ("gcp_prod_autograph_authenticode_sha2", stask.sign_authenticode),
+        ("gcp_prod_autograph_authenticode_sha2_stub", stask.sign_authenticode),
+        ("gcp_prod_apple_notarization", stask.apple_notarize),
+        ("gcp_prod_autograph_xpi", stask.sign_xpi),
+        ("gcp_prod_autograph_xpi_sha256_es256", stask.sign_xpi),
+        ("gcp_prod_autograph_xpi_foobar", stask.sign_xpi),
+        # GCP stage
         ("stage_autograph_hash_only_mar384", stask.sign_mar384_with_autograph_hash),
         ("stage_autograph_gpg", stask.sign_gpg_with_autograph),
         ("stage_macapp", stask.sign_macapp),


### PR DESCRIPTION
This patch adds another set of new formats that point at Autograph GCP prod. These entries contain equivalents for all current production formats, and use the exact same credentials the existing production formats. Where they differ are:
* Different formats (so we can opt into them)
* Different autograph URL
* Ensure we use explicit keyids everywhere

Note that this patch landing and being deployed should _not_ end up changing how we sign anything on its own, it will merely make gcp prod available to dev and fake-prod workers.