### PR TITLE
Limit should_push() logic to dry_run

### DIFF
--- a/treescript/src/treescript/gecko/__init__.py
+++ b/treescript/src/treescript/gecko/__init__.py
@@ -38,7 +38,7 @@ async def perform_merge_actions(config, task, actions, repo_path):
 
     push_activity = await do_merge(config, task, repo_path, l10n_bump_action)
 
-    if should_push(task, actions) and push_activity:
+    if should_push(task) and push_activity:
         log.info("%d branches to push", len(push_activity))
         for target_repo, revision in push_activity:
             log.info("pushing %s to %s", revision, target_repo)
@@ -89,7 +89,7 @@ async def do_actions(config, task):
     num_outgoing = await vcs.log_outgoing(config, task, repo_path)
     if num_outgoing != num_changes:
         raise TreeScriptError("Outgoing changesets don't match number of expected changesets! {} vs {}".format(num_outgoing, num_changes))
-    if should_push(task, actions):
+    if should_push(task):
         if num_changes:
             await vcs.push(config, task, repo_path, target_repo=get_source_repo(task))
         else:

--- a/treescript/src/treescript/github/versionmanip.py
+++ b/treescript/src/treescript/github/versionmanip.py
@@ -91,7 +91,7 @@ async def bump_version(client: GithubClient, task: Dict) -> None:
     if get_dontbuild(task):
         commit_msg += DONTBUILD_MSG
 
-    push = should_push(task, [])
+    push = should_push(task)
     verb = "Committing" if push else "Would commit"
     log.info(f"{verb} the following patch:\n\n{commit_msg}\n{diff}\n")
 

--- a/treescript/src/treescript/util/task.py
+++ b/treescript/src/treescript/util/task.py
@@ -282,12 +282,11 @@ def task_action_types(config, task):
 
 
 # is_dry_run {{{1
-def should_push(task, actions):
+def should_push(task):
     """Determine whether this task should push the changes it makes.
 
     If `dry_run` is true on the task, there will not be a push.
-    Otherwise, if `push` is specified, that determines if there should be a push.
-    Otherwise, there is a push if the `push` action is specified.
+    Otherwise, there will be a push.
 
     Args:
         task (dict): the task definition.
@@ -297,21 +296,9 @@ def should_push(task, actions):
 
     """
     dry_run = task["payload"].get("dry_run", False)
-    push = task["payload"].get("push")
-    push_action = "push" in actions
     if dry_run:
         log.info("Not pushing changes, dry_run was forced")
-        return False
-    elif push is not None:
-        if not push and push_action:
-            log.warning("Push disabled, but push action provided; ignore push action")
-        return push
-    elif push_action:
-        log.warning("Specifying push as an action is deprecated; task.payload.push instead.")
-        return True
-    else:
-        log.info("Not pushing changes, no push requested")
-        return False
+    return not dry_run
 
 
 # get_ssh_user {{{1

--- a/treescript/tests/test_gecko.py
+++ b/treescript/tests/test_gecko.py
@@ -9,21 +9,14 @@ from treescript.exceptions import TreeScriptError
 # do_actions {{{1
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "push_scope,push_payload,dry_run,push_expect_called",
+    "dry_run,push_expect_called",
     (
-        (["push"], False, False, False),
-        (["push"], False, True, False),
-        (["push"], True, False, True),
-        (["push"], True, True, False),
-        ([], False, False, False),
-        ([], False, True, False),
-        ([], True, False, True),
-        ([], True, True, False),
+        (False, True),
+        (True, False),
     ),
 )
-async def test_do_actions(mocker, push_scope, push_payload, dry_run, push_expect_called):
+async def test_do_actions(mocker, dry_run, push_expect_called):
     actions = ["tag", "version_bump", "l10n_bump"]
-    actions += push_scope
     called = {"version_bump": False, "l10n_bump": False, "merge": False}
 
     async def mocked_bump(*args, **kwargs):
@@ -47,7 +40,7 @@ async def test_do_actions(mocker, push_scope, push_payload, dry_run, push_expect
     mocker.patch.object(gecko, "perform_merge_actions", new=mocked_perform_merge_actions)
 
     task_defn = {
-        "payload": {"push": push_payload, "dry_run": dry_run, "actions": actions},
+        "payload": {"dry_run": dry_run, "actions": actions},
         "metadata": {"source": "https://hg.mozilla.org/releases/mozilla-test-source" "/file/1b4ab9a276ce7bb217c02b83057586e7946860f9/taskcluster/ci/foobar"},
     }
     await gecko.do_actions({"work_dir": "foo", "trust_domain": "gecko"}, task_defn)

--- a/treescript/tests/test_util_task.py
+++ b/treescript/tests/test_util_task.py
@@ -358,25 +358,14 @@ def test_task_action_types_scopes(config, task, expected):
         assert actions == expected
 
 
-@pytest.mark.parametrize("task", ({"payload": {"push": True}}, {"payload": {"dry_run": False, "push": True}}, {"payload": {"actions": ["push"]}}))
+@pytest.mark.parametrize("task", ({"payload": {"dry_run": False}},))
 def test_should_push_true(task):
-    actions = ttask.task_action_types(SCRIPT_CONFIG, task)
-    assert True is ttask.should_push(task, actions)
+    assert True is ttask.should_push(task)
 
 
-@pytest.mark.parametrize(
-    "task",
-    (
-        {"payload": {"dry_run": True}},
-        {"payload": {"dry_run": True, "actions": ["push"]}},
-        {"payload": {"dry_run": True, "push": True}},
-        {"payload": {"push": False, "actions": ["push"]}},
-        {"payload": {}},
-    ),
-)
+@pytest.mark.parametrize("task", ({"payload": {"dry_run": True}},))
 def test_should_push_false(task):
-    actions = ttask.task_action_types(SCRIPT_CONFIG, task)
-    assert False is ttask.should_push(task, actions)
+    assert False is ttask.should_push(task)
 
 
 @pytest.mark.parametrize("ssh_user,expected", ((None, "default"), ("merge_user", "merge_user")))


### PR DESCRIPTION
Since the push action has been removed, we can limit the logic of should_push() to dry_run. In other words, push if dry_run is false, and don't push if dry_run is true.