### PR TITLE
fix(landoscript): remove unnecessary spam in logs

### DIFF
--- a/landoscript/src/landoscript/actions/android_l10n_import.py
+++ b/landoscript/src/landoscript/actions/android_l10n_import.py
@@ -11,7 +11,6 @@ from landoscript.errors import LandoscriptError
 from landoscript.lando import LandoAction, create_commit_action
 from landoscript.util.diffs import diff_contents
 from landoscript.util.l10n import L10nFile, getL10nFilesFromToml
-from landoscript.util.log import log_file_contents
 from scriptworker_client.github import extract_github_repo_owner_and_name
 from scriptworker_client.github_client import GithubClient
 
@@ -107,8 +106,7 @@ async def run(
         with open(os.path.join(public_artifact_dir, "android-import.diff"), "w+") as f:
             f.write(diff)
 
-        log.info("adding android l10n import! diff contents are:")
-        log_file_contents(diff)
+        log.info("adding android l10n import diff! contents omitted from log for brevity")
 
         # We always ignore closed trees for android l10n imports.
         commitmsg = f"Import translations from {l10n_repo_url} CLOSED TREE"

--- a/landoscript/src/landoscript/actions/android_l10n_sync.py
+++ b/landoscript/src/landoscript/actions/android_l10n_sync.py
@@ -11,7 +11,6 @@ from landoscript.errors import LandoscriptError
 from landoscript.lando import LandoAction, create_commit_action
 from landoscript.util.diffs import diff_contents
 from landoscript.util.l10n import L10nFile, getL10nFilesFromToml
-from landoscript.util.log import log_file_contents
 from scriptworker_client.github_client import GithubClient
 
 log = logging.getLogger(__name__)
@@ -99,8 +98,7 @@ async def run(github_client: GithubClient, public_artifact_dir: str, android_l10
     with open(os.path.join(public_artifact_dir, "android-sync.diff"), "w+") as f:
         f.write(diff)
 
-    log.info("adding android l10n sync! diff contents are:")
-    log_file_contents(diff)
+    log.info("adding android l10n sync diff! contents omitted from log for brevity")
 
     commitmsg = f"Import translations from {from_branch}"
     return create_commit_action(commitmsg, diff)

--- a/landoscript/src/landoscript/actions/l10n_bump.py
+++ b/landoscript/src/landoscript/actions/l10n_bump.py
@@ -105,7 +105,7 @@ async def run(
             with open(os.path.join(public_artifact_dir, f"l10n-bump-{bump_config.name}.diff"), "w+") as f:
                 f.write(diff)
 
-            log.info(f"adding l10n bump commit for {bump_config.name}! diff contents are:")
+            log.info(f"adding l10n bump commit for {bump_config.name}! diff contents omitted from log for brevity")
             log_file_contents(diff)
 
             # create commit message

--- a/landoscript/src/landoscript/lando.py
+++ b/landoscript/src/landoscript/lando.py
@@ -1,7 +1,6 @@
 import asyncio
 import datetime
 import logging
-from pprint import pprint
 from typing import Any, Callable, Tuple
 
 from aiohttp import ClientResponseError, ClientSession

--- a/landoscript/src/landoscript/lando.py
+++ b/landoscript/src/landoscript/lando.py
@@ -43,11 +43,16 @@ async def submit(
     url = f"{lando_api}/repo/{lando_repo}"
     json = {"actions": actions}
 
-    log.info(f"submitting actions to lando: {actions}")
+    log.info("submitting actions to lando:")
+    for action in actions:
+        print_action = action.copy()
+        if "diff" in print_action:
+            print_action["diff"] = "<omitted for brevity>"
+        log.info(print_action)
+
     async with timeout(30):
         log.info(f"submitting POST request to {url}")
         log.info("message body is:")
-        log.info(pprint(json))
 
         submit_resp = await retry_async(
             session.post,

--- a/landoscript/src/landoscript/script.py
+++ b/landoscript/src/landoscript/script.py
@@ -150,6 +150,8 @@ async def async_main(context):
 
 
 def main(config_path: str = ""):
+    # gql is extremely noisy at our typical log level (it logs all request and response bodies)
+    logging.getLogger("gql").setLevel(logging.WARNING)
     return scriptworker.client.sync_main(async_main, config_path=config_path, default_config=get_default_config())
 
 


### PR DESCRIPTION
GQL is notably noisy, and the android l10n diffs are typically very large as well. All diffs are attached as artifacts anyways, so there's little point in logging them.