### PR TITLE
fix(landoscript): ensure esr bumps use `esr` suffix where appropriate

### DIFF
--- a/landoscript/src/landoscript/actions/merge_day.py
+++ b/landoscript/src/landoscript/actions/merge_day.py
@@ -135,6 +135,7 @@ async def run(github_client: GithubClient, public_artifact_dir: str, merge_info:
                 bump_branch,
                 version_bump_infos,
                 dontbuild=False,
+                munge_next_version=False,
             )
         )
 

--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -201,6 +201,11 @@ def assert_add_commit_response(action, commit_msg_strings, initial_values, expec
 
     # ensure expected bumps are present to a reasonable degree of certainty
     for file, after in expected_bumps.items():
+        # if present, ensure `after` has a newline in it. even if it the last
+        # line of a file without a newline character, there will still be
+        # a newline in the diff (followed by the "no newline" escape sequence)
+        if after:
+            after = after.rstrip("\n") + "\n"
         for diff in diffs:
             # if the version is the last line in the file it may or may not
             # have a trailing newline. either way, there will be one (and

--- a/landoscript/tests/test_version_bump.py
+++ b/landoscript/tests/test_version_bump.py
@@ -128,36 +128,20 @@ def assert_success(req, commit_msg_strings, initial_values, expected_bumps):
                 "actions": ["version_bump"],
                 "lando_repo": "repo_name",
                 "version_bump_info": {
-                    "files": ["browser/config/version.txt"],
+                    "files": ["browser/config/version.txt", "browser/config/version_display.txt"],
                     "next_version": "128.2.1esr",
                 },
             },
             {
                 "browser/config/version.txt": "128.2.0",
-            },
-            {
-                "browser/config/version.txt": "128.2.1",
-            },
-            ["Automatic version bump", "NO BUG", "a=release", "CLOSED TREE", "DONTBUILD"],
-            id="esr_bump",
-        ),
-        pytest.param(
-            {
-                "actions": ["version_bump"],
-                "lando_repo": "repo_name",
-                "version_bump_info": {
-                    "files": ["browser/config/version_display.txt"],
-                    "next_version": "128.2.1esr",
-                },
-            },
-            {
                 "browser/config/version_display.txt": "128.2.0esr",
             },
             {
+                "browser/config/version.txt": "128.2.1",
                 "browser/config/version_display.txt": "128.2.1esr",
             },
             ["Automatic version bump", "NO BUG", "a=release", "CLOSED TREE", "DONTBUILD"],
-            id="esr_bump_display",
+            id="esr_bump",
         ),
         pytest.param(
             {


### PR DESCRIPTION
While inspecting some diffs that were spat out in dry run mode, I noticed that `browser/config/version.txt` ended up with an `esr` suffix on it when running `release-to-esr` merge-automation for esr128. As it turns out, this was happening in tests as well, but masked by an incomplete assertion (now fixed).
    
The fix I've implementing here is not great: it's a flag that only really affects anything for the `release-to-esr` merge automation case, but it's the best I could come up with for now. One would think it would be preferable to drop the esr logic in `get_cur_and_next_version` - which indeed fixes this problem, but it it ends up causing issues with the regular `version-bump` on esr: we end up with an esr-suffixed version in `version.txt`, because there's no per-file granularity in the `version_bump` action -- all files take the same version number. (To be quite honest - I think this is a problem in treescript as well, and it's avoided because we always end up in the "Version bumping skipped due to conflicting values" code path: https://github.com/mozilla-releng/scriptworker-scripts/blob/419abe11d20ca5c5a123aaaa5d010f428dff9ca4/treescript/src/treescript/gecko/versionmanip.py#L164C26-L164C75, and end up bumping the version through the `bump-esr` merge automation instead -- but I didn't want to perpepuate the problem here, in case it ends up mattering in the future.)