### PR TITLE
scriptworker_client: handle long lines in pipe_to_log (bug 1941166)

### DIFF
--- a/scriptworker_client/src/scriptworker_client/utils.py
+++ b/scriptworker_client/src/scriptworker_client/utils.py
@@ -128,7 +128,14 @@ async def pipe_to_log(pipe, filehandles=(), level=logging.INFO):
 
     """
     while True:
-        line = await pipe.readline()
+        try:
+            line = await pipe.readuntil()
+        except asyncio.exceptions.IncompleteReadError as e:
+            line = e.partial
+        except asyncio.exceptions.LimitOverrunError:
+            # line too long
+            line = bytes(pipe._buffer)
+            pipe._buffer.clear()
         if line:
             line = to_unicode(line)
             log.log(level, line.rstrip())

--- a/scriptworker_client/tests/test_utils.py
+++ b/scriptworker_client/tests/test_utils.py
@@ -179,6 +179,15 @@ def test_get_log_filehandle(path, tmpdir):
             None,
             True,
         ),
+        (
+            ["echo", "a" * 100_000],
+            0,
+            ["a" * 100_000 + "\n"],
+            None,
+            False,
+            None,
+            False,
+        ),
     ),
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
Avoid deadlock with full pipe buffer when the output contains long lines (>64kB).