### PR TITLE
fix(landoscript): set `config_path` to None by default

### DIFF
--- a/landoscript/src/landoscript/script.py
+++ b/landoscript/src/landoscript/script.py
@@ -154,7 +154,7 @@ async def async_main(context):
             log.info("No lando actions to submit!")
 
 
-def main(config_path: str = ""):
+def main(config_path=None):
     # gql is extremely noisy at our typical log level (it logs all request and response bodies)
     logging.getLogger("gql").setLevel(logging.WARNING)
     return scriptworker.client.sync_main(async_main, config_path=config_path, default_config=get_default_config())


### PR DESCRIPTION
...because scriptworker explicitly checks for None: https://github.com/mozilla-releng/scriptworker/blob/8117b7599a45b9b2eacc33b9a4038e6393a85661/src/scriptworker/client.py#L177