### PR TITLE
feat(landoscript): respect closed tree for android l10n sync

### DIFF
--- a/landoscript/src/landoscript/script.py
+++ b/landoscript/src/landoscript/script.py
@@ -5,9 +5,8 @@ import aiohttp
 import scriptworker.client
 from scriptworker.exceptions import TaskVerificationError
 
-from landoscript import lando
+from landoscript import lando, treestatus
 from landoscript.actions import android_l10n_import, android_l10n_sync, l10n_bump, merge_day, tag, version_bump
-from landoscript.treestatus import is_tree_open
 from scriptworker_client.github import extract_github_repo_owner_and_name
 from scriptworker_client.github_client import GithubClient
 
@@ -56,7 +55,7 @@ async def async_main(context):
         lando_token = config["lando_token"]
         lando_repo = payload["lando_repo"]
         dontbuild = payload.get("dontbuild", False)
-        ignore_closed_tree = payload.get("ignore_closed_tree", False)
+        ignore_closed_tree = payload.get("ignore_closed_tree", True)
 
         # pull owner, repo, and branch from config
         repo_url, branch = await lando.get_repo_info(session, lando_api, lando_token, lando_repo)
@@ -69,10 +68,18 @@ async def async_main(context):
             raise TaskVerificationError("must provide at least one action!")
 
         if not any([action == "l10n_bump" for action in payload["actions"]]):
-            if "dontbuild" in payload or "ignore_closed_tree" in payload:
-                raise TaskVerificationError("dontbuild and ignore_closed_tree are only respected in l10n_bump!")
+            if "dontbuild" in payload:
+                raise TaskVerificationError("dontbuild is only respected in l10n_bump!")
+
+        if not any([action in ("android_l10n_sync", "l10n_bump") for action in payload["actions"]]):
+            if "ignore_closed_tree" in payload:
+                raise TaskVerificationError("ignore_closed_tree is only respected in l10n_bump and android_l10n_sync!")
 
         os.makedirs(public_artifact_dir)
+
+        is_tree_open = True
+        if not ignore_closed_tree:
+            is_tree_open = await treestatus.is_tree_open(session, config["treestatus_url"], lando_repo, config["sleeptime_callback"])
 
         lando_actions: list[lando.LandoAction] = []
         async with GithubClient(context.config["github_config"], owner, repo) as gh_client:
@@ -96,14 +103,9 @@ async def async_main(context):
                     merge_day_actions = await merge_day.run(gh_client, public_artifact_dir, merge_day.MergeInfo.from_payload_data(payload["merge_info"]))
                     lando_actions.extend(merge_day_actions)
                 elif action == "l10n_bump":
-                    if not ignore_closed_tree:
-                        # despite `ignore_closed_tree` being at the top level of the
-                        # payload, only l10n bumps pay attention to it. we should probably
-                        # set it to true for all other actions so we can actually make
-                        # this a global check
-                        if not await is_tree_open(session, config["treestatus_url"], lando_repo, config["sleeptime_callback"]):
-                            log.info("Treestatus is closed; skipping l10n bump.")
-                            continue
+                    if not is_tree_open:
+                        log.info("Treestatus is closed; skipping l10n bump.")
+                        continue
 
                     l10n_bump_info = [l10n_bump.L10nBumpInfo.from_payload_data(lbi) for lbi in payload["l10n_bump_info"]]
                     l10n_bump_actions = await l10n_bump.run(
@@ -120,6 +122,10 @@ async def async_main(context):
                     if import_action:
                         lando_actions.append(import_action)
                 elif action == "android_l10n_sync":
+                    if not is_tree_open:
+                        log.info("Treestatus is closed; skipping android l10n sync.")
+                        continue
+
                     android_l10n_sync_info = android_l10n_sync.AndroidL10nSyncInfo.from_payload_data(payload["android_l10n_sync_info"])
                     import_action = await android_l10n_sync.run(gh_client, public_artifact_dir, android_l10n_sync_info, branch)
                     if import_action:

--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -43,7 +43,7 @@ def privkey_file(datadir):
     return datadir / "test_private_key.pem"
 
 
-def setup_treestatus_response(aioresponses, context, tree="repo_name", status="open", has_err=False):
+def setup_treestatus_response(aioresponses, context, tree="repo_name", status="approval required", has_err=False):
     url = f'{context.config["treestatus_url"]}/trees/{tree}'
     if has_err:
         aioresponses.get(url, status=500)

--- a/landoscript/tests/test_l10n_bump.py
+++ b/landoscript/tests/test_l10n_bump.py
@@ -546,7 +546,7 @@ async def test_success(
         "ignore_closed_tree": ignore_closed_tree,
     }
     submit_uri, status_uri, job_id, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["l10n_bump"])
-    setup_treestatus_response(aioresponses, context)
+    setup_treestatus_response(aioresponses, context, status="open")
 
     # because the github graphql endpoint is generic we need to make sure we create
     # these responses in the correct order...

--- a/landoscript/tests/test_script.py
+++ b/landoscript/tests/test_script.py
@@ -251,6 +251,28 @@ async def test_missing_scopes(aioresponses, github_installation_responses, conte
 
 
 @pytest.mark.asyncio
+async def test_dontbuild_properly_errors(aioresponses, github_installation_responses, context):
+    payload = {"actions": ["tag"], "lando_repo": "repo_name", "tags": ["FIREFOX_139_0_RELEASE"], "dontbuild": True}
+    await run_test(
+        aioresponses, github_installation_responses, context, payload, ["tag"], err=TaskVerificationError, errmsg="dontbuild is only respected in l10n_bump"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ignore_closed_tree_properly_errors(aioresponses, github_installation_responses, context):
+    payload = {"actions": ["tag"], "lando_repo": "repo_name", "tags": ["FIREFOX_139_0_RELEASE"], "ignore_closed_tree": True}
+    await run_test(
+        aioresponses,
+        github_installation_responses,
+        context,
+        payload,
+        ["tag"],
+        err=TaskVerificationError,
+        errmsg="ignore_closed_tree is only respected in l10n_bump and android_l10n_sync",
+    )
+
+
+@pytest.mark.asyncio
 async def test_failure_to_submit_to_lando_500(aioresponses, github_installation_responses, context):
     payload = {
         "actions": ["version_bump"],


### PR DESCRIPTION
I originally thought this was only used for l10n-bump, but it turns out we need to check treestatus for android l10n sync tasks as well.