### PR TITLE
fix(landoscript): remove now-unnecessary TODO about authentication

### DIFF
--- a/landoscript/src/landoscript/lando.py
+++ b/landoscript/src/landoscript/lando.py
@@ -48,7 +48,6 @@ async def submit(
             kwargs={
                 "json": json,
                 "raise_for_status": True,
-                # TODO: is this a bearer token?
                 "headers": {
                     "Authorization": f"Bearer {lando_token}",
                     "User-Agent": "Lando-User/release+landoscript@mozilla.com",


### PR DESCRIPTION
I've confirmed against a real lando instance that it is indeed a Bearer token.