### PR TITLE
fix(landoscript): improve commit messages

### DIFF
--- a/landoscript/src/landoscript/actions/android_l10n_import.py
+++ b/landoscript/src/landoscript/actions/android_l10n_import.py
@@ -109,5 +109,5 @@ async def run(
         log.info("adding android l10n import diff! contents omitted from log for brevity")
 
         # We always ignore closed trees for android l10n imports.
-        commitmsg = f"Import translations from {l10n_repo_url} CLOSED TREE"
+        commitmsg = f"No Bug - Import translations from {l10n_repo_url} CLOSED TREE"
         return create_commit_action(commitmsg, diff)

--- a/landoscript/src/landoscript/actions/android_l10n_sync.py
+++ b/landoscript/src/landoscript/actions/android_l10n_sync.py
@@ -100,5 +100,5 @@ async def run(github_client: GithubClient, public_artifact_dir: str, android_l10
 
     log.info("adding android l10n sync diff! contents omitted from log for brevity")
 
-    commitmsg = f"Import translations from {from_branch}"
+    commitmsg = f"No Bug - Import translations from {from_branch}"
     return create_commit_action(commitmsg, diff)

--- a/landoscript/src/landoscript/actions/l10n_bump.py
+++ b/landoscript/src/landoscript/actions/l10n_bump.py
@@ -208,7 +208,7 @@ def build_commit_message(name, locale_map, dontbuild=False, ignore_closed_tree=F
         approval_str += " DONTBUILD"
     if ignore_closed_tree:
         approval_str += " CLOSED TREE"
-    message = "no bug - Bumping %s %s\n\n" % (name, approval_str)
+    message = "No Bug - Bumping %s %s\n\n" % (name, approval_str)
     message += comments
     return message
 

--- a/landoscript/src/landoscript/actions/merge_day.py
+++ b/landoscript/src/landoscript/actions/merge_day.py
@@ -178,7 +178,7 @@ async def run(session: ClientSession, github_client: GithubClient, public_artifa
     with open(os.path.join(public_artifact_dir, "replacements.diff"), "w+") as f:
         f.write(diff)
 
-    commitmsg = "Subject: Update configs after merge day operations"
+    commitmsg = "No Bug - Update configs after merge day operations"
     actions.append(create_commit_action(commitmsg, diff))
 
     return actions

--- a/landoscript/src/landoscript/actions/version_bump.py
+++ b/landoscript/src/landoscript/actions/version_bump.py
@@ -102,7 +102,7 @@ async def run(
     log_file_contents(diff)
 
     # version bumps always ignore a closed tree
-    commitmsg = "Subject: Automatic version bump NO BUG a=release CLOSED TREE"
+    commitmsg = "Automatic version bump NO BUG a=release CLOSED TREE"
     if dontbuild:
         commitmsg += " DONTBUILD"
 


### PR DESCRIPTION
* adjust version bump and merge day commit messages to not include `Subject:`
* ensure `no bug` is in all commit messages, to avoid tripping over hg hooks
    
I'm not entirely sure how this prefix got into them, but it's not correct...