### PR TITLE
feat(landoscript): add schema file to landoscript config

### DIFF
--- a/landoscript/docker.d/worker.yml
+++ b/landoscript/docker.d/worker.yml
@@ -3,3 +3,4 @@ artifact_dir: { "$eval": "ARTIFACTS_DIR" }
 verbose: { "$eval": "VERBOSE == 'true'" }
 lando_api: { "$eval": "LANDO_API" }
 lando_token: { "$eval": "LANDO_TOKEN" }
+schema_file: /app/landoscript/src/landoscript/data/landoscript_task_schema.json

--- a/landoscript/src/landoscript/script.py
+++ b/landoscript/src/landoscript/script.py
@@ -142,7 +142,7 @@ async def async_main(context):
             log.info("No lando actions to submit!")
 
 
-def main(config_path: str = ""):
+def main(config_path: str | None = None):
     return scriptworker.client.sync_main(async_main, config_path=config_path, default_config=get_default_config())
 
 


### PR DESCRIPTION
This ensures that scriptworker will check payload schemas. This is not realistically testable, because we don't run tests through `scriptworker.client.sync_main`.

Also fixes a minor issue with `config_path` (scriptworker wants it to be `None` in order for usage to be printed).