### PR TITLE
Update mozilla-version

### DIFF
--- a/beetmoverscript/requirements/base.txt
+++ b/beetmoverscript/requirements/base.txt
@@ -750,9 +750,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/beetmoverscript/requirements/local.txt
+++ b/beetmoverscript/requirements/local.txt
@@ -856,9 +856,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/beetmoverscript/requirements/test.txt
+++ b/beetmoverscript/requirements/test.txt
@@ -841,9 +841,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/bouncerscript/requirements/base.txt
+++ b/bouncerscript/requirements/base.txt
@@ -586,9 +586,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/bouncerscript/requirements/local.txt
+++ b/bouncerscript/requirements/local.txt
@@ -694,9 +694,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/bouncerscript/requirements/test.txt
+++ b/bouncerscript/requirements/test.txt
@@ -677,9 +677,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/landoscript/requirements/base.txt
+++ b/landoscript/requirements/base.txt
@@ -623,9 +623,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/landoscript/requirements/local.txt
+++ b/landoscript/requirements/local.txt
@@ -718,9 +718,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/landoscript/requirements/test.txt
+++ b/landoscript/requirements/test.txt
@@ -701,9 +701,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/pushapkscript/requirements/base.txt
+++ b/pushapkscript/requirements/base.txt
@@ -1050,9 +1050,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via mozapkpublisher
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/pushapkscript/requirements/local.txt
+++ b/pushapkscript/requirements/local.txt
@@ -1150,9 +1150,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via mozapkpublisher
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/pushapkscript/requirements/test.txt
+++ b/pushapkscript/requirements/test.txt
@@ -1135,9 +1135,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via mozapkpublisher
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/treescript/requirements/base.txt
+++ b/treescript/requirements/base.txt
@@ -644,9 +644,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/treescript/requirements/local.txt
+++ b/treescript/requirements/local.txt
@@ -762,9 +762,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \

--- a/treescript/requirements/test.txt
+++ b/treescript/requirements/test.txt
@@ -762,9 +762,9 @@ mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
     --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
     # via taskcluster-taskgraph
-mozilla-version==3.2.1 \
-    --hash=sha256:76ddd4a9f7063063da3016af5ad8af76c3e7d7a958e5636bea51261dc6659649 \
-    --hash=sha256:c43dfc818c4bfb2c764c663bca9403c18a2ff64a15cc12f3a94337d812f3f704
+mozilla-version==4.0.0 \
+    --hash=sha256:144232981aec2cdfc900bba3b225f92804f110c62f816b624875ca0823a92828 \
+    --hash=sha256:b3b7e67e767959f6943ec3d2d1d7e29a60858865482a7ea1922029ae0ad60e65
     # via -r requirements/base.in
 multidict==6.4.3 \
     --hash=sha256:032efeab3049e37eef2ff91271884303becc9e54d740b492a93b7e7266e23756 \


### PR DESCRIPTION
The one breaking change is for the `MobileIosVersion` class which now uses `b` to denotate betas instead of using the patch component of the version. The only impacted script is treescript and only for firefox-ios repos