### PR TITLE
bug 1965876: fix(landoscript): include l10n.toml changes in android l10n updates

### DIFF
--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -210,15 +210,25 @@ def assert_add_commit_response(action, commit_msg_strings, initial_values, expec
             else:
                 before = initial_values[file]
             if file in diff:
+                # any expected changes that are multiline files do not have
+                # their diffs checked in depth; it's not worth the effort to
+                # do so. we've already checked that there was _some_ change in
+                # the diff.
                 if not before:
                     # addition
-                    if f"+{after}" in diff and "new file mode 100644" in diff:
+                    assert "new file mode 100644" in diff
+                    if "\n" not in after and f"+{after}" in diff:
                         break
                 elif not after:
                     # removal
-                    if f"-{before}" in diff and "deleted file mode 100644" in diff:
+                    assert "deleted file mode 100644" in diff
+                    if not "\n" in before and f"-{before}" in diff:
                         break
                 else:
+                    # change
+                    if "\n" in before or "\n" in after:
+                        break
+
                     if f"-{before}" in diff and f"+{after}":
                         break
         else:

--- a/landoscript/tests/test_android_l10n_import.py
+++ b/landoscript/tests/test_android_l10n_import.py
@@ -25,11 +25,40 @@ locales = [
   l10n = "components/**/src/main/res/values-{android_locale}/strings.xml"
 """
 
+ac_l10n_toml_new_locale = """
+basepath = "."
+
+locales = [
+    "ab",
+    "de",
+]
+
+[env]
+
+[[paths]]
+  reference = "components/**/src/main/res/values/strings.xml"
+  l10n = "components/**/src/main/res/values-{android_locale}/strings.xml"
+"""
+
 fenix_l10n_toml = """
 basepath = "."
 
 locales = [
     "my",
+]
+
+[env]
+
+[[paths]]
+  reference = "app/src/main/res/values/strings.xml"
+  l10n = "app/src/main/res/values-{android_locale}/strings.xml"
+"""
+
+fenix_l10n_toml_removed_locale = """
+basepath = "."
+
+locales = [
+    "zh",
 ]
 
 [env]
@@ -66,7 +95,7 @@ def assert_success(req, initial_values, expected_bumps):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "android_l10n_import_info,android_l10n_values,initial_values,expected_values",
+    "android_l10n_import_info,android_l10n_values,initial_values,expected_values,ac_toml,fenix_toml,focus_toml",
     (
         pytest.param(
             {
@@ -94,16 +123,25 @@ def assert_success(req, initial_values, expected_bumps):
             },
             {
                 # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
             },
             {
                 # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my expected contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam expected contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab expected contents",
             },
+            ac_l10n_toml,
+            fenix_l10n_toml,
+            focus_l10n_toml,
             id="import",
         ),
         pytest.param(
@@ -132,16 +170,25 @@ def assert_success(req, initial_values, expected_bumps):
             },
             {
                 # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": None,
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": None,
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": None,
             },
             {
                 # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my expected contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam expected contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab expected contents",
             },
+            ac_l10n_toml,
+            fenix_l10n_toml,
+            focus_l10n_toml,
             id="new files",
         ),
         pytest.param(
@@ -170,16 +217,25 @@ def assert_success(req, initial_values, expected_bumps):
             },
             {
                 # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
             },
             {
                 # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": None,
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": None,
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": None,
             },
+            ac_l10n_toml,
+            fenix_l10n_toml,
+            focus_l10n_toml,
             id="removed file",
         ),
         pytest.param(
@@ -208,21 +264,139 @@ def assert_success(req, initial_values, expected_bumps):
             },
             {
                 # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
             },
             {
                 # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
             },
+            ac_l10n_toml,
+            fenix_l10n_toml,
+            focus_l10n_toml,
             id="no_changes",
+        ),
+        pytest.param(
+            {
+                "from_repo_url": "https://github.com/mozilla-l10n/android-l10n",
+                "toml_info": [
+                    {
+                        "dest_path": "mobile/android/fenix",
+                        "toml_path": "mozilla-mobile/fenix/l10n.toml",
+                    },
+                    {
+                        "dest_path": "mobile/android/focus-android",
+                        "toml_path": "mozilla-mobile/focus-android/l10n.toml",
+                    },
+                    {
+                        "dest_path": "mobile/android/android-components",
+                        "toml_path": "mozilla-mobile/android-components/l10n.toml",
+                    },
+                ],
+            },
+            {
+                # paths in android-l10n
+                "mozilla-mobile/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
+                "mozilla-mobile/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
+                "mozilla-mobile/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
+                "mozilla-mobile/android-components/components/browser/toolbar/src/main/res/values-de/strings.xml": "de initial contents",
+            },
+            {
+                # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
+                "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
+                "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
+                "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
+                "mobile/android/android-components/components/browser/toolbar/src/main/res/values-de/strings.xml": None,
+            },
+            {
+                # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml_new_locale,
+                "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
+                "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
+                "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
+                "mobile/android/android-components/components/browser/toolbar/src/main/res/values-de/strings.xml": "de initial contents",
+            },
+            ac_l10n_toml_new_locale,
+            fenix_l10n_toml,
+            focus_l10n_toml,
+            id="toml_file_added_locale",
+        ),
+        pytest.param(
+            {
+                "from_repo_url": "https://github.com/mozilla-l10n/android-l10n",
+                "toml_info": [
+                    {
+                        "dest_path": "mobile/android/fenix",
+                        "toml_path": "mozilla-mobile/fenix/l10n.toml",
+                    },
+                    {
+                        "dest_path": "mobile/android/focus-android",
+                        "toml_path": "mozilla-mobile/focus-android/l10n.toml",
+                    },
+                    {
+                        "dest_path": "mobile/android/android-components",
+                        "toml_path": "mozilla-mobile/android-components/l10n.toml",
+                    },
+                ],
+            },
+            {
+                # paths in android-l10n
+                "mozilla-mobile/fenix/app/src/main/res/values-zh/strings.xml": "zh initial contents",
+                "mozilla-mobile/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
+                "mozilla-mobile/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
+            },
+            {
+                # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
+                "mobile/android/fenix/app/src/main/res/values-zh/strings.xml": None,
+                "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
+                "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
+            },
+            {
+                # paths in gecko
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml_removed_locale,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
+                "mobile/android/fenix/app/src/main/res/values-my/strings.xml": None,
+                "mobile/android/fenix/app/src/main/res/values-zh/strings.xml": "zh initial contents",
+                "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
+                "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
+            },
+            ac_l10n_toml,
+            fenix_l10n_toml_removed_locale,
+            focus_l10n_toml,
+            id="toml_file_removed_locale",
         ),
     ),
 )
-async def test_success(aioresponses, github_installation_responses, context, android_l10n_import_info, android_l10n_values, initial_values, expected_values):
+async def test_success(
+    aioresponses,
+    github_installation_responses,
+    context,
+    android_l10n_import_info,
+    android_l10n_values,
+    initial_values,
+    expected_values,
+    ac_toml,
+    fenix_toml,
+    focus_toml,
+):
     payload = {
         "actions": ["android_l10n_import"],
         "lando_repo": "repo_name",
@@ -329,9 +503,9 @@ async def test_success(aioresponses, github_installation_responses, context, and
         # toml files needed before fetching anything else
         get_files_payload(
             {
-                "mozilla-mobile/fenix/l10n.toml": fenix_l10n_toml,
-                "mozilla-mobile/focus-android/l10n.toml": focus_l10n_toml,
-                "mozilla-mobile/android-components/l10n.toml": ac_l10n_toml,
+                "mozilla-mobile/fenix/l10n.toml": fenix_toml,
+                "mozilla-mobile/focus-android/l10n.toml": focus_toml,
+                "mozilla-mobile/android-components/l10n.toml": ac_toml,
             }
         ),
         # directory tree information needed to correctly interpret the
@@ -370,9 +544,10 @@ async def test_success(aioresponses, github_installation_responses, context, and
     context.task = {"payload": payload, "scopes": scopes}
     await async_main(context)
 
-    if initial_values != expected_values:
+    expected_bumps = {k: v for k, v in expected_values.items() if initial_values.get(k) != v}
+    if expected_bumps:
         req = assert_lando_submission_response(aioresponses.requests, submit_uri)
-        assert_success(req, initial_values, expected_values)
+        assert_success(req, initial_values, expected_bumps)
         assert_status_response(aioresponses.requests, status_uri)
     else:
         assert ("POST", submit_uri) not in aioresponses.requests

--- a/landoscript/tests/test_android_l10n_sync.py
+++ b/landoscript/tests/test_android_l10n_sync.py
@@ -26,11 +26,40 @@ locales = [
   l10n = "components/**/src/main/res/values-{android_locale}/strings.xml"
 """
 
+ac_l10n_toml_new_locale = """
+basepath = "."
+
+locales = [
+    "ab",
+    "de",
+]
+
+[env]
+
+[[paths]]
+  reference = "components/**/src/main/res/values/strings.xml"
+  l10n = "components/**/src/main/res/values-{android_locale}/strings.xml"
+"""
+
 fenix_l10n_toml = """
 basepath = "."
 
 locales = [
     "my",
+]
+
+[env]
+
+[[paths]]
+  reference = "app/src/main/res/values/strings.xml"
+  l10n = "app/src/main/res/values-{android_locale}/strings.xml"
+"""
+
+fenix_l10n_toml_removed_locale = """
+basepath = "."
+
+locales = [
+    "zh",
 ]
 
 [env]
@@ -67,7 +96,7 @@ def assert_success(req, initial_values, expected_bumps):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "android_l10n_sync_info,android_l10n_values,initial_values,expected_values",
+    "android_l10n_sync_info,android_l10n_values,initial_values,expected_values,ac_toml,fenix_toml,focus_toml",
     (
         pytest.param(
             {
@@ -90,15 +119,24 @@ def assert_success(req, initial_values, expected_bumps):
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab expected contents",
             },
             {
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
             },
             {
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my expected contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam expected contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab expected contents",
             },
+            ac_l10n_toml,
+            fenix_l10n_toml,
+            focus_l10n_toml,
             id="only_changes",
         ),
         pytest.param(
@@ -122,15 +160,24 @@ def assert_success(req, initial_values, expected_bumps):
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab expected contents",
             },
             {
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": None,
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": None,
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": None,
             },
             {
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my expected contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam expected contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab expected contents",
             },
+            ac_l10n_toml,
+            fenix_l10n_toml,
+            focus_l10n_toml,
             id="new files",
         ),
         pytest.param(
@@ -154,15 +201,24 @@ def assert_success(req, initial_values, expected_bumps):
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": None,
             },
             {
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
             },
             {
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": None,
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": None,
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": None,
             },
+            ac_l10n_toml,
+            fenix_l10n_toml,
+            focus_l10n_toml,
             id="removed file",
         ),
         pytest.param(
@@ -186,20 +242,40 @@ def assert_success(req, initial_values, expected_bumps):
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
             },
             {
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
             },
             {
+                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
+                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
+                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
                 "mobile/android/fenix/app/src/main/res/values-my/strings.xml": "my initial contents",
                 "mobile/android/focus-android/app/src/main/res/values-zam/strings.xml": "zam initial contents",
                 "mobile/android/android-components/components/browser/toolbar/src/main/res/values-ab/strings.xml": "ab initial contents",
             },
+            ac_l10n_toml,
+            fenix_l10n_toml,
+            focus_l10n_toml,
             id="no_changes",
         ),
     ),
 )
-async def test_success(aioresponses, github_installation_responses, context, android_l10n_sync_info, android_l10n_values, initial_values, expected_values):
+async def test_success(
+    aioresponses,
+    github_installation_responses,
+    context,
+    android_l10n_sync_info,
+    android_l10n_values,
+    initial_values,
+    expected_values,
+    ac_toml,
+    fenix_toml,
+    focus_toml,
+):
     payload = {
         "actions": ["android_l10n_sync"],
         "lando_repo": "repo_name",
@@ -293,9 +369,9 @@ async def test_success(aioresponses, github_installation_responses, context, and
         # toml files needed before fetching anything else
         get_files_payload(
             {
-                "mobile/android/fenix/l10n.toml": fenix_l10n_toml,
-                "mobile/android/focus-android/l10n.toml": focus_l10n_toml,
-                "mobile/android/android-components/l10n.toml": ac_l10n_toml,
+                "mobile/android/fenix/l10n.toml": fenix_toml,
+                "mobile/android/focus-android/l10n.toml": focus_toml,
+                "mobile/android/android-components/l10n.toml": ac_toml,
             }
         ),
         # directory tree information needed to correctly interpret the
@@ -307,14 +383,16 @@ async def test_success(aioresponses, github_installation_responses, context, and
         get_files_payload(initial_values),
     )
 
-    def assert_func(req):
-        assert_success(req, initial_values, expected_values)
-        # check for diff on disk
+    expected_bumps = {k: v for k, v in expected_values.items() if initial_values.get(k) != v}
 
-    if initial_values == expected_values:
-        should_submit = False
-    else:
+    def assert_func(req):
+        if expected_bumps:
+            assert_success(req, initial_values, expected_bumps)
+
+    if expected_bumps:
         should_submit = True
+    else:
+        should_submit = False
 
     await run_test(aioresponses, github_installation_responses, context, payload, ["android_l10n_sync"], should_submit, assert_func)
 


### PR DESCRIPTION
This is a pure oversight from my original work here: I didn't realize these files were automatically updated in addition to strings. Typically this happens when a locale is added or removed.

The fix is fairly straightforward: additionally fetch the l10n.toml files from the destination repository and diff them against the ones from the source.

I was able to test this pretty thoroughly on try: [import task](https://firefox-ci-tc.services.mozilla.com/tasks/cPhNifENRsyt6CZuMUKh8w) and [commit](https://github.com/mozilla-releng/staging-firefox/commit/d85abd381aa4475101cbbb7f13a85c3c0a595b49#diff-8174e188ffab98600baf1c46a58b3a3bf3a98eb2e216fb0b844a1798f1b2bee0), [sync task](https://firefox-ci-tc.services.mozilla.com/tasks/NbXlOcjiQAysMxU-HGRofQ) and [commit](https://github.com/mozilla-releng/staging-firefox/commit/fc4ebbc1df0a5117a80a74876b408486786cb7b3). In both cases they correctly updated the new `bqi` locale to android-components and fenix:
```
diff --git a/mobile/android/android-components/l10n.toml b/mobile/android/android-components/l10n.toml
index 99e4fea201d5..6eb5ab3f3e2c 100644
--- a/mobile/android/android-components/l10n.toml
+++ b/mobile/android/android-components/l10n.toml
@@ -19,6 +19,7 @@ locales = [
     "bg",
     "bn",
     "bo",
+    "bqi",
     "br",
     "bs",
     "ca",
diff --git a/mobile/android/fenix/l10n.toml b/mobile/android/fenix/l10n.toml
index d150ae38f79c..cdfbf2900afc 100644
--- a/mobile/android/fenix/l10n.toml
+++ b/mobile/android/fenix/l10n.toml
@@ -19,6 +19,7 @@ locales = [
   "bg",
   "bn",
   "bo",
+  "bqi",
   "br",
   "bs",
   "ca",
```