### PR TITLE
Split out mobile scopes for shipitscript

### DIFF
--- a/shipitscript/docker.d/init_worker.sh
+++ b/shipitscript/docker.d/init_worker.sh
@@ -11,8 +11,11 @@ test_var_set() {
 }
 
 case $COT_PRODUCT in
-  firefox|mobile)
+  firefox)
     export TASKCLUSTER_SCOPE_PREFIX="project:releng:ship-it:"
+    ;;
+  mobile)
+    export TASKCLUSTER_SCOPE_PREFIX="project:mobile:releng:ship-it:"
     ;;
   thunderbird)
     export TASKCLUSTER_SCOPE_PREFIX="project:comm:thunderbird:releng:ship-it:"


### PR DESCRIPTION
When they got added by aaee32e6b68672c5f35d910606de58e38725f84b for some reasons they didn't contain the trust-domain. However the shipit feature in fxci inserts said trust domain in the given scopes.

The firefox android project had those scopes specifically given to it, but since no one else is using shipit in the mobile trust domain atm, let's just make it be coherent with the rest.