### PR TITLE
Allow beetmover to receive optional exclude patterns

### DIFF
--- a/beetmoverscript/src/beetmoverscript/data/artifactMap_beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/artifactMap_beetmover_task_schema.json
@@ -89,6 +89,14 @@
                     "minItems": 1,
                     "uniqueItems": true
                 },
+                "exclude": {
+                    "type": "array",
+                    "minItems": 0,
+                    "uniqueItems": false,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "artifactMap": {
                     "type": "array",
                     "items": {

--- a/beetmoverscript/src/beetmoverscript/data/beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/beetmover_task_schema.json
@@ -85,6 +85,14 @@
                     },
                     "minItems": 1,
                     "uniqueItems": true
+                },
+                "exclude": {
+                    "type": "array",
+                    "minItems": 0,
+                    "uniqueItems": false,
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "required": ["upload_date", "upstreamArtifacts", "releaseProperties"]

--- a/beetmoverscript/src/beetmoverscript/data/maven_beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/maven_beetmover_task_schema.json
@@ -82,6 +82,14 @@
                     },
                     "minItems": 1,
                     "uniqueItems": true
+                },
+                "exclude": {
+                    "type": "array",
+                    "minItems": 0,
+                    "uniqueItems": false,
+                    "items": {
+                        "type": "string"
+                    }
                 }
             },
             "required": ["upstreamArtifacts", "releaseProperties"]

--- a/beetmoverscript/src/beetmoverscript/data/release_beetmover_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/release_beetmover_task_schema.json
@@ -53,6 +53,14 @@
                     "minItems": 0,
                     "uniqueItems": true
                 },
+                "exclude": {
+                    "type": "array",
+                    "minItems": 0,
+                    "uniqueItems": false,
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "partners": {
                     "type": "array",
                     "minItems": 0,

--- a/beetmoverscript/src/beetmoverscript/gcloud.py
+++ b/beetmoverscript/src/beetmoverscript/gcloud.py
@@ -203,6 +203,7 @@ async def push_to_releases_gcs(context):
 
     # Weed out RELEASE_EXCLUDE matches, but allow partners specified in the payload
     push_partners = context.task["payload"].get("partners", [])
+    exclude = context.task["payload"].get("exclude", []) + list(RELEASE_EXCLUDE)
 
     for blob_path in candidates_blobs.keys():
         if "/partner-repacks/" in blob_path:
@@ -214,7 +215,7 @@ async def push_to_releases_gcs(context):
                 )
             else:
                 log.debug("Excluding partner repack {}".format(blob_path))
-        elif not matches_exclude(blob_path, RELEASE_EXCLUDE):
+        elif not matches_exclude(blob_path, exclude):
             blobs_to_copy[blob_path] = blob_path.replace(candidates_prefix, releases_prefix)
         else:
             log.debug("Excluding {}".format(blob_path))

--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -226,6 +226,8 @@ async def push_to_releases_s3(context):
 
     # Weed out RELEASE_EXCLUDE matches, but allow partners specified in the payload
     push_partners = context.task["payload"].get("partners", [])
+    exclude = context.task["payload"].get("exclude", []) + list(RELEASE_EXCLUDE)
+
     for k in candidates_keys_checksums.keys():
         if "/partner-repacks/" in k:
             partner_match = get_partner_match(k, candidates_prefix, push_partners)
@@ -236,7 +238,7 @@ async def push_to_releases_s3(context):
                 )
             else:
                 log.debug("Excluding partner repack {}".format(k))
-        elif not matches_exclude(k, RELEASE_EXCLUDE):
+        elif not matches_exclude(k, exclude):
             context.artifacts_to_beetmove[k] = k.replace(candidates_prefix, releases_prefix)
         else:
             log.debug("Excluding {}".format(k))

--- a/beetmoverscript/tests/test_gcloud.py
+++ b/beetmoverscript/tests/test_gcloud.py
@@ -259,6 +259,7 @@ async def test_push_to_releases_gcs_exclude(context, monkeypatch, candidate_blob
             return {}
 
     expect_blobs = {f"{test_candidate_prefix}{key}": f"{test_release_prefix}{key}" for key in results}
+
     def fake_move_artifacts(client, bucket_name, blobs_to_copy, candidates_blobs, releases_blobs):
         assert blobs_to_copy == expect_blobs
 

--- a/beetmoverscript/tests/test_gcloud.py
+++ b/beetmoverscript/tests/test_gcloud.py
@@ -10,6 +10,7 @@ from google.cloud.storage.retry import DEFAULT_RETRY_IF_GENERATION_SPECIFIED, Co
 from scriptworker.exceptions import ScriptWorkerTaskException
 
 import beetmoverscript.gcloud
+from beetmoverscript.utils import get_candidates_prefix, get_releases_prefix
 
 from . import get_fake_valid_task, noop_sync
 
@@ -231,6 +232,40 @@ async def test_push_to_releases_gcs_no_moves(context, monkeypatch, candidate_blo
             await beetmoverscript.gcloud.push_to_releases_gcs(context)
     else:
         await beetmoverscript.gcloud.push_to_releases_gcs(context)
+
+
+@pytest.mark.parametrize(
+    "candidate_blobs,exclude,results",
+    [
+        ({"foo/bar.zip": "md5hash", "foo/baz.exe": "abcd", "foo/qux.js": "shasum"}, [], ["foo/baz.exe", "foo/qux.js"]),
+        ({"foo/bar.zip": "md5hash", "foo/baz.exe": "abcd", "foo/qux.js": "shasum"}, [r"^.*\.exe$"], ["foo/qux.js"]),
+        ({"foo/bar.zip": "md5hash", "foo/baz.exe": "abcd", "foo/qux.js": "shasum"}, [r"^.*\.exe$", r"^.*\.js"], []),
+    ],
+)
+@pytest.mark.asyncio
+async def test_push_to_releases_gcs_exclude(context, monkeypatch, candidate_blobs, exclude, results):
+    context.gcs_client = FakeClient()
+    context.task = get_fake_valid_task("task_push_to_releases.json")
+
+    payload = context.task["payload"]
+    payload["exclude"] = exclude
+    test_candidate_prefix = get_candidates_prefix(payload["product"], payload["version"], payload["build_number"])
+    test_release_prefix = get_releases_prefix(payload["product"], payload["version"])
+
+    def fake_list_bucket_objects_gcs_same(client, bucket, prefix):
+        if "candidates" in prefix:
+            return {f"{prefix}{key}": value for (key, value) in candidate_blobs.items()}
+        if "releases" in prefix:
+            return {}
+
+    expect_blobs = {f"{test_candidate_prefix}{key}": f"{test_release_prefix}{key}" for key in results}
+    def fake_move_artifacts(client, bucket_name, blobs_to_copy, candidates_blobs, releases_blobs):
+        assert blobs_to_copy == expect_blobs
+
+    monkeypatch.setattr(beetmoverscript.gcloud, "list_bucket_objects_gcs", fake_list_bucket_objects_gcs_same)
+    monkeypatch.setattr(beetmoverscript.gcloud, "move_artifacts", fake_move_artifacts)
+
+    await beetmoverscript.gcloud.push_to_releases_gcs(context)
 
 
 def test_list_bucket_objects_gcs():

--- a/beetmoverscript/tests/test_script.py
+++ b/beetmoverscript/tests/test_script.py
@@ -69,6 +69,7 @@ async def test_push_to_releases_s3(context, mocker, candidates_keys, releases_ke
     else:
         await push_to_releases_s3(context)
 
+
 # push_to_releases_s3_exclude {{{1
 @pytest.mark.parametrize(
     "candidates_keys,exclude,results",
@@ -88,6 +89,7 @@ async def test_push_to_releases_s3_exclude(context, mocker, candidates_keys, exc
     objects = [{f"{test_candidate_prefix}{key}": candidates_keys[key] for key in candidates_keys}, {}]
 
     expect_artifacts = {f"{test_candidate_prefix}{key}": f"{test_release_prefix}{key}" for key in results}
+
     def check(ctx, _, r):
         assert ctx.artifacts_to_beetmove == expect_artifacts
 
@@ -99,6 +101,7 @@ async def test_push_to_releases_s3_exclude(context, mocker, candidates_keys, exc
     mocker.patch.object(beetmoverscript.script, "copy_beets", new=check)
 
     await push_to_releases_s3(context)
+
 
 # copy_beets {{{1
 @pytest.mark.parametrize("releases_keys,raises", (({}, False), ({"to2": "from2_md5"}, False), ({"to1": "to1_md5"}, True)))

--- a/beetmoverscript/tests/test_script.py
+++ b/beetmoverscript/tests/test_script.py
@@ -29,7 +29,7 @@ from beetmoverscript.script import (
     setup_mimetypes,
 )
 from beetmoverscript.task import get_release_props, get_upstream_artifacts
-from beetmoverscript.utils import generate_beetmover_manifest, is_promotion_action
+from beetmoverscript.utils import get_candidates_prefix, get_releases_prefix, generate_beetmover_manifest, is_promotion_action
 
 from . import get_fake_valid_config, get_fake_valid_task, get_test_jinja_env, noop_async, noop_sync
 
@@ -69,6 +69,36 @@ async def test_push_to_releases_s3(context, mocker, candidates_keys, releases_ke
     else:
         await push_to_releases_s3(context)
 
+# push_to_releases_s3_exclude {{{1
+@pytest.mark.parametrize(
+    "candidates_keys,exclude,results",
+    [
+        ({"foo.zip": "x", "bar.exe": "y", "baz.js": "z"}, [], ["bar.exe", "baz.js"]),
+        ({"foo.zip": "x", "bar.exe": "y", "baz.js": "z"}, [r"^.*\.exe$"], ["baz.js"]),
+        ({"foo.zip": "x", "bar.exe": "y", "baz.js": "z"}, [r"^.*\.exe$", r"^.*\.js"], []),
+    ],
+)
+@pytest.mark.asyncio
+async def test_push_to_releases_s3_exclude(context, mocker, candidates_keys, exclude, results):
+    payload = {"product": "devedition", "build_number": 33, "version": "99.0b44", "exclude": exclude}
+    context.task = {"payload": payload}
+    test_candidate_prefix = get_candidates_prefix(payload["product"], payload["version"], payload["build_number"])
+    test_release_prefix = get_releases_prefix(payload["product"], payload["version"])
+
+    objects = [{f"{test_candidate_prefix}{key}": candidates_keys[key] for key in candidates_keys}, {}]
+
+    expect_artifacts = {f"{test_candidate_prefix}{key}": f"{test_release_prefix}{key}" for key in results}
+    def check(ctx, _, r):
+        assert ctx.artifacts_to_beetmove == expect_artifacts
+
+    def fake_list(*args):
+        return objects.pop(0)
+
+    mocker.patch.object(boto3, "resource")
+    mocker.patch.object(beetmoverscript.script, "list_bucket_objects", new=fake_list)
+    mocker.patch.object(beetmoverscript.script, "copy_beets", new=check)
+
+    await push_to_releases_s3(context)
 
 # copy_beets {{{1
 @pytest.mark.parametrize("releases_keys,raises", (({}, False), ({"to2": "from2_md5"}, False), ({"to1": "to1_md5"}, True)))


### PR DESCRIPTION
This patch attempts to add the ability for tasks to specify artifacts which should be excluded from beetmover. This has previously been done by updating the `RELEASE_EXCLUDE` in `constants.py` but that is a bit of a fragile way of making changes, and it would be handy if the tasks could provide this exclusion information in the payload.

With this change, a task can provide an optional `exclude` field in the payload, which contains an array of regex patterns to exclude from the beetmover action. For example:
```
payload:
   exclude:
      - somepath/*.exe
```

As perhaps a bit of an open question, should this be a literal path instead of a regex pattern? I went with regex simply because that's what is currently done with `RELEASE_EXCLUDE`