### PR TITLE
feat(beetmover): allow not failing on unknown mimetypes

### DIFF
--- a/beetmoverscript/src/beetmoverscript/gcloud.py
+++ b/beetmoverscript/src/beetmoverscript/gcloud.py
@@ -102,11 +102,14 @@ def setup_gcs_credentials(raw_creds):
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = fp.name
 
 
-async def upload_to_gcs(context, target_path, path, expiry=None):
+async def upload_to_gcs(context, target_path, path, expiry=None, fail_on_unknown_mimetype=True):
     product = get_product_name(context.task, context.config)
     mime_type = mimetypes.guess_type(path)[0]
     if not mime_type:
-        raise ScriptWorkerTaskException("Unable to discover valid mime-type for path ({}), mimetypes.guess_type() returned {}".format(path, mime_type))
+        if fail_on_unknown_mimetype:
+            raise ScriptWorkerTaskException("Unable to discover valid mime-type for path ({}), mimetypes.guess_type() returned {}".format(path, mime_type))
+        else:
+            mime_type = "application/octet-stream"
     bucket_name = get_bucket_name(context, product, "gcloud")
 
     bucket = Bucket(context.gcs_client, name=bucket_name)


### PR DESCRIPTION
This is needed to support work from https://github.com/mozilla-releng/scriptworker-scripts/pull/1141 where we're uploading all artifacts from upstream tasks, and can't reasonably predict all possible file types and extensions.

This also fixes a minor bug in the `upload_to_s3` tests, where they implicitly rely on `setup_mimetypes()` being called elsewhere to pass (which means they fail mysteriously if run independently).

I considered making this the default behaviour, but ultimately decided against it because we most likely want to notice and fix mime types for files from other projects, rather than have them uploaded so generically.