### PR TITLE
Bug 1934634 - Add linux aarch64 support in scriptworker-scripts

### DIFF
--- a/beetmoverscript/src/beetmoverscript/constants.py
+++ b/beetmoverscript/src/beetmoverscript/constants.py
@@ -36,6 +36,7 @@ STAGE_PLATFORM_MAP = {
     "linux64": "linux-x86_64",
     "linux64-asan-reporter": "linux-x86_64-asan-reporter",
     "linux64-devedition": "linux-x86_64",
+    "linux64-aarch64-devedition": "linux-aarch64",
     "macosx64": "mac",
     "macosx64-asan-reporter": "mac-asan-reporter",
     "macosx64-devedition": "mac",
@@ -47,6 +48,7 @@ STAGE_PLATFORM_MAP = {
 NORMALIZED_BALROG_PLATFORMS = {
     "linux-devedition": "linux",
     "linux64-devedition": "linux64",
+    "linux64-aarch64-devedition": "linux64-aarch64",
     "macosx64-devedition": "macosx64",
     "win32-devedition": "win32",
     "win64-devedition": "win64",

--- a/bouncerscript/src/bouncerscript/constants.py
+++ b/bouncerscript/src/bouncerscript/constants.py
@@ -163,7 +163,7 @@ PRODUCT_TO_PRODUCT_ENTRY = [
     ("thunderbird", r"^Thunderbird-.*$"),
 ]
 
-BOUNCER_LOCATION_PLATFORMS = ["linux", "linux64", "osx", "win", "win64", "android-x86", "android", "win64-aarch64", "linux64-aarch64"]
+BOUNCER_LOCATION_PLATFORMS = ["linux", "linux64", "linux64-aarch64", "osx", "win", "win64", "android-x86", "android", "win64-aarch64", "linux64-aarch64"]
 
 GO_BOUNCER_URL_TMPL = {
     "project:releng:bouncer:server:production": "https://download.mozilla.org/?product={}&print=yes",

--- a/bouncerscript/src/bouncerscript/constants.py
+++ b/bouncerscript/src/bouncerscript/constants.py
@@ -65,15 +65,15 @@ PARTNER_ALIASES_REGEX = {
 
 PRODUCT_TO_DESTINATIONS_REGEXES = {
     "firefox-rc": (
-        r"^(/firefox/candidates/.*?/build[0-9]+/(update/)?(?:linux-i686|linux-x86_64|mac|win32|win64(?:|-aarch64))/\:lang/(?:firefox|Firefox)"
+        r"^(/firefox/candidates/.*?/build[0-9]+/(update/)?(?:linux-i686|linux-x86_64|linux-aarch64|mac|win32|win64(?:|-aarch64))/\:lang/(?:firefox|Firefox)"
         r".*\.(?:bz2|xz|dmg|exe|mar))$"
     ),
     "firefox": (
-        r"^(/firefox/releases/.*?/(update/)?(?:linux-i686|linux-x86_64|mac|win32|win64(?:|-aarch64))/(?:(?:\:lang|multi)/(?:firefox|Firefox)"
+        r"^(/firefox/releases/.*?/(update/)?(?:linux-i686|linux-x86_64|linux-aarch64|mac|win32|win64(?:|-aarch64))/(?:(?:\:lang|multi)/(?:firefox|Firefox)"
         r".*\.(?:bz2|xz|dmg|exe|mar|msi|msix|pkg)|xpi/:lang.xpi))$"
     ),
     "devedition": (
-        r"^(/devedition/releases/.*?/(update/)?(?:linux-i686|linux-x86_64|mac|win32|win64(?:|-aarch64))/(?:\:lang|multi)/(?:firefox|Firefox)"
+        r"^(/devedition/releases/.*?/(update/)?(?:linux-i686|linux-x86_64|linux-aarch64|mac|win32|win64(?:|-aarch64))/(?:\:lang|multi)/(?:firefox|Firefox)"
         r".*\.(?:bz2|xz|dmg|exe|mar|msi|msix))$"
     ),
     "thunderbird": (


### PR DESCRIPTION
https://firefox-ci-tc.services.mozilla.com/tasks/OqxKlz8KQAWntEyV74F10w/runs/0/logs/public/logs/live_backing.log