### PR TITLE
Replace deprecated whitelist_externals usage in tox.ini

### DIFF
--- a/balrogscript/tox.ini
+++ b/balrogscript/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =

--- a/beetmoverscript/tox.ini
+++ b/beetmoverscript/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =

--- a/bitrisescript/tox.ini
+++ b/bitrisescript/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =

--- a/configloader/tox.ini
+++ b/configloader/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =

--- a/githubscript/tox.ini
+++ b/githubscript/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =

--- a/iscript/tox.ini
+++ b/iscript/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =
@@ -42,7 +42,7 @@ deps =
     -r requirements/base.txt
     -r requirements/test.txt
 
-whitelist_externals =
+allowlist_externals =
     bash
     test
 

--- a/notarization_poller/tox.ini
+++ b/notarization_poller/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =

--- a/pushapkscript/tox.ini
+++ b/pushapkscript/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =

--- a/pushmsixscript/tox.ini
+++ b/pushmsixscript/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =

--- a/scriptworker_client/tox.ini
+++ b/scriptworker_client/tox.ini
@@ -21,7 +21,7 @@ commands=
 deps =
     coveralls
     coverage
-whitelist_externals =
+allowlist_externals =
     bash
     test
 commands =

--- a/shipitscript/tox.ini
+++ b/shipitscript/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =

--- a/treescript/tox.ini
+++ b/treescript/tox.ini
@@ -2,7 +2,7 @@
 envlist = docker
 
 [testenv:docker]
-whitelist_externals=docker
+allowlist_externals=docker
 deps =
 usedevelop = false
 depends =


### PR DESCRIPTION
This was deprecated back in 2020, then removed in 2022. See https://github.com/tox-dev/tox/pull/2600