### PR TITLE
support uploading translations artifacts

### DIFF
--- a/beetmoverscript/src/beetmoverscript/constants.py
+++ b/beetmoverscript/src/beetmoverscript/constants.py
@@ -89,6 +89,8 @@ ARTIFACT_REGISTRY_ACTIONS = ("import-from-gcs-to-artifact-registry",)
 
 UPLOAD_DATA_ACTIONS = ("upload-data",)
 
+TRANSLATIONS_ACTIONS = ("upload-translations-artifacts",)
+
 # XXX this is a fairly clunky way of specifying which files to copy from
 # candidates to releases -- let's find a nicer way of doing this.
 # XXX if we keep this, let's make it configurable? overridable in config?

--- a/beetmoverscript/src/beetmoverscript/data/upload_translations_artifacts_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/upload_translations_artifacts_task_schema.json
@@ -1,0 +1,97 @@
+{
+  "title": "Taskcluster beetmover upload translations artifacts task schema",
+  "type": "object",
+  "properties": {
+    "dependencies": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "releaseProperties": {
+            "type": "object",
+            "properties": {
+                "appName": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "appName"
+            ],
+            "additionalProperties": false
+        },
+        "upstreamArtifacts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "taskType": {
+                        "type": "string"
+                    },
+                    "taskId": {
+                        "type": "string"
+                    },
+                    "paths": {
+                        "type": "array",
+                        "minItems": 1,
+                        "uniqueItems": true,
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "optional": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["taskId", "taskType", "paths"]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "artifactMap": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "taskId": {
+                        "type": "string"
+                    },
+                    "paths": {
+                        "type": "object",
+                        "minProperties": 1,
+                        "additionalProperties": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "destinations": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "taskId",
+                    "paths"
+                ]
+            },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+      },
+      "required": ["releaseProperties", "upstreamArtifacts", "artifactMap"]
+    }
+  },
+  "required": ["payload", "dependencies"]
+}

--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -412,7 +412,7 @@ def get_concrete_artifact_map_from_globbed(work_dir, upstreamArtifactPaths, arti
                 if not artifact.startswith(leading_dir):
                     raise ScriptWorkerTaskException(f"cannot determine relative artifact path for {artifact}")
 
-                relative_artifact = artifact[len(leading_dir):]
+                relative_artifact = artifact[len(leading_dir) :]
 
                 destinations = []
                 # We need to look at non-'*' paths separate from '*' paths.
@@ -470,7 +470,7 @@ def get_concrete_artifact_map_from_globbed(work_dir, upstreamArtifactPaths, arti
 def remove_prefixes(string, prefixes):
     for p in prefixes:
         if string.startswith(p):
-            string = string[len(p):]
+            string = string[len(p) :]
             return string
 
     return string
@@ -497,7 +497,9 @@ async def upload_translations_artifacts(context):
 
     # Ignore any failed artifacts; we'll take whatever we can get. All artifacts are considered optional.
     upstreamArtifactPaths = scriptworker_artifacts.get_upstream_artifacts_full_paths_per_task_id(context)[0]
-    concreteArtifactMap = get_concrete_artifact_map_from_globbed(context.config["work_dir"], upstreamArtifactPaths, artifactMap, strip_prefixes=("public/build/", "public/logs/"))
+    concreteArtifactMap = get_concrete_artifact_map_from_globbed(
+        context.config["work_dir"], upstreamArtifactPaths, artifactMap, strip_prefixes=("public/build/", "public/logs/")
+    )
 
     for map_ in concreteArtifactMap:
         for input_path, outputs in map_["paths"].items():

--- a/beetmoverscript/src/beetmoverscript/task.py
+++ b/beetmoverscript/src/beetmoverscript/task.py
@@ -30,6 +30,8 @@ def get_schema_key_by_action(context):
         return "import_from_gcs_to_artifact_registry_schema_file"
     elif utils.is_upload_data_action(action):
         return "upload_data_schema_file"
+    elif utils.is_upload_translations_artifacts_action(action):
+        return "upload_translations_artifacts"
 
     return "schema_file"
 

--- a/beetmoverscript/src/beetmoverscript/utils.py
+++ b/beetmoverscript/src/beetmoverscript/utils.py
@@ -27,6 +27,7 @@ from beetmoverscript.constants import (
     PRODUCT_TO_PATH,
     PROMOTION_ACTIONS,
     RELEASE_ACTIONS,
+    TRANSLATIONS_ACTIONS,
     UPLOAD_DATA_ACTIONS,
 )
 
@@ -146,6 +147,10 @@ def is_maven_action(action):
 
 def is_upload_data_action(action):
     return action in UPLOAD_DATA_ACTIONS
+
+
+def is_upload_translations_artifacts_action(action):
+    return action in TRANSLATIONS_ACTIONS
 
 
 def get_product_name(task, config, lowercase_app_name=True):


### PR DESCRIPTION
The first commit here is a sortof companion to https://github.com/mozilla-releng/scriptworker/pull/644, where wildcard support was added in scriptworker. It adds a helper function to take a beetmover artifact map with wildcards, and turn it into one with those resolved.

The second commit is a fairly straightfoward addition of a new action for uploading the translations artifacts.

I've been testing this in https://github.com/mozilla/translations/pull/590 / https://firefox-ci-tc.services.mozilla.com/tasks/groups/c-dILkwwTA-SxTdTZ22oLA. The beetmover parts of that are all working well (the failures are intermittent issues in the pipeline).