### PR TITLE
signingscript: enable gpg nightly-signing on adhoc (bug 1947765)

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -906,6 +906,12 @@ in:
              ["gcp_prodautograph_hash_only_mar384"],
              "firefox_ngt1"
           ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_GPG_USERNAME"},
+             {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
+             ["gcp_prod_autograph_gpg"],
+             "release_at_mozilla_rel_pgp_202503"
+          ]
 
           # AWS Autograph; to be removed when production is switched over to GCP by default.
           - ["https://autograph-external.prod.autograph.services.mozaws.net",


### PR DESCRIPTION
This uses the new subkey for testing before rolling out to other trust domains.