### PR TITLE
signingscript: use new gpg signing subkey for release-signing (bug 1947765)

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -490,7 +490,7 @@ in:
                {"$eval": "AUTOGRAPH_GPG_USERNAME"},
                {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
                ["gcp_prod_autograph_gpg"],
-               "release_at_mozilla_rel_pgp_2023"
+               "release_at_mozilla_rel_pgp_202503"
             ]
             - ["https://prod.autograph.prod.webservices.mozgcp.net",
                {"$eval": "AUTOGRAPH_WIDEVINE_USERNAME"},
@@ -722,7 +722,7 @@ in:
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["gcp_prod_autograph_gpg"],
-             "release_at_mozilla_rel_pgp_2023"
+             "release_at_mozilla_rel_pgp_202503"
           ]
 
           # AWS Autograph; to be removed when production is switched over to GCP by default.
@@ -738,7 +738,7 @@ in:
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["gcp_prod_autograph_gpg"],
-             "release_at_mozilla_rel_pgp_2023"
+             "release_at_mozilla_rel_pgp_202503"
           ]
 
           # AWS Autograph; to be removed when production is switched over to GCP by default.
@@ -854,7 +854,7 @@ in:
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["gcp_prod_autograph_gpg"],
-             "release_at_mozilla_rel_pgp_2023"
+             "release_at_mozilla_rel_pgp_202503"
           ]
           - ["https://prod.autograph.prod.webservices.mozgcp.net",
              {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},


### PR DESCRIPTION
This doesn't include the aws formats, on the assumption we'll have moved off of it before the 2023 key expires.