### PR TITLE
bug 1942364: signingscript: autograph gcp migration step 4: add gcp_prod entries for L3 workers

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -407,7 +407,7 @@ in:
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
              ["gcp_prod_autograph_authenticode_202412", "gcp_prod_autograph_authenticode_202412_stub",
-              "gcp_prod_autograph_authenticode_ev", "gcp_prod_autograph_authenticode_ev_202412"],
+              "gcp_prod_autograph_authenticode_ev_202412"],
              "authenticode_dep_sha256"
           ]
           - ["https://prod.autograph.prod.webservices.mozgcp.net",
@@ -470,6 +470,45 @@ in:
       'ENV == "prod" && (COT_PRODUCT == "firefox" || COT_PRODUCT == "thunderbird")':
         $let:
           firefox_and_thunderbird_prod_release_autograph:
+            # GCP Autograph prod
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
+               {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
+               ["gcp_prod_autograph_authenticode_202501", "gcp_prod_autograph_authenticode_202501_stub"],
+               "authenticode_rel_sha256_202412"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_MAR_RELEASE_USERNAME"},
+               {"$eval": "AUTOGRAPH_MAR_RELEASE_PASSWORD"},
+               ["gcp_prod_autograph_hash_only_mar384"],
+               "firefox_rel1",
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+               {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+               ["gcp_prod_autograph_gpg"],
+               "release_at_mozilla_rel_pgp_2023"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_WIDEVINE_USERNAME"},
+               {"$eval": "AUTOGRAPH_WIDEVINE_PASSWORD"},
+               ["gcp_prod_autograph_widevine"],
+               "widevine_rel1"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_OMNIJA_USERNAME"},
+               {"$eval": "AUTOGRAPH_OMNIJA_PASSWORD"},
+               ["gcp_prod_autograph_omnija"],
+               "systemaddon_rsa_rel_2024"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
+               {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
+               ["gcp_prod_autograph_langpack"],
+               "webextensions_rsa_202402"
+            ]
+
+            # AWS Autograph; to be removed when production is switched over to GCP by default.
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
                {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
@@ -503,6 +542,45 @@ in:
                "webextensions_rsa_202404"
             ]
           firefox_and_thunderbird_prod_nightly_autograph:
+            # GCP Autograph prod
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
+               {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
+               ["gcp_prod_autograph_authenticode_202501", "gcp_prod_autograph_authenticode_202501_stub"],
+               "authenticode_rel_sha256_202412"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_MAR_NIGHTLY_USERNAME"},
+               {"$eval": "AUTOGRAPH_MAR_NIGHTLY_PASSWORD"},
+               ["gcp_prod_autograph_hash_only_mar384"],
+               "firefox_ngt1",
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+               {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+               ["gcp_prod_autograph_gpg"],
+               "release_at_mozilla_rel_pgp_2023"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_WIDEVINE_USERNAME"},
+               {"$eval": "AUTOGRAPH_WIDEVINE_PASSWORD"},
+               ["gcp_prod_autograph_widevine"],
+               "widevine_rel1"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_OMNIJA_USERNAME"},
+               {"$eval": "AUTOGRAPH_OMNIJA_PASSWORD"},
+               ["gcp_prod_autograph_omnija"],
+               "systemaddon_rsa_rel_2024"
+            ]
+            - ["https://prod.autograph.prod.webservices.mozgcp.net",
+               {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
+               {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
+               ["gcp_prod_autograph_langpack"],
+               "webextensions_rsa_202402"
+            ]
+
+            # AWS Autograph; to be removed when production is switched over to GCP by default.
             - ["https://autograph-external.prod.autograph.services.mozaws.net",
                {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
                {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
@@ -545,6 +623,27 @@ in:
           '${scope_prefix[0]}cert:production-signing':
             $if: 'COT_PRODUCT == "firefox"'
             then:
+              # GCP Autograph prod
+              - ["https://prod.autograph.prod.webservices.mozgcp.net",
+                 {"$eval": "AUTOGRAPH_FOCUS_USERNAME"},
+                 {"$eval": "AUTOGRAPH_FOCUS_PASSWORD"},
+                 ["gcp_prod_autograph_focus"],
+                 "focus_rel_apk"
+              ]
+              - ["https://prod.autograph.prod.webservices.mozgcp.net",
+                 {"$eval": "AUTOGRAPH_FENIX_USERNAME"},
+                 {"$eval": "AUTOGRAPH_FENIX_PASSWORD"},
+                 ["gcp_prod_autograph_apk"],
+                 "fenix_release_apk"
+              ]
+              - ["https://prod.autograph.prod.webservices.mozgcp.net",
+                 {"$eval": "AUTOGRAPH_FENIX_MOZILLA_ONLINE_USERNAME"},
+                 {"$eval": "AUTOGRAPH_FENIX_MOZILLA_ONLINE_PASSWORD"},
+                 ["gcp_prod_autograph_apk_mozillaonline"],
+                 "fenix_china_rel_apk"
+              ]
+
+              # AWS Autograph; to be removed when production is switched over to GCP by default.
               - ["https://autograph-external.prod.autograph.services.mozaws.net",
                  {"$eval": "AUTOGRAPH_FOCUS_USERNAME"},
                  {"$eval": "AUTOGRAPH_FOCUS_PASSWORD"},
@@ -563,6 +662,15 @@ in:
           '${scope_prefix[0]}cert:fennec-production-signing':
             $if: 'COT_PRODUCT == "firefox"'
             then:
+              # GCP Autograph prod
+              - ["https://prod.autograph.prod.webservices.mozgcp.net",
+                 {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},
+                 {"$eval": "AUTOGRAPH_FENNEC_RELEASE_PASSWORD"},
+                 ["gcp_prod_autograph_apk"],
+                 "fennec_rel_apk"
+              ]
+
+              # AWS Autograph; to be removed when production is switched over to GCP by default.
               - ["https://autograph-external.prod.autograph.services.mozaws.net",
                  {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},
                  {"$eval": "AUTOGRAPH_FENNEC_RELEASE_PASSWORD"},
@@ -572,6 +680,22 @@ in:
       # passwords-mobile.json
       'ENV == "prod" && COT_PRODUCT == "mobile"':
         project:mobile:reference-browser:releng:signing:cert:release-signing:
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_USERNAME"},
+             {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_PASSWORD"},
+             ["gcp_prod_autograph_apk"],
+             "geckoview_reference_browser_rel_apk"
+          ]
+
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_USERNAME"},
+             {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_PASSWORD"},
+             ["gcp_prod_autograph_aab"],
+             "geckoview_reference_browser_2024"
+          ]
+
+          # AWS Autograph; to be removed when production is switched over to GCP by default.
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_USERNAME"},
              {"$eval": "AUTOGRAPH_REFERENCE_BROWSER_PASSWORD"},
@@ -587,6 +711,15 @@ in:
       # passwords-appsv.json
       'ENV == "prod" && COT_PRODUCT == "app-services"':
         project:mozilla:app-services:releng:signing:cert:release-signing:
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+             {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+             ["gcp_prod_autograph_gpg"],
+             "release_at_mozilla_rel_pgp_2023"
+          ]
+
+          # AWS Autograph; to be removed when production is switched over to GCP by default.
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
@@ -594,6 +727,15 @@ in:
           ]
       'ENV == "prod" && COT_PRODUCT == "glean"':
         project:mozilla:glean:releng:signing:cert:release-signing:
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+             {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+             ["gcp_prod_autograph_gpg"],
+             "release_at_mozilla_rel_pgp_2023"
+          ]
+
+          # AWS Autograph; to be removed when production is switched over to GCP by default.
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
@@ -603,6 +745,21 @@ in:
       # passwords-xpi.json
       'ENV == "prod" && COT_PRODUCT == "xpi"':
         '${scope_prefix[0]}cert:release-signing':
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_USERNAME"},
+             {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_PASSWORD"},
+             ["gcp_prod_privileged_webextension"],
+             "extension_rsa_202404"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_USERNAME"},
+             {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_PASSWORD"},
+             ["gcp_prod_system_addon"],
+             "systemaddon_rsa_rel_202404"
+          ]
+
+          # AWS Autograph; to be removed when production is switched over to GCP by default.
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_USERNAME"},
              {"$eval": "AUTOGRAPH_XPI_PRIVILEGED_PASSWORD"},
@@ -619,6 +776,27 @@ in:
       # passwords-mozillavpn.json
       'ENV == "prod" && COT_PRODUCT == "mozillavpn"':
         '${scope_prefix[0]}cert:release-signing':
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
+             ["gcp_prod_autograph_authenticode_202412"],
+             "authenticode_rel_sha256_202412"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_MOZILLAVPN_USERNAME"},
+             {"$eval": "AUTOGRAPH_MOZILLAVPN_PASSWORD"},
+             ["gcp_prod_autograph_apk"],
+             "firefox_vpn_apk"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_MOZILLAVPN_ADDONS_USERNAME"},
+             {"$eval": "AUTOGRAPH_MOZILLAVPN_ADDONS_PASSWORD"},
+             ["gcp_prod_autograph_rsa"],
+             "vpn_addons_rel_2022"
+          ]
+
+          # AWS Autograph; to be removed when production is switched over to GCP by default.
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
@@ -638,6 +816,39 @@ in:
       # passwords-adhoc.json
       'ENV == "prod" && COT_PRODUCT == "adhoc"':
         '${scope_prefix[0]}cert:release-signing':
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
+             ["gcp_prod_autograph_authenticode_202412", "gcp_prod_autograph_authenticode_202412_stub"],
+             "authenticode_rel_sha256_202412"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_EV_USERNAME"},
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_EV_PASSWORD"},
+             ["gcp_prod_autograph_authenticode_ev_202412"],
+             "authenticode_ev_rel_sha256_202412"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_MAR_RELEASE_USERNAME"},
+             {"$eval": "AUTOGRAPH_MAR_RELEASE_PASSWORD"},
+             ["gcp_prod_autograph_hash_only_mar384"],
+             "firefox_rel1",
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+             {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+             ["gcp_prod_autograph_gpg"],
+             "release_at_mozilla_rel_pgp_2023"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},
+             {"$eval": "AUTOGRAPH_FENNEC_RELEASE_PASSWORD"},
+             ["gcp_prod_autograph_apk"],
+             "fennec_rel_apk"
+          ]
+
+          # AWS Autograph; to be removed when production is switched over to GCP by default.
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
@@ -664,6 +875,21 @@ in:
              ["autograph_apk"]
           ]
         '${scope_prefix[0]}cert:nightly-signing':
+          # GCP Autograph prod
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
+             {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},
+             ["gcp_prod_autograph_authenticode_202412", "gcp_prod_autograph_authenticode_202412_stub"],
+             "authenticode_rel_sha256_202412"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_MAR_NIGHTLY_USERNAME"},
+             {"$eval": "AUTOGRAPH_MAR_NIGHTLY_PASSWORD"},
+             ["gcp_prodautograph_hash_only_mar384"],
+             "firefox_ngt1"
+          ]
+
+          # AWS Autograph; to be removed when production is switched over to GCP by default.
           - ["https://autograph-external.prod.autograph.services.mozaws.net",
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME"},
              {"$eval": "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD"},


### PR DESCRIPTION
This adds `gcp_prod` prefixes for everything in the production workers, except for the authenticode stub format in `vpn`, which it doesn't actually use.

The new authenticode keyids require new hawk credentials. There is a `gcp-prod-level-3` branch in the sops repo with the necessary changes staged in it that needs to be pushed before this rolls out.

This is step 4 of https://docs.google.com/document/d/1nOZoNfAg96pPUMU1_NGOoRQD0gQcWgxyMYRnKnOgyJg/edit?tab=t.0#heading=h.xv0nvnha14du, and relates to https://mozilla-hub.atlassian.net/browse/AUT-300.