### PR TITLE
fix(landoscript): handle all lando status states

### DIFF
--- a/landoscript/src/landoscript/lando.py
+++ b/landoscript/src/landoscript/lando.py
@@ -95,9 +95,15 @@ async def poll_until_complete(session: ClientSession, lando_token: str, poll_tim
             status = body.get("status")
 
             # IN_PROGRESS jobs still return 200
-            if status == "IN_PROGRESS":
+            if status in ("SUBMITTED", "IN_PROGRESS", "DEFERRED"):
                 log.info("landing IN_PROGRESS still...trying again")
                 continue
+
+            if status == "FAILED":
+                raise LandoscriptError(f"Landing status is FAILED: {body}")
+
+            if status == "CANCELLED":
+                raise LandoscriptError(f"Landing status is CANCELLED: {body}")
 
             if status != "LANDED":
                 raise LandoscriptError(f"code is 200, status is not LANDED (it's {status})...result is unclear...failing!")

--- a/landoscript/tests/test_script.py
+++ b/landoscript/tests/test_script.py
@@ -366,8 +366,9 @@ async def test_lando_polling_result_not_correct(aioresponses, github_installatio
         assert "status is not LANDED" in e.args[0]
 
 
+@pytest.mark.parametrize("status", ["SUBMITTED", "IN_PROGRESS", "DEFERRED"])
 @pytest.mark.asyncio
-async def test_lando_in_progress_retries(aioresponses, github_installation_responses, context):
+async def test_lando_200_status_retries(aioresponses, github_installation_responses, context, status):
     payload = {
         "actions": ["version_bump"],
         "lando_repo": "repo_name",
@@ -386,7 +387,7 @@ async def test_lando_in_progress_retries(aioresponses, github_installation_respo
         payload={
             "commits": ["abcdef123"],
             "push_id": job_id,
-            "status": "IN_PROGRESS",
+            "status": status,
         },
     )
     aioresponses.get(


### PR DESCRIPTION
I previously started handling `IN_PROGRESS`, but it turns out there's more states to consider: https://github.com/mozilla-conduit/lando/blob/dd20f1b88608ecebb4387bbc98c2fba44f50c3f8/src/lando/main/models/landing_job.py#L28-L54