### PR TITLE
Bug 1939751 - Use proper keyids for omnija signing

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -105,7 +105,8 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_OMNIJA_USERNAME"},
                {"$eval": "AUTOGRAPH_OMNIJA_PASSWORD"},
-               ["autograph_omnija"]
+               ["autograph_omnija"],
+               "systemaddon_rsa_dep_202402"
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
@@ -351,7 +352,8 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_OMNIJA_USERNAME"},
                {"$eval": "AUTOGRAPH_OMNIJA_PASSWORD"},
-               ["autograph_omnija"]
+               ["autograph_omnija"],
+               "systemaddon_rsa_rel_202404"
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
@@ -383,7 +385,8 @@ in:
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_OMNIJA_USERNAME"},
                {"$eval": "AUTOGRAPH_OMNIJA_PASSWORD"},
-               ["autograph_omnija"]
+               ["autograph_omnija"],
+               "systemaddon_rsa_rel_202404"
             ]
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},


### PR DESCRIPTION
The default keyids here were still using the old root CA. These should be using the new CA.