### PR TITLE
fix(landoscript): log file name instead of contents in android l10n a…

### DIFF
--- a/landoscript/src/landoscript/actions/android_l10n_import.py
+++ b/landoscript/src/landoscript/actions/android_l10n_import.py
@@ -95,7 +95,7 @@ async def run(
             orig_file = orig_files[l10n_file.dst_name]
             new_file = new_files[l10n_file.src_name]
             if orig_file == new_file:
-                log.warning(f"old and new contents of {new_file} are the same, skipping bump...")
+                log.warning(f"old and new contents of {l10n_file.dst_name} are the same, skipping bump...")
                 continue
 
             diff += diff_contents(orig_file, new_file, l10n_file.dst_name)

--- a/landoscript/src/landoscript/actions/android_l10n_sync.py
+++ b/landoscript/src/landoscript/actions/android_l10n_sync.py
@@ -87,7 +87,7 @@ async def run(github_client: GithubClient, public_artifact_dir: str, android_l10
         orig_file = orig_files[l10n_file.dst_name]
         new_file = new_files[l10n_file.src_name]
         if orig_file == new_file:
-            log.warning(f"old and new contents of {new_file} are the same, skipping bump...")
+            log.warning(f"old and new contents of {l10n_file.dst_name} are the same, skipping bump...")
             continue
 
         diff += diff_contents(orig_file, new_file, l10n_file.dst_name)

--- a/landoscript/src/landoscript/lando.py
+++ b/landoscript/src/landoscript/lando.py
@@ -51,7 +51,6 @@ async def submit(
 
     async with timeout(30):
         log.info(f"submitting POST request to {url}")
-        log.info("message body is:")
 
         submit_resp = await retry_async(
             session.post,


### PR DESCRIPTION
…ctions

...and a ride along to remove the now pointless `message body is:` that should've been removed in #1191.