### PR TITLE
fix(landoscript): don't look for non-existent 'commits' in landoscript status response

### DIFF
--- a/landoscript/src/landoscript/lando.py
+++ b/landoscript/src/landoscript/lando.py
@@ -94,10 +94,6 @@ async def poll_until_complete(session: ClientSession, lando_token: str, poll_tim
 
             log.info("success! got 200 response with 'LANDED' status")
 
-            log.info("Commits are:")
-            for commit in body["commits"]:
-                log.info(commit)
-
             break
 
 


### PR DESCRIPTION
This was in [the spec](https://docs.google.com/document/d/1F3xYp6v4YLLHsX7zFkYoygDyvIUPzujxeMW7W4qte0o/edit?tab=t.0#heading=h.c29tth48xps4) but does not exist in reality (at least, not yet).