### PR TITLE
Add `asyncio_default_fixture_loop_scope` to pytest config

### DIFF
--- a/addonscript/tox.ini
+++ b/addonscript/tox.ini
@@ -35,3 +35,6 @@ parallel_show_output = true
 
 [coverage:run]
 branch = true
+
+[pytest]
+asyncio_default_fixture_loop_scope = function

--- a/balrogscript/tox.ini
+++ b/balrogscript/tox.ini
@@ -42,9 +42,10 @@ commands=
     coveralls
 
 [pytest]
+addopts = -vv -s --color=yes
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox
 python_files = test_*.py
-addopts = -vv -s --color=yes
 
 [coverage:run]
 branch = true

--- a/beetmoverscript/tox.ini
+++ b/beetmoverscript/tox.ini
@@ -40,9 +40,10 @@ commands =
     coveralls
 
 [pytest]
+addopts = -vv -s --color=yes
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox build
 python_files = test_*.py
-addopts = -vv -s --color=yes
 
 [coverage:run]
 branch = true

--- a/bitrisescript/tox.ini
+++ b/bitrisescript/tox.ini
@@ -41,6 +41,7 @@ commands=
     coveralls
 
 [pytest]
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox
 python_files = test_*.py
 

--- a/bouncerscript/tox.ini
+++ b/bouncerscript/tox.ini
@@ -41,6 +41,7 @@ commands=
     coveralls
 
 [pytest]
+addopts = -vv -s --color=yes
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox build
 python_files = test_*.py
-addopts = -vv -s --color=yes

--- a/githubscript/tox.ini
+++ b/githubscript/tox.ini
@@ -41,6 +41,7 @@ commands=
     coveralls
 
 [pytest]
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox
 python_files = test_*.py
 

--- a/iscript/tox.ini
+++ b/iscript/tox.ini
@@ -52,9 +52,10 @@ commands=
     - coveralls
 
 [pytest]
+addopts = -vv -s --color=yes
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox build
 python_files = test_*.py
-addopts = -vv -s --color=yes
 
 [coverage:run]
 branch = true

--- a/landoscript/tox.ini
+++ b/landoscript/tox.ini
@@ -46,3 +46,5 @@ commands=
     pip install -e {toxinidir}/../scriptworker_client
     coveralls
 
+[pytest]
+asyncio_default_fixture_loop_scope = function

--- a/notarization_poller/tox.ini
+++ b/notarization_poller/tox.ini
@@ -38,3 +38,6 @@ parallel_show_output = true
 
 [coverage:run]
 branch = true
+
+[pytest]
+asyncio_default_fixture_loop_scope = function

--- a/pushapkscript/tox.ini
+++ b/pushapkscript/tox.ini
@@ -39,6 +39,7 @@ commands=
     coveralls
 
 [pytest]
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox
 python_files = test_*.py
 

--- a/pushflatpakscript/tox.ini
+++ b/pushflatpakscript/tox.ini
@@ -42,6 +42,7 @@ commands=
     coveralls
 
 [pytest]
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox
 python_files = test_*.py
 

--- a/pushmsixscript/tox.ini
+++ b/pushmsixscript/tox.ini
@@ -41,6 +41,7 @@ commands=
     coveralls
 
 [pytest]
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox
 python_files = test_*.py
 # log_cli_level = DEBUG

--- a/scriptworker_client/tox.ini
+++ b/scriptworker_client/tox.ini
@@ -36,6 +36,7 @@ commands =
     mypy src
 
 [pytest]
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox build
 python_files = test_*.py
 addopts = -vv -s --color=yes

--- a/shipitscript/tox.ini
+++ b/shipitscript/tox.ini
@@ -40,9 +40,10 @@ commands =
     coveralls
 
 [pytest]
+addopts = -vv -s --color=yes
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox
 python_files = test_*.py
-addopts = -vv -s --color=yes
 
 [coverage:run]
 branch = true

--- a/signingscript/tox.ini
+++ b/signingscript/tox.ini
@@ -43,9 +43,10 @@ commands=
     coveralls
 
 [pytest]
+addopts = -vv --color=yes
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox build src/signingscript/vendored
 python_files = test_*.py
-addopts = -vv --color=yes
 
 [coverage:run]
 branch = True

--- a/treescript/tox.ini
+++ b/treescript/tox.ini
@@ -43,6 +43,7 @@ commands=
     coveralls
 
 [pytest]
+addopts = -vv -s --color=yes
+asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox
 python_files = test_*.py
-addopts = -vv -s --color=yes


### PR DESCRIPTION
This silences warnings related to asyncio fixtures.

I used some bespoke shell command to find out which scripts were using asyncio fixtures and just added the config option to all of them.

`vim -p $(rg -l pytest.mark.asyncio | xargs -I {} sh -c "echo {} | cut -d '/' -f 1" | sort | uniq | xargs -I {} echo {}/tox.ini | xargs)`