### PR TITLE
fix(landoscript) include correct metadata for additions and removals in diffs

### DIFF
--- a/landoscript/src/landoscript/util/diffs.py
+++ b/landoscript/src/landoscript/util/diffs.py
@@ -3,6 +3,7 @@ from difflib import unified_diff
 
 def diff_contents(orig, modified, file):
     """Create a git-style unified diff of `orig` and `modified` with the filename `file`."""
+    add_remove_metadata = ""
     if orig:
         # orig exists already
         orig_contents = orig.splitlines()
@@ -11,6 +12,7 @@ def diff_contents(orig, modified, file):
         # orig does not exist yet; ie: it will be added
         orig_contents = ""
         fromfile = "/dev/null"
+        add_remove_metadata = "new file mode 100644\n"
     if modified:
         # modified exists already
         modified_contents = modified.splitlines()
@@ -19,10 +21,11 @@ def diff_contents(orig, modified, file):
         # modified does not exist yet; ie: it will be added
         modified_contents = ""
         tofile = "/dev/null"
+        add_remove_metadata = "deleted file mode 100644\n"
 
     diff = ""
     # header line always uses the same filename twice - even with additions and removals
-    diff += f"diff --git a/{file} b/{file}\n"
+    diff += f"diff --git a/{file} b/{file}\n{add_remove_metadata}"
     diff += "\n".join(unified_diff(orig_contents, modified_contents, fromfile=fromfile, tofile=tofile, lineterm=""))
     # preserve the newline at the end of the new version of the file, if it exists
     if modified:

--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -222,11 +222,11 @@ def assert_add_commit_response(action, commit_msg_strings, initial_values, expec
             if file in diff:
                 if not before:
                     # addition
-                    if f"\n+{after}" in diff:
+                    if f"\n+{after}" in diff and "new file mode 100644" in diff:
                         break
                 elif not after:
                     # removal
-                    if f"\n-{before}" in diff:
+                    if f"\n-{before}" in diff and "deleted file mode 100644" in diff:
                         break
                 else:
                     if f"\n-{before}+{after}" in diff:


### PR DESCRIPTION
These lines are necessary for the diff to apply correctly with `git apply`.