### PR TITLE
feat(scriptworker_client): replace get_files sentinel values with hashes

### DIFF
--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 from yarl import URL
+from pytest_scriptworker_client import get_files_payload
 
 import pytest
 from scriptworker.context import Context
@@ -132,21 +133,6 @@ async def run_test(
             assert ("GET", status_uri) not in aioresponses.requests
 
 
-def fetch_files_payload(initial_values={}):
-    if initial_values:
-        payload = {"data": {"repository": {}}}
-
-        for file, contents in initial_values.items():
-            if contents is None:
-                payload["data"]["repository"][file] = None
-            else:
-                payload["data"]["repository"][file] = {"text": contents}
-    else:
-        payload = {}
-
-    return payload
-
-
 def setup_github_graphql_responses(aioresponses, *payloads):
     for payload in payloads:
         aioresponses.post(GITHUB_GRAPHQL_ENDPOINT, status=200, payload=payload)
@@ -207,7 +193,7 @@ def setup_l10n_file_responses(aioresponses, l10n_bump_info, initial_values, expe
 
     file_responses[l10n_bump_info["path"]] = json.dumps(changesets_data)
 
-    setup_github_graphql_responses(aioresponses, fetch_files_payload(file_responses))
+    setup_github_graphql_responses(aioresponses, get_files_payload(file_responses))
 
 
 def assert_lando_submission_response(requests, submit_uri, attempts=1):

--- a/landoscript/tests/test_android_l10n_import.py
+++ b/landoscript/tests/test_android_l10n_import.py
@@ -1,5 +1,6 @@
 import pytest
 from yarl import URL
+from pytest_scriptworker_client import get_files_payload
 
 from landoscript.errors import LandoscriptError
 from landoscript.script import async_main
@@ -7,7 +8,6 @@ from tests.conftest import (
     assert_add_commit_response,
     assert_lando_submission_response,
     assert_status_response,
-    fetch_files_payload,
     get_file_listing_payload,
     setup_github_graphql_responses,
 )
@@ -263,7 +263,7 @@ async def test_success(
     setup_github_graphql_responses(
         aioresponses,
         # toml files needed before fetching anything else
-        fetch_files_payload(
+        get_files_payload(
             {
                 "mozilla-mobile/fenix/l10n.toml": fenix_l10n_toml,
                 "mozilla-mobile/focus-android/l10n.toml": focus_l10n_toml,
@@ -274,7 +274,7 @@ async def test_success(
         # android-components l10n.toml
         get_file_listing_payload(file_listing_files),
         # string values in the android l10n repository
-        fetch_files_payload(android_l10n_values),
+        get_files_payload(android_l10n_values),
     )
 
     aioresponses.get(
@@ -289,7 +289,7 @@ async def test_success(
 
     github_installation_responses(owner)
     # current string values in the destination repository
-    setup_github_graphql_responses(aioresponses, fetch_files_payload(initial_values))
+    setup_github_graphql_responses(aioresponses, get_files_payload(initial_values))
 
     aioresponses.post(submit_uri, status=202, payload={"job_id": job_id, "status_url": str(status_uri), "message": "foo", "started_at": "2025-03-08T12:25:00Z"})
 
@@ -358,7 +358,7 @@ async def test_missing_toml_file(aioresponses, github_installation_responses, co
     setup_github_graphql_responses(
         aioresponses,
         # toml files needed before fetching anything else
-        fetch_files_payload(
+        get_files_payload(
             {
                 "mozilla-mobile/fenix/l10n.toml": None,
                 "mozilla-mobile/focus-android/l10n.toml": focus_l10n_toml,

--- a/landoscript/tests/test_android_l10n_sync.py
+++ b/landoscript/tests/test_android_l10n_sync.py
@@ -1,5 +1,6 @@
 import pytest
 from scriptworker_client.github_client import TransportQueryError
+from pytest_scriptworker_client import get_files_payload
 
 from landoscript.errors import LandoscriptError
 from tests.conftest import (
@@ -7,7 +8,6 @@ from tests.conftest import (
     get_file_listing_payload,
     run_test,
     setup_github_graphql_responses,
-    fetch_files_payload,
 )
 
 ac_l10n_toml = """
@@ -221,7 +221,7 @@ async def test_success(
     setup_github_graphql_responses(
         aioresponses,
         # toml files needed before fetching anything else
-        fetch_files_payload(
+        get_files_payload(
             {
                 "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
                 "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
@@ -232,9 +232,9 @@ async def test_success(
         # android-components l10n.toml
         get_file_listing_payload(file_listing_files),
         # string values in the android l10n repository
-        fetch_files_payload(android_l10n_values),
+        get_files_payload(android_l10n_values),
         # current string values in the destination repository
-        fetch_files_payload(initial_values),
+        get_files_payload(initial_values),
     )
 
     def assert_func(req):
@@ -273,7 +273,7 @@ async def test_missing_toml_file(aioresponses, github_installation_responses, co
     setup_github_graphql_responses(
         aioresponses,
         # toml files needed before fetching anything else
-        fetch_files_payload(
+        get_files_payload(
             {
                 "mobile/android/fenix/l10n.toml": None,
                 "mobile/android/focus-android/l10n.toml": focus_l10n_toml,

--- a/landoscript/tests/test_merge_day.py
+++ b/landoscript/tests/test_merge_day.py
@@ -1,9 +1,10 @@
 from collections import defaultdict
 import pytest
+from pytest_scriptworker_client import get_files_payload
 
 from landoscript.script import async_main
 
-from .conftest import fetch_files_payload, run_test, assert_merge_response, setup_github_graphql_responses
+from .conftest import run_test, assert_merge_response, setup_github_graphql_responses
 
 
 @pytest.mark.asyncio
@@ -153,13 +154,13 @@ async def test_success_bump_main(
     setup_github_graphql_responses(
         aioresponses,
         # existing version in `to_branch`
-        fetch_files_payload({merge_info["fetch_version_from"]: "137.0a1"}),
+        get_files_payload({merge_info["fetch_version_from"]: "137.0a1"}),
         # fetch of original contents of files to bump, if we expect any replacements
-        fetch_files_payload(initial_values if expected_bumps else {}),
+        get_files_payload(initial_values if expected_bumps else {}),
         # fetch of original contents of `replacements` and `regex_replacements` files
-        fetch_files_payload(initial_replacement_values if expected_replacement_bumps else {}),
+        get_files_payload(initial_replacement_values if expected_replacement_bumps else {}),
         # clobber file
-        fetch_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
+        get_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
     )
 
     def assert_func(req):
@@ -215,11 +216,11 @@ async def test_success_bump_esr(aioresponses, github_installation_responses, con
     setup_github_graphql_responses(
         aioresponses,
         # existing version in `to_branch`
-        fetch_files_payload({merge_info["fetch_version_from"]: "128.9.0"}),
+        get_files_payload({merge_info["fetch_version_from"]: "128.9.0"}),
         # fetch of original contents of files to bump
-        *[fetch_files_payload(iv) for iv in initial_values_by_expected_version.values()],
+        *[get_files_payload(iv) for iv in initial_values_by_expected_version.values()],
         # clobber file
-        fetch_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
+        get_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
     )
 
     def assert_func(req):
@@ -263,11 +264,11 @@ async def test_success_early_to_late_beta(aioresponses, github_installation_resp
         aioresponses,
         # initial version fetch; technically not needed for this use case
         # but it keeps the merge day code cleaner to keep it
-        fetch_files_payload({merge_info["fetch_version_from"]: "139.0"}),
+        get_files_payload({merge_info["fetch_version_from"]: "139.0"}),
         # fetch of original contents of `replacements` file
-        fetch_files_payload(initial_replacement_values),
+        get_files_payload(initial_replacement_values),
         # clobber file
-        fetch_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
+        get_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
     )
 
     def assert_func(req):
@@ -370,15 +371,15 @@ async def test_success_main_to_beta(aioresponses, github_installation_responses,
     setup_github_graphql_responses(
         aioresponses,
         # existing version in `to_branch`
-        fetch_files_payload({merge_info["fetch_version_from"]: "139.0b11"}),
+        get_files_payload({merge_info["fetch_version_from"]: "139.0b11"}),
         # existing version in `from_branch`
-        fetch_files_payload({merge_info["fetch_version_from"]: "140.0a1"}),
+        get_files_payload({merge_info["fetch_version_from"]: "140.0a1"}),
         # fetch of original contents of files to bump
-        *[fetch_files_payload(iv) for iv in initial_values_by_expected_version.values()],
+        *[get_files_payload(iv) for iv in initial_values_by_expected_version.values()],
         # fetch of original contents of `replacements` and `regex_replacements` files
-        fetch_files_payload(initial_replacement_values),
+        get_files_payload(initial_replacement_values),
         # clobber file
-        fetch_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
+        get_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
     )
 
     def assert_func(req):
@@ -416,7 +417,6 @@ async def test_success_beta_to_release(aioresponses, github_installation_respons
     # despite it looking weird, these beta looking versions _are_ the correct
     # "before" versions after we've "merged" the beta branch into release
     initial_values = {
-        "browser/config/version.txt": "136.0",
         "browser/config/version_display.txt": "136.0b11",
         "mobile/android/version.txt": "136.0b11",
     }
@@ -444,15 +444,15 @@ async def test_success_beta_to_release(aioresponses, github_installation_respons
     setup_github_graphql_responses(
         aioresponses,
         # existing version in `to_branch`
-        fetch_files_payload({merge_info["fetch_version_from"]: "135.0"}),
+        get_files_payload({merge_info["fetch_version_from"]: "135.0"}),
         # existing version in `from_branch`
-        fetch_files_payload({merge_info["fetch_version_from"]: "136.0"}),
+        get_files_payload({merge_info["fetch_version_from"]: "136.0"}),
         # fetch of original contents of files to bump, if we expect any replacements
-        fetch_files_payload(initial_values),
+        get_files_payload(initial_values),
         # fetch of original contents of `replacements` and `regex_replacements` files
-        fetch_files_payload(initial_replacement_values),
+        get_files_payload(initial_replacement_values),
         # clobber file
-        fetch_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
+        get_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
     )
 
     def assert_func(req):
@@ -510,13 +510,13 @@ async def test_success_release_to_esr(aioresponses, github_installation_response
     setup_github_graphql_responses(
         aioresponses,
         # existing version in `to_branch`
-        fetch_files_payload({merge_info["fetch_version_from"]: "128.0"}),
+        get_files_payload({merge_info["fetch_version_from"]: "128.0"}),
         # fetch of original contents of files to bump, if we expect any replacements
-        fetch_files_payload(initial_values if expected_bumps else {}),
+        get_files_payload(initial_values if expected_bumps else {}),
         # fetch of original contents of `replacements` and `regex_replacements` files
-        fetch_files_payload(initial_replacement_values),
+        get_files_payload(initial_replacement_values),
         # clobber file
-        fetch_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
+        get_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
     )
 
     def assert_func(req):

--- a/landoscript/tests/test_script.py
+++ b/landoscript/tests/test_script.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import pytest
 from scriptworker.client import TaskVerificationError
 from simple_github.client import GITHUB_GRAPHQL_ENDPOINT
+from pytest_scriptworker_client import get_files_payload
 
 from landoscript.errors import LandoscriptError
 from landoscript.script import async_main
@@ -10,7 +11,6 @@ from .conftest import (
     assert_l10n_bump_response,
     assert_lando_submission_response,
     assert_status_response,
-    fetch_files_payload,
     run_test,
     setup_github_graphql_responses,
     setup_test,
@@ -81,7 +81,7 @@ def assert_success(req, commit_msg_strings, initial_values, expected_bumps):
     ),
 )
 async def test_tag_and_bump(aioresponses, github_installation_responses, context, payload, dry_run, initial_values, expected_bumps, commit_msg_strings, tags):
-    setup_github_graphql_responses(aioresponses, fetch_files_payload(initial_values))
+    setup_github_graphql_responses(aioresponses, get_files_payload(initial_values))
 
     def assert_func(req):
         assert_success(req, commit_msg_strings, initial_values, expected_bumps)
@@ -146,7 +146,7 @@ async def test_tag_and_bump(aioresponses, github_installation_responses, context
 )
 async def test_success_with_retries(aioresponses, github_installation_responses, context, payload, initial_values, expected_bumps, commit_msg_strings):
     submit_uri, status_uri, job_id, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["version_bump"])
-    setup_github_graphql_responses(aioresponses, fetch_files_payload(initial_values))
+    setup_github_graphql_responses(aioresponses, get_files_payload(initial_values))
 
     aioresponses.post(submit_uri, status=500)
     aioresponses.post(submit_uri, status=202, payload={"job_id": job_id, "status_url": str(status_uri), "message": "foo", "started_at": "2025-03-08T12:25:00Z"})
@@ -262,7 +262,7 @@ async def test_failure_to_submit_to_lando_500(aioresponses, github_installation_
     }
     initial_values = {"browser/config/version.txt": "134.0"}
     submit_uri, _, _, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["version_bump"])
-    setup_github_graphql_responses(aioresponses, fetch_files_payload(initial_values))
+    setup_github_graphql_responses(aioresponses, get_files_payload(initial_values))
 
     for _ in range(10):
         aioresponses.post(submit_uri, status=500)
@@ -288,7 +288,7 @@ async def test_to_submit_to_lando_no_status_url(aioresponses, github_installatio
     }
     initial_values = {"browser/config/version.txt": "134.0"}
     submit_uri, _, _, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["version_bump"])
-    setup_github_graphql_responses(aioresponses, fetch_files_payload(initial_values))
+    setup_github_graphql_responses(aioresponses, get_files_payload(initial_values))
     aioresponses.post(submit_uri, status=202, payload={})
 
     context.task = {"payload": payload, "scopes": scopes}
@@ -312,7 +312,7 @@ async def test_lando_polling_result_not_correct(aioresponses, github_installatio
     }
     initial_values = {"browser/config/version.txt": "134.0"}
     submit_uri, status_uri, job_id, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["version_bump"])
-    setup_github_graphql_responses(aioresponses, fetch_files_payload(initial_values))
+    setup_github_graphql_responses(aioresponses, get_files_payload(initial_values))
     aioresponses.post(submit_uri, status=202, payload={"job_id": job_id, "status_url": str(status_uri), "message": "foo", "started_at": "2025-03-08T12:25:00Z"})
     aioresponses.get(status_uri, status=200, payload={})
 
@@ -337,7 +337,7 @@ async def test_lando_polling_retry_on_failure(aioresponses, github_installation_
     }
     initial_values = {"browser/config/version.txt": "134.0"}
     submit_uri, status_uri, job_id, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["version_bump"])
-    setup_github_graphql_responses(aioresponses, fetch_files_payload(initial_values))
+    setup_github_graphql_responses(aioresponses, get_files_payload(initial_values))
     aioresponses.post(submit_uri, status=202, payload={"job_id": job_id, "status_url": str(status_uri), "message": "foo", "started_at": "2025-03-08T12:25:00Z"})
     aioresponses.get(status_uri, status=500, payload={})
     aioresponses.get(
@@ -499,15 +499,15 @@ async def test_success_main_to_beta_merge_day(aioresponses, github_installation_
     setup_github_graphql_responses(
         aioresponses,
         # existing version in `to_branch`
-        fetch_files_payload({merge_info["fetch_version_from"]: "139.0b11"}),
+        get_files_payload({merge_info["fetch_version_from"]: "139.0b11"}),
         # existing version in `from_branch`
-        fetch_files_payload({merge_info["fetch_version_from"]: "140.0a1"}),
+        get_files_payload({merge_info["fetch_version_from"]: "140.0a1"}),
         # fetch of original contents of files to bump
-        *[fetch_files_payload(iv) for iv in initial_values_by_expected_version.values()],
+        *[get_files_payload(iv) for iv in initial_values_by_expected_version.values()],
         # fetch of original contents of `replacements` and `regex_replacements` files
-        fetch_files_payload(initial_replacement_values),
+        get_files_payload(initial_replacement_values),
         # clobber file
-        fetch_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
+        get_files_payload({"CLOBBER": "# Modifying this file will automatically clobber\nMerge day clobber 2025-03-03"}),
     )
 
     aioresponses.post(submit_uri, status=202, payload={"job_id": job_id, "status_url": str(status_uri), "message": "foo", "started_at": "2025-03-08T12:25:00Z"})

--- a/landoscript/tests/test_version_bump.py
+++ b/landoscript/tests/test_version_bump.py
@@ -1,6 +1,7 @@
 import pytest
 from scriptworker.client import TaskVerificationError
 from simple_github.client import GITHUB_GRAPHQL_ENDPOINT
+from pytest_scriptworker_client import get_files_payload
 
 from landoscript.errors import LandoscriptError
 from landoscript.script import async_main
@@ -10,7 +11,6 @@ from landoscript.util.version import _VERSION_CLASS_PER_BEGINNING_OF_PATH
 from .conftest import (
     assert_lando_submission_response,
     assert_status_response,
-    fetch_files_payload,
     run_test,
     setup_github_graphql_responses,
     setup_test,
@@ -218,7 +218,7 @@ def assert_success(req, commit_msg_strings, initial_values, expected_bumps):
     ),
 )
 async def test_success_with_bumps(aioresponses, github_installation_responses, context, payload, initial_values, expected_bumps, commit_msg_strings):
-    setup_github_graphql_responses(aioresponses, fetch_files_payload(initial_values))
+    setup_github_graphql_responses(aioresponses, get_files_payload(initial_values))
     dryrun = payload.get("dry_run", False)
 
     def assert_func(req):
@@ -282,7 +282,7 @@ async def test_success_with_bumps(aioresponses, github_installation_responses, c
 )
 async def test_success_with_retries(aioresponses, github_installation_responses, context, payload, initial_values, expected_bumps, commit_msg_strings):
     submit_uri, status_uri, job_id, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["version_bump"])
-    setup_github_graphql_responses(aioresponses, fetch_files_payload(initial_values))
+    setup_github_graphql_responses(aioresponses, get_files_payload(initial_values))
 
     aioresponses.post(submit_uri, status=500)
     aioresponses.post(submit_uri, status=202, payload={"job_id": job_id, "status_url": str(status_uri), "message": "foo", "started_at": "2025-03-08T12:25:00Z"})
@@ -329,7 +329,7 @@ async def test_success_with_retries(aioresponses, github_installation_responses,
 )
 async def test_success_without_bumps(aioresponses, github_installation_responses, context, payload, initial_values):
     submit_uri, status_uri, _, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["version_bump"])
-    setup_github_graphql_responses(aioresponses, fetch_files_payload(initial_values))
+    setup_github_graphql_responses(aioresponses, get_files_payload(initial_values))
 
     context.task = {"payload": payload, "scopes": scopes}
     await async_main(context)

--- a/scriptworker_client/packages/pytest-scriptworker-client/src/pytest_scriptworker_client/__init__.py
+++ b/scriptworker_client/packages/pytest-scriptworker-client/src/pytest_scriptworker_client/__init__.py
@@ -1,3 +1,4 @@
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -48,3 +49,19 @@ def github_installation_responses(aioresponses):
         )
 
     return inner
+
+
+def get_files_payload(file_contents={}):
+    if file_contents:
+        payload = {"data": {"repository": {}}}
+
+        for file, contents in file_contents.items():
+            hash_ = "a" + hashlib.md5(file.encode()).hexdigest()
+            if contents is None:
+                payload["data"]["repository"][hash_] = None
+            else:
+                payload["data"]["repository"][hash_] = {"text": contents}
+    else:
+        payload = {}
+
+    return payload

--- a/treescript/tests/test_github_versionmanip.py
+++ b/treescript/tests/test_github_versionmanip.py
@@ -3,6 +3,7 @@ import base64
 import pytest
 from simple_github.client import GITHUB_GRAPHQL_ENDPOINT
 from yarl import URL
+from pytest_scriptworker_client import get_files_payload
 
 from treescript.github import versionmanip as vmanip
 
@@ -25,7 +26,7 @@ async def test_bump_version_mobile(aioresponses, github_client):
     }
 
     # First query is to get the contents of 'version.txt'
-    aioresponses.post(GITHUB_GRAPHQL_ENDPOINT, status=200, payload={"data": {"repository": {"version.txt": {"text": "109.1.0"}}}})
+    aioresponses.post(GITHUB_GRAPHQL_ENDPOINT, status=200, payload=get_files_payload({"version.txt": "109.1.0"}))
     # Second query is to get the head_rev
     aioresponses.post(GITHUB_GRAPHQL_ENDPOINT, status=200, payload={"data": {"repository": {"object": {"oid": head_rev}}}})
     # Third query is to commit


### PR DESCRIPTION
The sentinel values quickly run afoul of the maximum key length of 320 characters for longer file/path names.