### PR TITLE
fix(signingscript): gcp prod langpack keyid

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -508,7 +508,7 @@ in:
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
                {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
                ["gcp_prod_autograph_langpack"],
-               "webextensions_rsa_202402"
+               "webextensions_rsa_202404"
             ]
 
             # AWS Autograph; to be removed when production is switched over to GCP by default.
@@ -583,7 +583,7 @@ in:
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
                {"$eval": "AUTOGRAPH_LANGPACK_PASSWORD"},
                ["gcp_prod_autograph_langpack"],
-               "webextensions_rsa_202402"
+               "webextensions_rsa_202404"
             ]
 
             # AWS Autograph; to be removed when production is switched over to GCP by default.


### PR DESCRIPTION
I bungled this in my original patch; it has a different month than both the webextensions dep key and the systemaddons prod key.