### PR TITLE
feat(landoscript): support target revisions in tagging, and correct tag action payload

### DIFF
--- a/landoscript/src/landoscript/actions/tag.py
+++ b/landoscript/src/landoscript/actions/tag.py
@@ -1,17 +1,58 @@
-from scriptworker.client import TaskVerificationError
+from dataclasses import dataclass
 
+from aiohttp import ClientSession
+from scriptworker.client import TaskVerificationError
+from scriptworker.utils import retry_async
+
+from landoscript.errors import LandoscriptError
 from landoscript.lando import LandoAction
 
 
-def run(tags: list[str], target_revision: str | None = None) -> list[LandoAction]:
-    if len(tags) < 1:
+# We have two tag info classes to make it easy to signify whether the provided
+# revision is an hg one or a git one. At the time of writing, we use the former
+# for direct tagging tasks (such as `release-early-tagging`), and the latter
+# for merge day operations, where the task payload does not contain a revision.
+# When we switch all consumers (namely, Gecko) to firing their decision tasks
+# off of Github events, we can drop `HgTagInfo`.
+@dataclass(frozen=True)
+class HgTagInfo:
+    revision: str
+    hg_repo_url: str
+    tags: list[str]
+
+
+@dataclass(frozen=True)
+class GitTagInfo:
+    revision: str
+    tags: list[str]
+
+
+async def run(session: ClientSession, tag_info: HgTagInfo | GitTagInfo) -> list[LandoAction]:
+    if len(tag_info.tags) < 1:
         raise TaskVerificationError("must provide at least one tag!")
 
+    git_commit = None
+    if isinstance(tag_info, GitTagInfo):
+        git_commit = tag_info.revision
+    else:
+        # tag_info.revision is an hg revision; lando wants a git revision
+        resp = await retry_async(
+            session.get,
+            args=(f"{tag_info.hg_repo_url}/json-rev/{tag_info.revision}",),
+            kwargs={"raise_for_status": True},
+        )
+        hg_revision_info = await resp.json()
+        # TODO: fail if `git_commit` is None. We can only start doing this
+        # when it will be non-fatal for Try though.
+        if hg_revision_info.get("git_commit") is None:
+            raise LandoscriptError("Couldn't look up target revision for tag(s) in hg, can't proceed!")
+        git_commit = hg_revision_info["git_commit"]
+
     actions = []
-    for tag in tags:
+    for tag in tag_info.tags:
         action = {"action": "tag", "name": tag}
-        if target_revision:
-            action["target"] = target_revision
+        if git_commit:
+            action["target"] = git_commit
         actions.append(action)
 
     return actions

--- a/landoscript/src/landoscript/data/landoscript_task_schema.json
+++ b/landoscript/src/landoscript/data/landoscript_task_schema.json
@@ -140,6 +140,9 @@
                         },
                         "revision": {
                             "type": "string"
+                        },
+                        "hg_repo_url": {
+                            "type": "string"
                         }
                     },
                     "required": [

--- a/landoscript/src/landoscript/script.py
+++ b/landoscript/src/landoscript/script.py
@@ -98,10 +98,14 @@ async def async_main(context):
                     if version_bump_action:
                         lando_actions.append(version_bump_action)
                 elif action == "tag":
-                    tag_actions = tag.run(payload["tags"])
+                    if "hg_repo_url" not in payload["tag_info"]:
+                        raise TaskVerificationError("must provide hg_repo_url!")
+                    tag_actions = await tag.run(session, tag.HgTagInfo(**payload["tag_info"]))
                     lando_actions.extend(tag_actions)
                 elif action == "merge_day":
-                    merge_day_actions = await merge_day.run(gh_client, public_artifact_dir, merge_day.MergeInfo.from_payload_data(payload["merge_info"]))
+                    merge_day_actions = await merge_day.run(
+                        session, gh_client, public_artifact_dir, merge_day.MergeInfo.from_payload_data(payload["merge_info"])
+                    )
                     lando_actions.extend(merge_day_actions)
                 elif action == "l10n_bump":
                     if not is_tree_open:

--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -357,7 +357,9 @@ def assert_merge_response(
     initial_replacement_values={},
     expected_replacement_bumps={},
     end_tag="",
+    end_tag_target_ref="",
     base_tag="",
+    base_tag_target_ref="",
     target_ref="",
 ):
     actions = req.kwargs["json"]["actions"]
@@ -369,10 +371,13 @@ def assert_merge_response(
         assert len(tag_actions) == 2
         # if it exists, base tag happens second
         assert tag_actions[0]["name"] == end_tag
+        assert tag_actions[0]["target"] == end_tag_target_ref
         assert tag_actions[1]["name"] == base_tag
+        assert tag_actions[1]["target"] == base_tag_target_ref
     elif end_tag:
         assert len(tag_actions) == 1
         assert tag_actions[0]["name"] == end_tag
+        assert tag_actions[0]["target"] == end_tag_target_ref
 
     if "merge-onto" in expected_actions:
         # `merge-onto` action w/ target revision, commit message, and `ours` strategy

--- a/landoscript/tests/test_merge_day.py
+++ b/landoscript/tests/test_merge_day.py
@@ -151,10 +151,14 @@ async def test_success_bump_main(
         "dry_run": dry_run,
     }
 
+    end_tag_target_ref = "ghijkl654321"
+
     setup_github_graphql_responses(
         aioresponses,
         # existing version in `to_branch`
         get_files_payload({merge_info["fetch_version_from"]: "137.0a1"}),
+        # branch ref for `end` tag
+        {"data": {"repository": {"object": {"oid": end_tag_target_ref}}}},
         # fetch of original contents of files to bump, if we expect any replacements
         get_files_payload(initial_values if expected_bumps else {}),
         # fetch of original contents of `replacements` and `regex_replacements` files
@@ -173,6 +177,7 @@ async def test_success_bump_main(
             initial_replacement_values,
             expected_replacement_bumps,
             end_tag,
+            end_tag_target_ref,
         )
 
     await run_test(aioresponses, github_installation_responses, context, payload, ["merge_day"], not dry_run, assert_func)
@@ -356,12 +361,13 @@ async def test_success_main_to_beta(aioresponses, github_installation_responses,
     expected_actions = ["tag", "tag", "merge-onto", "create-commit", "create-commit"]
     base_tag = "FIREFOX_BETA_140_BASE"
     end_tag = "FIREFOX_BETA_139_END"
-    target_ref = "main"
     payload = {
         "actions": ["merge_day"],
         "lando_repo": "repo_name",
         "merge_info": merge_info,
     }
+    end_tag_target_ref = "ghijkl654321"
+    base_tag_target_ref = "mnopqr987654"
 
     # version bump files are fetched in groups, by initial version
     initial_values_by_expected_version = defaultdict(dict)
@@ -372,8 +378,12 @@ async def test_success_main_to_beta(aioresponses, github_installation_responses,
         aioresponses,
         # existing version in `to_branch`
         get_files_payload({merge_info["fetch_version_from"]: "139.0b11"}),
+        # branch ref for `end` tag
+        {"data": {"repository": {"object": {"oid": end_tag_target_ref}}}},
         # existing version in `from_branch`
         get_files_payload({merge_info["fetch_version_from"]: "140.0a1"}),
+        # branch ref for `base` tag
+        {"data": {"repository": {"object": {"oid": base_tag_target_ref}}}},
         # fetch of original contents of files to bump
         *[get_files_payload(iv) for iv in initial_values_by_expected_version.values()],
         # fetch of original contents of `replacements` and `regex_replacements` files
@@ -392,8 +402,10 @@ async def test_success_main_to_beta(aioresponses, github_installation_responses,
             initial_replacement_values,
             expected_replacement_values,
             end_tag,
+            end_tag_target_ref,
             base_tag,
-            target_ref,
+            base_tag_target_ref,
+            base_tag_target_ref,
         )
 
     await run_test(aioresponses, github_installation_responses, context, payload, ["merge_day"], assert_func=assert_func)
@@ -434,19 +446,24 @@ async def test_success_beta_to_release(aioresponses, github_installation_respons
     expected_actions = ["tag", "tag", "merge-onto", "create-commit", "create-commit"]
     base_tag = "FIREFOX_RELEASE_136_BASE"
     end_tag = "FIREFOX_RELEASE_135_END"
-    target_ref = "beta"
     payload = {
         "actions": ["merge_day"],
         "lando_repo": "repo_name",
         "merge_info": merge_info,
     }
+    end_tag_target_ref = "ghijkl654321"
+    base_tag_target_ref = "mnopqr987654"
 
     setup_github_graphql_responses(
         aioresponses,
         # existing version in `to_branch`
         get_files_payload({merge_info["fetch_version_from"]: "135.0"}),
+        # branch ref for `end` tag
+        {"data": {"repository": {"object": {"oid": end_tag_target_ref}}}},
         # existing version in `from_branch`
         get_files_payload({merge_info["fetch_version_from"]: "136.0"}),
+        # branch ref for `base` tag
+        {"data": {"repository": {"object": {"oid": base_tag_target_ref}}}},
         # fetch of original contents of files to bump, if we expect any replacements
         get_files_payload(initial_values),
         # fetch of original contents of `replacements` and `regex_replacements` files
@@ -465,8 +482,10 @@ async def test_success_beta_to_release(aioresponses, github_installation_respons
             initial_replacement_values,
             expected_replacement_values,
             end_tag,
+            end_tag_target_ref,
             base_tag,
-            target_ref,
+            base_tag_target_ref,
+            base_tag_target_ref,
         )
 
     await run_test(aioresponses, github_installation_responses, context, payload, ["merge_day"], assert_func=assert_func)
@@ -500,17 +519,19 @@ async def test_success_release_to_esr(aioresponses, github_installation_response
     # end tag, version bump, replacements
     expected_actions = ["tag", "create-commit", "create-commit"]
     end_tag = "FIREFOX_ESR_128_BASE"
-    target_ref = "release"
     payload = {
         "actions": ["merge_day"],
         "lando_repo": "repo_name",
         "merge_info": merge_info,
     }
+    end_tag_target_ref = "ghijkl654321"
 
     setup_github_graphql_responses(
         aioresponses,
         # existing version in `to_branch`
         get_files_payload({merge_info["fetch_version_from"]: "128.0"}),
+        # branch ref for `end` tag
+        {"data": {"repository": {"object": {"oid": end_tag_target_ref}}}},
         # fetch of original contents of files to bump, if we expect any replacements
         get_files_payload(initial_values if expected_bumps else {}),
         # fetch of original contents of `replacements` and `regex_replacements` files
@@ -529,7 +550,7 @@ async def test_success_release_to_esr(aioresponses, github_installation_response
             initial_replacement_values,
             expected_replacement_bumps,
             end_tag,
-            target_ref=target_ref,
+            end_tag_target_ref,
         )
 
     await run_test(aioresponses, github_installation_responses, context, payload, ["merge_day"], assert_func=assert_func)

--- a/landoscript/tests/test_tag.py
+++ b/landoscript/tests/test_tag.py
@@ -1,50 +1,73 @@
+from landoscript.errors import LandoscriptError
 import pytest
 from scriptworker.client import TaskVerificationError
 
 from .conftest import run_test
 
 
-def assert_tag_response(req, tags):
+def assert_tag_response(req, tag_info, target_revision):
     assert "json" in req.kwargs
     assert "actions" in req.kwargs["json"]
     tag_actions = [action for action in req.kwargs["json"]["actions"] if action["action"] == "tag"]
-    assert len(tag_actions) == len(tags)
+    assert len(tag_actions) == len(tag_info["tags"])
 
     requested_tags = set([action["name"] for action in tag_actions])
-    assert requested_tags == set(tags)
+    assert requested_tags == set(tag_info["tags"])
+
+    revisions = set([action["target"] for action in tag_actions])
+    assert len(revisions) == 1
+    assert revisions.pop() == target_revision
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "tags,dry_run",
+    "tag_info,dry_run",
     (
         pytest.param(
-            ["BUILD1"],
+            {
+                "revision": "abcdef123456",
+                "hg_repo_url": "https://hg.testing/repo",
+                "tags": ["BUILD1"],
+            },
             True,
             id="dry_run",
         ),
         pytest.param(
-            ["BUILD1"],
+            {
+                "revision": "abcdef123456",
+                "hg_repo_url": "https://hg.testing/repo",
+                "tags": ["BUILD1"],
+            },
             False,
             id="one_tag",
         ),
         pytest.param(
-            ["BUILD1", "RELEASE"],
+            {
+                "revision": "abcdef123456",
+                "hg_repo_url": "https://hg.testing/repo",
+                "tags": ["BUILD1", "RELEASE"],
+            },
             False,
             id="multiple_tags",
         ),
     ),
 )
-async def test_success(aioresponses, github_installation_responses, context, tags, dry_run):
+async def test_success(aioresponses, github_installation_responses, context, tag_info, dry_run):
     payload = {
         "actions": ["tag"],
         "lando_repo": "repo_name",
-        "tags": tags,
+        "tag_info": tag_info,
         "dry_run": dry_run,
     }
+    git_commit = "ghijkl654321"
+    aioresponses.get(
+        f"{tag_info['hg_repo_url']}/json-rev/{tag_info['revision']}",
+        status=200,
+        payload={"git_commit": git_commit},
+    )
 
     def assert_func(req):
-        assert_tag_response(req, tags)
+        assert_tag_response(req, tag_info, git_commit)
 
     await run_test(aioresponses, github_installation_responses, context, payload, ["tag"], not dry_run, assert_func)
 
@@ -54,6 +77,59 @@ async def test_no_tags(aioresponses, github_installation_responses, context):
     payload = {
         "actions": ["tag"],
         "lando_repo": "repo_name",
-        "tags": [],
+        "tag_info": {
+            "revision": "abcdef123456",
+            "hg_repo_url": "https://hg.testing/repo",
+            "tags": [],
+        },
     }
     await run_test(aioresponses, github_installation_responses, context, payload, ["tag"], err=TaskVerificationError, errmsg="must provide at least one tag!")
+
+
+@pytest.mark.asyncio
+async def test_hg_repo_url(aioresponses, github_installation_responses, context):
+    payload = {
+        "actions": ["tag"],
+        "lando_repo": "repo_name",
+        "tag_info": {
+            "revision": "abcdef123456",
+            "tags": ["FOO"],
+        },
+    }
+    await run_test(aioresponses, github_installation_responses, context, payload, ["tag"], err=TaskVerificationError, errmsg="must provide hg_repo_url!")
+
+
+@pytest.mark.parametrize(
+    "hg_response",
+    (
+        pytest.param(
+            {},
+            id="no_git_commit",
+        ),
+        pytest.param(
+            {"git_commit": None},
+            id="git_commit_is_none",
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_no_git_commit(aioresponses, github_installation_responses, context, hg_response):
+    payload = {
+        "actions": ["tag"],
+        "lando_repo": "repo_name",
+        "tag_info": {
+            "revision": "abcdef123456",
+            "hg_repo_url": "https://hg.testing/repo",
+            "tags": ["FOO"],
+        },
+    }
+
+    aioresponses.get(
+        f"https://hg.testing/repo/json-rev/abcdef123456",
+        status=200,
+        payload=hg_response,
+    )
+
+    await run_test(
+        aioresponses, github_installation_responses, context, payload, ["tag"], err=LandoscriptError, errmsg="Couldn't look up target revision for tag(s) in hg"
+    )


### PR DESCRIPTION
When I originally implemented the `tag` action I failed to use the right payload. This patch addresses that, including adding support for target revisions.
    
Of note with the latter is that for direct tagging (eg: `release-early-tagging`) we need to accept an hg revision (to avoid taskgraph needing to look up the git revision). This revision + repo url can be used to look up the git revision.
    
For merge day tagging, the revision is not known up front: we use whatever the tip of the to and/or from branches, which we can look-up directly in github.
    
When we move decision tasks over to firing from Github events, we can drop the hg support.