### PR TITLE
fix(signingscript): use newer systemaddon dep keyid for firefox dep/f…

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -111,7 +111,7 @@ in:
                {"$eval": "AUTOGRAPH_OMNIJA_USERNAME"},
                {"$eval": "AUTOGRAPH_OMNIJA_PASSWORD"},
                ["gcp_prod_autograph_omnija"],
-               "systemaddon_rsa_dep"
+               "systemaddon_rsa_dep_202402"
             ]
             - ["https://prod.autograph.prod.webservices.mozgcp.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},


### PR DESCRIPTION
…ake-prod

We're already using this elsewhere; this was a simple typo