### PR TITLE
fix(signingscript): use correct keyid for stage mar signing

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -42,7 +42,7 @@ in:
                {"$eval": "AUTOGRAPH_STAGE_MAR_USERNAME"},
                {"$eval": "AUTOGRAPH_STAGE_MAR_PASSWORD"},
                ["stage_autograph_hash_only_mar384"],
-               "mar_202411",
+               "firefox_dep1",
             ]
             - ["https://stage.autograph.nonprod.webservices.mozgcp.net",
                {"$eval": "AUTOGRAPH_STAGE_GPG_USERNAME"},
@@ -272,7 +272,7 @@ in:
              {"$eval": "AUTOGRAPH_STAGE_MAR_USERNAME"},
              {"$eval": "AUTOGRAPH_STAGE_MAR_PASSWORD"},
              ["stage_autograph_mar384", "stage_autograph_hash_only_mar384"],
-             "mar_202411"
+             "firefox_dep1"
           ]
           - ["https://stage.autograph.nonprod.webservices.mozgcp.net",
              {"$eval": "AUTOGRAPH_STAGE_GPG_USERNAME"},


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/AUT-339 imported the dep key into stage and set up new hawk creds for it. We should sign with it instead of the completely fake mar cert we're currently using, which doesn't pass the mar verification that we do after signing:
```
2025-01-07 14:20:10,312 - signingscript.sign - DEBUG - make_signing_req took 0.00s; RSS:75820 (+0)
2025-01-07 14:20:10,312 - signingscript.sign - DEBUG - sign_with_autograph: url: https://stage.autograph.nonprod.webservices.mozgcp.net/sign/hash, keyid: mar_202411, client_id: releng_signingscript_2023
2025-01-07 14:20:10,313 - signingscript.sign - DEBUG - req_size: 99
2025-01-07 14:20:10,441 - signingscript.sign - DEBUG - Autograph response: 201
2025-01-07 14:20:10,442 - signingscript.sign - DEBUG - call_autograph took 0.13s; RSS:75820 (+0)
2025-01-07 14:20:10,442 - signingscript.sign - DEBUG - sign_with_autograph took 0.13s; RSS:75820 (+0)
2025-01-07 14:20:10,442 - signingscript.sign - DEBUG - sign_hash_with_autograph took 0.13s; RSS:75820 (+0)
2025-01-07 14:20:11,376 - signingscript.sign - INFO - Running ['/app/bin/mar', '-k', '/app/lib/python3.11/site-packages/signingscript/data/dep1.pem', '-v', '/app/workdir/public/build/af/target.complete.mar']
Verification failed
2025-01-07 14:20:11,968 - signingscript.sign - DEBUG - sign_mar384_with_autograph_hash took 2.35s; RSS:75820 (+0)
2025-01-07 14:20:11,969 - scriptworker.client - ERROR - Failed to run async_main
Traceback (most recent call last):
  File "/app/lib/python3.11/site-packages/signingscript/sign.py", line 1198, in verify_mar_signature
    subprocess.check_call(cmd, stdout=sys.stdout, stderr=sys.stderr)
  File "/usr/local/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/app/bin/mar', '-k', '/app/lib/python3.11/site-packages/signingscript/data/dep1.pem', '-v', '/app/workdir/public/build/af/target.complete.mar']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/lib/python3.11/site-packages/scriptworker/client.py", line 204, in _handle_asyncio_loop
    await async_main(context)
  File "/app/lib/python3.11/site-packages/signingscript/script.py", line 60, in async_main
    output_files = await sign(context, os.path.join(work_dir, path), path_dict["formats"], authenticode_comment=path_dict.get("comment"))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lib/python3.11/site-packages/signingscript/task.py", line 160, in sign
    output = await signing_func(context, output, fmt, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lib/python3.11/site-packages/signingscript/sign.py", line 112, in wrapped
    return await f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lib/python3.11/site-packages/signingscript/sign.py", line 1260, in sign_mar384_with_autograph_hash
    verify_mar_signature(cert_type, fmt, to, keyid)
  File "/app/lib/python3.11/site-packages/signingscript/sign.py", line 1201, in verify_mar_signature
    raise SigningScriptError(e)
signingscript.exceptions.SigningScriptError: Command '['/app/bin/mar', '-k', '/app/lib/python3.11/site-packages/signingscript/data/dep1.pem', '-v', '/app/workdir/public/build/af/target.complete.mar']' returned non-zero exit status 1.
exit code: 5

```

This depends on the `stage-mar-update` branch in the sops repo as well, which is where the hawk cred changes are happening.