### PR TITLE
fix(landoscript): include package data when installing/building wheels

### DIFF
--- a/landoscript/setup.py
+++ b/landoscript/setup.py
@@ -11,6 +11,7 @@ setup(
     url="https://github.com/mozilla-releng/scriptworker-scripts",
     packages=find_packages("src"),
     package_dir={"": "src"},
+    include_package_data=True,
     entry_points={"console_scripts": ["landoscript = landoscript.script:main"]},
     python_requires=">=3.11",
     license="MPL2",


### PR DESCRIPTION
This is needed for the schema to be available ><