### PR TITLE
fix(scriptworker_client): make prefix correct for recursive get_file_listings queries

### DIFF
--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -138,35 +138,6 @@ def setup_github_graphql_responses(aioresponses, *payloads):
         aioresponses.post(GITHUB_GRAPHQL_ENDPOINT, status=200, payload=payload)
 
 
-def get_file_listing_payload(paths):
-    def make_entry(path):
-        parts = path.split("/", 1)
-        type_ = "blob" if len(parts) == 1 else "tree"
-        obj = {}
-        if type_ == "tree":
-            # Note: this does not handle multiple files in the same directory
-            # properly (we'll only end up with an entry for the last file seen).
-            # This is being ignored to avoid complicating this code until
-            # an actual use case for it comes up.
-            obj["entries"] = [make_entry(parts[1])]
-        return {
-            "name": parts[0],
-            "type": type_,
-            "object": obj,
-        }
-
-    entries = [make_entry(path) for path in paths]
-    return {
-        "data": {
-            "repository": {
-                "object": {
-                    "entries": entries,
-                }
-            }
-        }
-    }
-
-
 def setup_l10n_file_responses(aioresponses, l10n_bump_info, initial_values, expected_locales):
     file_responses = {}
     name = l10n_bump_info["name"]

--- a/landoscript/tests/test_android_l10n_sync.py
+++ b/landoscript/tests/test_android_l10n_sync.py
@@ -5,7 +5,6 @@ from pytest_scriptworker_client import get_files_payload
 from landoscript.errors import LandoscriptError
 from tests.conftest import (
     assert_add_commit_response,
-    get_file_listing_payload,
     run_test,
     setup_github_graphql_responses,
 )
@@ -65,7 +64,7 @@ def assert_success(req, initial_values, expected_bumps):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "android_l10n_sync_info,android_l10n_values,file_listing_files,initial_values,expected_values",
+    "android_l10n_sync_info,android_l10n_values,initial_values,expected_values",
     (
         pytest.param(
             {
@@ -87,9 +86,6 @@ def assert_success(req, initial_values, expected_bumps):
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam expected contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab expected contents",
             },
-            [
-                "mobile/android/android-components/components/browser/toolbar/src/main/res/values/strings.xml",
-            ],
             {
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
@@ -122,9 +118,6 @@ def assert_success(req, initial_values, expected_bumps):
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam expected contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab expected contents",
             },
-            [
-                "mobile/android/android-components/components/browser/toolbar/src/main/res/values/strings.xml",
-            ],
             {
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": None,
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": None,
@@ -157,9 +150,6 @@ def assert_success(req, initial_values, expected_bumps):
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": None,
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": None,
             },
-            [
-                "mobile/android/android-components/components/browser/toolbar/src/main/res/values/strings.xml",
-            ],
             {
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
@@ -192,9 +182,6 @@ def assert_success(req, initial_values, expected_bumps):
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
             },
-            [
-                "mobile/android/android-components/components/browser/toolbar/src/main/res/values/strings.xml",
-            ],
             {
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
@@ -209,14 +196,92 @@ def assert_success(req, initial_values, expected_bumps):
         ),
     ),
 )
-async def test_success(
-    aioresponses, github_installation_responses, context, android_l10n_sync_info, android_l10n_values, file_listing_files, initial_values, expected_values
-):
+async def test_success(aioresponses, github_installation_responses, context, android_l10n_sync_info, android_l10n_values, initial_values, expected_values):
     payload = {
         "actions": ["android_l10n_sync"],
         "lando_repo": "repo_name",
         "android_l10n_sync_info": android_l10n_sync_info,
     }
+
+    file_listing_payloads = [
+        {
+            "data": {
+                "repository": {
+                    "object": {
+                        "entries": [
+                            {
+                                "name": "components",
+                                "type": "tree",
+                                "object": {
+                                    "entries": [
+                                        {
+                                            "name": "browser",
+                                            "type": "tree",
+                                            "object": {
+                                                "entries": [
+                                                    {
+                                                        "name": "toolbar",
+                                                        "type": "tree",
+                                                        "object": {
+                                                            "entries": [
+                                                                {
+                                                                    "name": "src",
+                                                                    "type": "tree",
+                                                                }
+                                                            ],
+                                                        },
+                                                    }
+                                                ],
+                                            },
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                    }
+                },
+            },
+        },
+        {
+            "data": {
+                "repository": {
+                    "object": {
+                        "entries": [
+                            {
+                                "name": "main",
+                                "type": "tree",
+                                "object": {
+                                    "entries": [
+                                        {
+                                            "name": "res",
+                                            "type": "tree",
+                                            "object": {
+                                                "entries": [
+                                                    {
+                                                        "name": "values",
+                                                        "type": "tree",
+                                                        "object": {
+                                                            "entries": [
+                                                                {
+                                                                    "name": "strings.xml",
+                                                                    "type": "blob",
+                                                                    "object": {},
+                                                                }
+                                                            ]
+                                                        },
+                                                    }
+                                                ],
+                                            },
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                    }
+                },
+            },
+        },
+    ]
 
     setup_github_graphql_responses(
         aioresponses,
@@ -230,7 +295,7 @@ async def test_success(
         ),
         # directory tree information needed to correctly interpret the
         # android-components l10n.toml
-        get_file_listing_payload(file_listing_files),
+        *file_listing_payloads,
         # string values in the android l10n repository
         get_files_payload(android_l10n_values),
         # current string values in the destination repository

--- a/scriptworker_client/src/scriptworker_client/github_client.py
+++ b/scriptworker_client/src/scriptworker_client/github_client.py
@@ -252,20 +252,12 @@ class GithubClient:
 
         # Process the returing entries
         entries = resp["repository"]["object"].get("entries")
-        files, refetches = self._process_file_listings(entries)
+        files, refetches = self._process_file_listings(entries, prefix=Path(path))
         # Any subtrees that were not fully traversed will be returned in `refetches`
         # We need to refetch data starting at each of these subtrees to ensure we
         # don't miss anything.
         for refetch in refetches:
-            for deep_file in await self.get_file_listing(str(refetch), branch, depth_per_query):
-                # Any files returned be a nested call need to have some path munging done.
-
-                # First we strip off the last part of the subtree we're fetching because
-                # it will already be included in the files returned.
-                prefix = str(refetch.parent)
-                # Then we combine the proper prefix with each returned file, giving us
-                # the full path to the file from the root of the repository.
-                files.append(f"{prefix}/{deep_file}")
+            files.extend(await self.get_file_listing(str(refetch), branch, depth_per_query))
 
         return files
 

--- a/scriptworker_client/tests/test_github_client.py
+++ b/scriptworker_client/tests/test_github_client.py
@@ -301,17 +301,7 @@ async def test_get_repository_files(aioresponses, github_client):
         payload={
             "data": {
                 "repository": {
-                    "object": {
-                        "entries": [
-                            {
-                                "name": "d",
-                                "type": "tree",
-                                "object": {
-                                    "entries": [{"name": "e", "type": "tree", "object": {"entries": [{"name": "deepfile1", "type": "blob", "object": {}}]}}]
-                                },
-                            }
-                        ]
-                    }
+                    "object": {"entries": [{"name": "e", "type": "tree", "object": {"entries": [{"name": "deepfile1", "type": "blob", "object": {}}]}}]}
                 }
             }
         },
@@ -420,7 +410,7 @@ async def test_get_repository_files(aioresponses, github_client):
 async def test_get_repository_files_with_initial_subtree(aioresponses, github_client):
     branch = "main"
     expected = [
-        "a/b/file",
+        "a/b/c/d/e/deepfile1",
     ]
 
     # we expect more than one request because of the deeply nested file
@@ -433,22 +423,13 @@ async def test_get_repository_files_with_initial_subtree(aioresponses, github_cl
                     "object": {
                         "entries": [
                             {
-                                "name": "a",
+                                "name": "d",
                                 "type": "tree",
                                 "object": {
                                     "entries": [
                                         {
-                                            "name": "b",
+                                            "name": "e",
                                             "type": "tree",
-                                            "object": {
-                                                "entries": [
-                                                    {
-                                                        "name": "file",
-                                                        "type": "blob",
-                                                        "object": {},
-                                                    },
-                                                ],
-                                            },
                                         },
                                     ]
                                 },
@@ -459,14 +440,34 @@ async def test_get_repository_files_with_initial_subtree(aioresponses, github_cl
             }
         },
     )
+    aioresponses.post(
+        GITHUB_GRAPHQL_ENDPOINT,
+        status=200,
+        payload={
+            "data": {
+                "repository": {
+                    "object": {
+                        "entries": [
+                            {
+                                "name": "deepfile1",
+                                "type": "blob",
+                                "object": {}
+                            },
+                        ]
+                    }
+                }
+            }
+        },
+    )
 
-    result = await github_client.get_file_listing("a/b", branch=branch, depth_per_query=4)
+    result = await github_client.get_file_listing("a/b/c", branch=branch, depth_per_query=2)
     assert result == expected
 
     aioresponses.assert_called()
 
     key = ("POST", URL(GITHUB_GRAPHQL_ENDPOINT))
-    first_request = aioresponses.requests[key][-1][1]["json"]
+    first_request = aioresponses.requests[key][-2][1]["json"]
+    second_request = aioresponses.requests[key][-1][1]["json"]
 
     assert first_request == {
         "query": Template(
@@ -474,7 +475,7 @@ async def test_get_repository_files_with_initial_subtree(aioresponses, github_cl
                 f"""
             query RepoFiles {{
               repository(owner: "$owner", name: "$repo") {{
-                object(expression: "main:a/b") {{
+                object(expression: "main:a/b/c") {{
                   ... on Tree {{
                     entries {{
                       name
@@ -484,22 +485,34 @@ async def test_get_repository_files_with_initial_subtree(aioresponses, github_cl
                           entries {{
                             name
                             type
-                            object {{
-                              ... on Tree {{
-                                entries {{
-                                  name
-                                  type
-                                  object {{
-                                    ... on Tree {{
-                                      entries {{
-                                        name
-                                        type
-                                      }}
-                                    }}
-                                  }}
-                                }}
-                              }}
-                            }}
+                          }}
+                        }}
+                      }}
+                    }}
+                  }}
+                }}
+              }}
+            }}
+            """
+            ).strip(),
+        ).substitute(owner=github_client.owner, repo=github_client.repo)
+    }
+    assert second_request == {
+        "query": Template(
+            dedent(
+                f"""
+            query RepoFiles {{
+              repository(owner: "$owner", name: "$repo") {{
+                object(expression: "main:a/b/c/d/e") {{
+                  ... on Tree {{
+                    entries {{
+                      name
+                      type
+                      object {{
+                        ... on Tree {{
+                          entries {{
+                            name
+                            type
                           }}
                         }}
                       }}

--- a/scriptworker_client/tests/test_github_client.py
+++ b/scriptworker_client/tests/test_github_client.py
@@ -448,11 +448,7 @@ async def test_get_repository_files_with_initial_subtree(aioresponses, github_cl
                 "repository": {
                     "object": {
                         "entries": [
-                            {
-                                "name": "deepfile1",
-                                "type": "blob",
-                                "object": {}
-                            },
+                            {"name": "deepfile1", "type": "blob", "object": {}},
                         ]
                     }
                 }


### PR DESCRIPTION
The `get_file_listing` code here is identical to that in #1170, but the tests for it have been improved, and the landoscript tests have had some necessary adjustments made to them.