### PR TITLE
fix(landoscript): use correct field for commit message in merge actions

### DIFF
--- a/landoscript/src/landoscript/actions/merge_day.py
+++ b/landoscript/src/landoscript/actions/merge_day.py
@@ -97,7 +97,7 @@ async def run(session: ClientSession, github_client: GithubClient, public_artifa
             # `theirs` strategy means that the repo being modified will have its tree updated to match that
             # of the `target`.
             merge_msg = f"Update {to_branch} to {from_branch}"
-            actions.append({"action": "merge-onto", "target": end_revision, "strategy": "theirs", "message": merge_msg})
+            actions.append({"action": "merge-onto", "target": end_revision, "strategy": "theirs", "commit_message": merge_msg})
     else:
         if merge_old_head:
             raise TaskVerificationError("'from_branch' is required when merge_old_head is True or version_files are present")

--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -386,6 +386,7 @@ def assert_merge_response(
         action = merge_actions[0]
         assert action["target"] == target_ref
         assert action["strategy"] == "theirs"
+        assert "commit_message" in action
 
     # `create-commit` action. check diff for:
     # - firefox version bumps


### PR DESCRIPTION
see https://github.com/mozilla-conduit/lando/blob/b0d1f9d633c6ea1a714ed4d1bde89ebd9cb4ef36/src/lando/headless_api/api.py#L227-L230