### PR TITLE
fix(scriptworker_client): make prefix correct for recursive get_file_listings queries

### DIFF
--- a/scriptworker_client/src/scriptworker_client/github_client.py
+++ b/scriptworker_client/src/scriptworker_client/github_client.py
@@ -241,20 +241,12 @@ class GithubClient:
 
         # Process the returing entries
         entries = resp["repository"]["object"].get("entries")
-        files, refetches = self._process_file_listings(entries)
+        files, refetches = self._process_file_listings(entries, prefix=Path(path))
         # Any subtrees that were not fully traversed will be returned in `refetches`
         # We need to refetch data starting at each of these subtrees to ensure we
         # don't miss anything.
         for refetch in refetches:
-            for deep_file in await self.get_file_listing(str(refetch), branch, depth_per_query):
-                # Any files returned be a nested call need to have some path munging done.
-
-                # First we strip off the last part of the subtree we're fetching because
-                # it will already be included in the files returned.
-                prefix = str(refetch.parent)
-                # Then we combine the proper prefix with each returned file, giving us
-                # the full path to the file from the root of the repository.
-                files.append(f"{prefix}/{deep_file}")
+            files.extend(await self.get_file_listing(str(refetch), branch, depth_per_query))
 
         return files
 

--- a/scriptworker_client/tests/test_github_client.py
+++ b/scriptworker_client/tests/test_github_client.py
@@ -291,17 +291,7 @@ async def test_get_repository_files(aioresponses, github_client):
         payload={
             "data": {
                 "repository": {
-                    "object": {
-                        "entries": [
-                            {
-                                "name": "d",
-                                "type": "tree",
-                                "object": {
-                                    "entries": [{"name": "e", "type": "tree", "object": {"entries": [{"name": "deepfile1", "type": "blob", "object": {}}]}}]
-                                },
-                            }
-                        ]
-                    }
+                    "object": {"entries": [{"name": "e", "type": "tree", "object": {"entries": [{"name": "deepfile1", "type": "blob", "object": {}}]}}]}
                 }
             }
         },
@@ -423,25 +413,9 @@ async def test_get_repository_files_with_initial_subtree(aioresponses, github_cl
                     "object": {
                         "entries": [
                             {
-                                "name": "a",
-                                "type": "tree",
-                                "object": {
-                                    "entries": [
-                                        {
-                                            "name": "b",
-                                            "type": "tree",
-                                            "object": {
-                                                "entries": [
-                                                    {
-                                                        "name": "file",
-                                                        "type": "blob",
-                                                        "object": {},
-                                                    },
-                                                ],
-                                            },
-                                        },
-                                    ]
-                                },
+                                "name": "file",
+                                "type": "blob",
+                                "object": {},
                             },
                         ]
                     }


### PR DESCRIPTION
While doing some more real world testing of this code against GitHub I realized that the tests for this feature return the wrong responses when a `path` is given: they should not include leading directories in the response, only the children of the `path` given. Fixing this actually cleaned up the real code as well: as long as we path `prefix` to `_process_file_listings`, the files returned will always have the correct path, and we don't need to do any munging for the `refetches`.