### PR TITLE
fix: systemaddon keyid in two places

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -502,7 +502,7 @@ in:
                {"$eval": "AUTOGRAPH_OMNIJA_USERNAME"},
                {"$eval": "AUTOGRAPH_OMNIJA_PASSWORD"},
                ["gcp_prod_autograph_omnija"],
-               "systemaddon_rsa_rel_2024"
+               "systemaddon_rsa_rel_202404"
             ]
             - ["https://prod.autograph.prod.webservices.mozgcp.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},
@@ -577,7 +577,7 @@ in:
                {"$eval": "AUTOGRAPH_OMNIJA_USERNAME"},
                {"$eval": "AUTOGRAPH_OMNIJA_PASSWORD"},
                ["gcp_prod_autograph_omnija"],
-               "systemaddon_rsa_rel_2024"
+               "systemaddon_rsa_rel_202404"
             ]
             - ["https://prod.autograph.prod.webservices.mozgcp.net",
                {"$eval": "AUTOGRAPH_LANGPACK_USERNAME"},


### PR DESCRIPTION
Over in https://github.com/mozilla-releng/scriptworker-scripts/pull/1123 I managed to mess this keyid up, but only in two places.