### PR TITLE
bug 1967787: feat: handle landoscript terminations better

### DIFF
--- a/docker.d/pre-stop.sh
+++ b/docker.d/pre-stop.sh
@@ -10,7 +10,8 @@ SCRIPTWORKER_PID=${SCRIPTWORKER_PID:-1}
 # in case the task takes too long, this script exits 2 minutes before
 # `terminationGracePeriodSeconds` (as set e.g. in
 # https://github.com/mozilla-services/cloudops-infra/blob/d94d5fd6a7704ffd2c829d870206f5c0ed8d75e7/projects/relengworker/k8s/charts/beetmover/templates/deployment.yaml)
-# to let scriptworker upload files and report `worker-shutdown` to Taskcluster.
+# this will cause kubernetes to send SIGTERM earlier, and allow
+# scriptworker time to upload files and report `worker-shutdown` to Taskcluster.
 case ${PROJECT_NAME} in
     bitrise)
         POLL_DURATION=7080 # 118 minutes

--- a/landoscript/requirements/base.txt
+++ b/landoscript/requirements/base.txt
@@ -310,7 +310,7 @@ click==8.2.0 \
     --hash=sha256:6b303f0b2aa85f1cb4e5303078fadcbcd4e476f114fab9b5007005711839325c \
     --hash=sha256:f5452aeddd9988eefa20f90f05ab66f17fce1ee2a36907fd30b05bbb5953814d
     # via cookiecutter
-colorama==0.4.6 ; sys_platform == 'win32' \
+colorama==0.4.6 ; platform_system == 'Windows' \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
     # via click

--- a/landoscript/requirements/local.txt
+++ b/landoscript/requirements/local.txt
@@ -982,6 +982,7 @@ pytest==8.3.5 \
     #   pytest-aioresponses
     #   pytest-asyncio
     #   pytest-cov
+    #   pytest-responses
 pytest-aioresponses==0.3.0 \
     --hash=sha256:5677b32dfa1a36908b347524b5867aab35ac1c5ce1d4970244d6f66009bca7b6 \
     --hash=sha256:60f3124ff05a0210a5f369dd95e4cf66090774ba76b322f7178858ce4e6c1647
@@ -993,6 +994,9 @@ pytest-asyncio==0.26.0 \
 pytest-cov==6.1.1 \
     --hash=sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a \
     --hash=sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde
+    # via -r requirements/test.in
+pytest-responses==0.5.1 \
+    --hash=sha256:4172e565b94ac1ea3b10aba6e40855ad60cd7f141476b2d8a47e4b5f250be734
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
@@ -1061,6 +1065,7 @@ pyyaml==6.0.2 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
     # via
     #   cookiecutter
+    #   responses
     #   scriptworker
     #   taskcluster-taskgraph
 redo==3.0.0 \
@@ -1079,8 +1084,13 @@ requests==2.32.3 \
     # via
     #   cookiecutter
     #   github3-py
+    #   responses
     #   taskcluster
     #   taskcluster-taskgraph
+responses==0.25.7 \
+    --hash=sha256:8ebae11405d7a5df79ab6fd54277f6f2bc29b2d002d0dd2d5c632594d1ddcedb \
+    --hash=sha256:92ca17416c90fe6b35921f52179bff29332076bb32694c0df02dcac2c6bc043c
+    # via pytest-responses
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -1312,7 +1322,9 @@ uritemplate==4.1.1 \
 urllib3==2.4.0 \
     --hash=sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466 \
     --hash=sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813
-    # via requests
+    # via
+    #   requests
+    #   responses
 virtualenv==20.31.2 \
     --hash=sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11 \
     --hash=sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af

--- a/landoscript/requirements/test.in
+++ b/landoscript/requirements/test.in
@@ -5,3 +5,4 @@ pytest
 pytest-aioresponses
 pytest-asyncio
 pytest-cov
+pytest-responses

--- a/landoscript/requirements/test.txt
+++ b/landoscript/requirements/test.txt
@@ -315,7 +315,7 @@ click==8.2.0 \
     --hash=sha256:6b303f0b2aa85f1cb4e5303078fadcbcd4e476f114fab9b5007005711839325c \
     --hash=sha256:f5452aeddd9988eefa20f90f05ab66f17fce1ee2a36907fd30b05bbb5953814d
     # via cookiecutter
-colorama==0.4.6 ; sys_platform == 'win32' \
+colorama==0.4.6 ; sys_platform == 'win32' or platform_system == 'Windows' \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
     # via
@@ -951,6 +951,7 @@ pytest==8.3.5 \
     #   pytest-aioresponses
     #   pytest-asyncio
     #   pytest-cov
+    #   pytest-responses
 pytest-aioresponses==0.3.0 \
     --hash=sha256:5677b32dfa1a36908b347524b5867aab35ac1c5ce1d4970244d6f66009bca7b6 \
     --hash=sha256:60f3124ff05a0210a5f369dd95e4cf66090774ba76b322f7178858ce4e6c1647
@@ -962,6 +963,9 @@ pytest-asyncio==0.26.0 \
 pytest-cov==6.1.1 \
     --hash=sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a \
     --hash=sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde
+    # via -r requirements/test.in
+pytest-responses==0.5.1 \
+    --hash=sha256:4172e565b94ac1ea3b10aba6e40855ad60cd7f141476b2d8a47e4b5f250be734
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
@@ -1030,6 +1034,7 @@ pyyaml==6.0.2 \
     --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4
     # via
     #   cookiecutter
+    #   responses
     #   scriptworker
     #   taskcluster-taskgraph
 redo==3.0.0 \
@@ -1048,8 +1053,13 @@ requests==2.32.3 \
     # via
     #   cookiecutter
     #   github3-py
+    #   responses
     #   taskcluster
     #   taskcluster-taskgraph
+responses==0.25.7 \
+    --hash=sha256:8ebae11405d7a5df79ab6fd54277f6f2bc29b2d002d0dd2d5c632594d1ddcedb \
+    --hash=sha256:92ca17416c90fe6b35921f52179bff29332076bb32694c0df02dcac2c6bc043c
+    # via pytest-responses
 rfc3339-validator==0.1.4 \
     --hash=sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b \
     --hash=sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa
@@ -1277,7 +1287,9 @@ uritemplate==4.1.1 \
 urllib3==2.4.0 \
     --hash=sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466 \
     --hash=sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813
-    # via requests
+    # via
+    #   requests
+    #   responses
 voluptuous==0.15.2 \
     --hash=sha256:016348bc7788a9af9520b1764ebd4de0df41fe2138ebe9e06fa036bf86a65566 \
     --hash=sha256:6ffcab32c4d3230b4d2af3a577c87e1908a714a11f6f95570456b1849b0279aa

--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -191,6 +191,20 @@ def assert_status_response(requests, status_uri, attempts=1):
     assert reqs[0].kwargs["headers"]["User-Agent"] == "Lando-User/release+landoscript@mozilla.com"
 
 
+def assert_tag_response(req, tag_info, target_revision):
+    assert "json" in req.kwargs
+    assert "actions" in req.kwargs["json"]
+    tag_actions = [action for action in req.kwargs["json"]["actions"] if action["action"] == "tag"]
+    assert len(tag_actions) == len(tag_info["tags"])
+
+    requested_tags = set([action["name"] for action in tag_actions])
+    assert requested_tags == set(tag_info["tags"])
+
+    revisions = set([action["target"] for action in tag_actions])
+    assert len(revisions) == 1
+    assert revisions.pop() == target_revision
+
+
 def assert_add_commit_response(action, commit_msg_strings, initial_values, expected_bumps):
     # ensure metadata is correct
     assert action["author"] == "Release Engineering Landoscript <release+landoscript@mozilla.com>"

--- a/landoscript/tests/test_rerun_handling.py
+++ b/landoscript/tests/test_rerun_handling.py
@@ -1,0 +1,218 @@
+import pytest
+from yarl import URL
+
+from landoscript.errors import LandoscriptError
+from landoscript.script import async_main
+from tests.conftest import assert_status_response, assert_tag_response, run_test, setup_test
+
+
+@pytest.mark.asyncio
+async def test_rerun_previous_lando_job_not_found(monkeypatch, aioresponses, responses, github_installation_responses, context):
+    """A rerun that did not find a lando job url from a previous run should
+    function as if no lando job was submitted."""
+    monkeypatch.setenv("TASKCLUSTER_ROOT_URL", "https://tc")
+    monkeypatch.setenv("TASK_ID", "task_id")
+    monkeypatch.setenv("RUN_ID", "4")
+    tag_info = {
+        "revision": "abcdef123456",
+        "hg_repo_url": "https://hg.testing/repo",
+        "tags": ["BUILD1", "RELEASE"],
+    }
+    payload = {
+        "actions": ["tag"],
+        "lando_repo": "repo_name",
+        "tag_info": tag_info,
+    }
+    git_commit = "ghijkl654321"
+    aioresponses.get(
+        f"{tag_info['hg_repo_url']}/json-rev/{tag_info['revision']}",
+        status=200,
+        payload={"git_commit": git_commit},
+    )
+
+    artifact_info_resps = []
+    for i in range(4):
+        artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/{i}/artifacts/public%2Fbuild%2Flando-status.txt"
+        artifact_info_resps.append(
+            responses.get(
+                artifact_url,
+                status=404,
+            )
+        )
+
+    def assert_func(req):
+        assert_tag_response(req, tag_info, git_commit)
+        for resp in artifact_info_resps:
+            assert resp.call_count == 1
+
+    await run_test(aioresponses, github_installation_responses, context, payload, ["tag"], assert_func=assert_func)
+
+
+@pytest.mark.asyncio
+async def test_rerun_previous_lando_job_succeeded(monkeypatch, aioresponses, responses, github_installation_responses, context):
+    """A rerun that finds a lando job that succeeded should return success
+    and do nothing else."""
+    monkeypatch.setenv("TASKCLUSTER_ROOT_URL", "https://tc")
+    monkeypatch.setenv("TASK_ID", "task_id")
+    monkeypatch.setenv("RUN_ID", "1")
+    tag_info = {
+        "revision": "abcdef123456",
+        "hg_repo_url": "https://hg.testing/repo",
+        "tags": ["BUILD1", "RELEASE"],
+    }
+    payload = {
+        "actions": ["tag"],
+        "lando_repo": "repo_name",
+        "tag_info": tag_info,
+    }
+    submit_uri, status_uri, job_id, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["tag"], "repo_name")
+    context.task = {"payload": payload, "scopes": scopes}
+
+    # previous run's status artifact info
+    artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/0/artifacts/public%2Fbuild%2Flando-status.txt"
+    artifact_info_resp = responses.get(artifact_url, status=303, json={"storageType": "s3", "url": "https://s3.fake/artifact"})
+
+    # the actual artifact
+    aioresponses.get(
+        "https://s3.fake/artifact",
+        status=200,
+        body=str(status_uri),
+    )
+
+    # response from lando when this run checks on the job
+    aioresponses.get(
+        status_uri,
+        status=200,
+        payload={
+            "commits": ["abcdef123"],
+            "push_id": job_id,
+            "status": "LANDED",
+        },
+    )
+
+    await async_main(context)
+
+    assert_status_response(aioresponses.requests, status_uri)
+    # ensure we found the previous run's artifact
+    assert artifact_info_resp.call_count == 1
+    assert ("GET", URL("https://s3.fake/artifact")) in aioresponses.requests
+    # ensure another lando job was _not_ submitted
+    assert ("POST", submit_uri) not in aioresponses.requests
+
+
+@pytest.mark.asyncio
+async def test_rerun_previous_lando_job_failed(monkeypatch, aioresponses, responses, github_installation_responses, context):
+    """A rerun that finds a lando job that succeeded should return failure
+    and do nothing else."""
+    monkeypatch.setenv("TASKCLUSTER_ROOT_URL", "https://tc")
+    monkeypatch.setenv("TASK_ID", "task_id")
+    monkeypatch.setenv("RUN_ID", "1")
+    tag_info = {
+        "revision": "abcdef123456",
+        "hg_repo_url": "https://hg.testing/repo",
+        "tags": ["BUILD1", "RELEASE"],
+    }
+    payload = {
+        "actions": ["tag"],
+        "lando_repo": "repo_name",
+        "tag_info": tag_info,
+    }
+    submit_uri, status_uri, job_id, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["tag"], "repo_name")
+    context.task = {"payload": payload, "scopes": scopes}
+
+    # previous run's status artifact
+    artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/0/artifacts/public%2Fbuild%2Flando-status.txt"
+    artifact_info_resp = responses.get(artifact_url, status=303, json={"storageType": "s3", "url": "https://s3.fake/artifact"})
+
+    # the actual artifact
+    aioresponses.get(
+        "https://s3.fake/artifact",
+        status=200,
+        body=str(status_uri),
+    )
+
+    # response from lando when this run checks on the job
+    aioresponses.get(
+        status_uri,
+        status=200,
+        payload={
+            "commits": ["abcdef123"],
+            "push_id": job_id,
+            "status": "FAILED",
+        },
+    )
+
+    try:
+        await async_main(context)
+        assert False, f"should've raised LandoScriptError"
+    except LandoscriptError as e:
+        assert_status_response(aioresponses.requests, status_uri)
+
+        # ensure we got the correct error
+        assert "Landing status is FAILED" in e.args[0]
+        # ensure we found the previous run's artifact
+        assert artifact_info_resp.call_count == 1
+        assert ("GET", URL("https://s3.fake/artifact")) in aioresponses.requests
+        # ensure another lando job was _not_ submitted
+        assert ("POST", submit_uri) not in aioresponses.requests
+
+
+@pytest.mark.asyncio
+async def test_rerun_previous_lando_job_in_progress(monkeypatch, aioresponses, responses, github_installation_responses, context):
+    """A rerun that finds a lando job still in progress should poll that job
+    for status and do nothing else."""
+    monkeypatch.setenv("TASKCLUSTER_ROOT_URL", "https://tc")
+    monkeypatch.setenv("TASK_ID", "task_id")
+    monkeypatch.setenv("RUN_ID", "1")
+    tag_info = {
+        "revision": "abcdef123456",
+        "hg_repo_url": "https://hg.testing/repo",
+        "tags": ["BUILD1", "RELEASE"],
+    }
+    payload = {
+        "actions": ["tag"],
+        "lando_repo": "repo_name",
+        "tag_info": tag_info,
+    }
+    submit_uri, status_uri, job_id, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["tag"], "repo_name")
+    context.task = {"payload": payload, "scopes": scopes}
+
+    # previous run's status artifact
+    artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/0/artifacts/public%2Fbuild%2Flando-status.txt"
+    artifact_info_resp = responses.get(artifact_url, status=303, json={"storageType": "s3", "url": "https://s3.fake/artifact"})
+
+    # the actual artifact
+    aioresponses.get(
+        "https://s3.fake/artifact",
+        status=200,
+        body=str(status_uri),
+    )
+
+    # response from lando when this run checks on the job
+    aioresponses.get(
+        status_uri,
+        status=200,
+        payload={
+            "commits": ["abcdef123"],
+            "push_id": job_id,
+            "status": "IN_PROGRESS",
+        },
+    )
+    aioresponses.get(
+        status_uri,
+        status=200,
+        payload={
+            "commits": ["abcdef123"],
+            "push_id": job_id,
+            "status": "LANDED",
+        },
+    )
+
+    await async_main(context)
+
+    assert_status_response(aioresponses.requests, status_uri, 2)
+    # ensure we found the previous run's artifact
+    assert artifact_info_resp.call_count == 1
+    assert ("GET", URL("https://s3.fake/artifact")) in aioresponses.requests
+    # ensure another lando job was _not_ submitted
+    assert ("POST", submit_uri) not in aioresponses.requests

--- a/landoscript/tests/test_script.py
+++ b/landoscript/tests/test_script.py
@@ -19,6 +19,7 @@ from .test_tag import assert_tag_response
 def assert_success(artifact_dir, req, commit_msg_strings, initial_values, expected_bumps, has_actions=True):
     if has_actions:
         assert (artifact_dir / "public/build/lando-actions.json").exists()
+        assert (artifact_dir / "public/build/lando-status.txt").exists()
 
     assert "json" in req.kwargs
     assert "actions" in req.kwargs["json"]

--- a/landoscript/tests/test_tag.py
+++ b/landoscript/tests/test_tag.py
@@ -2,21 +2,7 @@ from landoscript.errors import LandoscriptError
 import pytest
 from scriptworker.client import TaskVerificationError
 
-from .conftest import run_test
-
-
-def assert_tag_response(req, tag_info, target_revision):
-    assert "json" in req.kwargs
-    assert "actions" in req.kwargs["json"]
-    tag_actions = [action for action in req.kwargs["json"]["actions"] if action["action"] == "tag"]
-    assert len(tag_actions) == len(tag_info["tags"])
-
-    requested_tags = set([action["name"] for action in tag_actions])
-    assert requested_tags == set(tag_info["tags"])
-
-    revisions = set([action["target"] for action in tag_actions])
-    assert len(revisions) == 1
-    assert revisions.pop() == target_revision
+from .conftest import assert_tag_response, run_test
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This improves landoscript reruns by looking for the lando status URL from an earlier run, and polling it instead of redoing work (that is likely to fail). I don't think we can be _perfect_ here, but this is much better than the current state of affairs.