### PR TITLE
Bug 1946095 - Add support for the samsung galaxy store to pushapkscript

### DIFF
--- a/pushapkscript/docker.d/init_worker.sh
+++ b/pushapkscript/docker.d/init_worker.sh
@@ -71,6 +71,8 @@ case $COT_PRODUCT in
         echo "dummy" > $CONFIG_DIR/fake_cert.json
         export GOOGLE_CREDENTIALS_FENIX_DEP_PATH=$CONFIG_DIR/fake_cert.json
         export GOOGLE_CREDENTIALS_FOCUS_DEP_PATH=$CONFIG_DIR/fake_cert.json
+        export SGS_SERVICE_ACCOUNT_ID_DEP="0123456"
+        export SGS_ACCESS_TOKEN_DEP="dummy"
 
         import_cert fenix $CERT_DIR/fenix_dep.pem
         import_cert focus $CERT_DIR/focus_dep.pem
@@ -81,6 +83,8 @@ case $COT_PRODUCT in
         test_var_set 'GOOGLE_SERVICE_ACCOUNT_FENIX_NIGHTLY'
         test_var_set 'GOOGLE_SERVICE_ACCOUNT_FENIX_BETA'
         test_var_set 'GOOGLE_SERVICE_ACCOUNT_FENIX_RELEASE'
+        test_var_set 'SGS_SERVICE_ACCOUNT_ID'
+        test_var_set 'SGS_ACCESS_TOKEN'
 
         export GOOGLE_CREDENTIALS_FOCUS_PATH=$CONFIG_DIR/focus.json
         export GOOGLE_CREDENTIALS_FENIX_NIGHTLY_PATH=$CONFIG_DIR/fenix_nightly.json

--- a/pushapkscript/docker.d/worker.yml
+++ b/pushapkscript/docker.d/worker.yml
@@ -39,6 +39,9 @@ products:
               google:
                 default_track: 'alpha'
                 credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_RELEASE_PATH" }
+              samsung:
+                service_account_id: { "$eval": "SGS_SERVICE_ACCOUNT_ID" }
+                access_token: { "$eval": "SGS_ACCESS_TOKEN" }
         - product_names: ["focus-android" ]
           digest_algorithm: 'SHA-256'
           skip_check_ordered_version_codes: true
@@ -64,6 +67,9 @@ products:
               google:
                 default_track: 'alpha'
                 credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_PATH" }
+              samsung:
+                service_account_id: { "$eval": "SGS_SERVICE_ACCOUNT_ID" }
+                access_token: { "$eval": "SGS_ACCESS_TOKEN" }
             klar-release:
               package_names: ["org.mozilla.klar"]
               certificate_alias: 'focus'
@@ -95,6 +101,9 @@ products:
               google:
                 default_track: 'alpha'
                 credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FENIX_DEP_PATH" }
+              samsung:
+                service_account_id: { "$eval": "SGS_SERVICE_ACCOUNT_ID_DEP" }
+                access_token: { "$eval": "SGS_ACCESS_TOKEN_DEP" }
         - product_names: ["focus-android" ]
           digest_algorithm: "SHA-256"
           skip_check_ordered_version_codes: true
@@ -120,6 +129,9 @@ products:
               google:
                 default_track: 'alpha'
                 credentials_file: { "$eval": "GOOGLE_CREDENTIALS_FOCUS_DEP_PATH" }
+              samsung:
+                service_account_id: { "$eval": "SGS_SERVICE_ACCOUNT_ID_DEP" }
+                access_token: { "$eval": "SGS_ACCESS_TOKEN_DEP" }
             klar-release:
               package_names: ["org.mozilla.klar"]
               certificate_alias: 'focus'

--- a/pushapkscript/examples/config.example.json
+++ b/pushapkscript/examples/config.example.json
@@ -64,6 +64,10 @@
                 "google": {
                     "default_track": "production",
                     "credentials_file": "/fenix-production.json"
+                },
+                "samsung": {
+                    "sgs_service_account_id": "0123456",
+                    "sgs_access_token": "abcdef"
                 }
             }
         }

--- a/pushapkscript/requirements/base.in
+++ b/pushapkscript/requirements/base.in
@@ -1,3 +1,3 @@
-mozapkpublisher>=7
+mozapkpublisher>=9.0.1
 androguard<4  # TODO: remove when mozapkpublisher>7.0.0 is released
 scriptworker

--- a/pushapkscript/requirements/base.txt
+++ b/pushapkscript/requirements/base.txt
@@ -646,10 +646,6 @@ httplib2==0.22.0 \
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-humanize==4.12.3 \
-    --hash=sha256:2cbf6370af06568fa6d2da77c86edb7886f3160ecd19ee1ffef07979efc597f6 \
-    --hash=sha256:8430be3a615106fdfceb0b2c1b41c4c98c6b0fc5cc59663a5539b111dd325fb0
-    # via mozapkpublisher
 idna==3.10 \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
@@ -1030,9 +1026,9 @@ mohawk==1.1.0 \
     --hash=sha256:3ed296a30453d0b724679e0fd41e4e940497f8e461a9a9c3b7f36e43bab0fa09 \
     --hash=sha256:d2a0e3ab10a209cc79e95e28f2dd54bd4a73fd1998ffe27b7ba0f962b6be9723
     # via taskcluster
-mozapkpublisher==7.0.2 \
-    --hash=sha256:0e7a56010f0663e0ee29ac2223454198e943ab5a985e9f60a0bd7eb0eb13062d \
-    --hash=sha256:be083c26244028fc178f5bd95533c5270405be86df6c39dcc33cbab264e1bd63
+mozapkpublisher==9.0.1 \
+    --hash=sha256:6cdc3871e9f847364cccfca975ae85b9e48988a799f0720ab6cd1dd820176aed \
+    --hash=sha256:c264333be9be698755be14e288085520886d7c3c221845d26ffc17dc8ed74374
     # via -r requirements/base.in
 mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
@@ -1469,7 +1465,9 @@ pygments==2.19.1 \
 pyjwt==2.10.1 \
     --hash=sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953 \
     --hash=sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb
-    # via github3-py
+    # via
+    #   github3-py
+    #   mozapkpublisher
 pyparsing==3.2.3 \
     --hash=sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf \
     --hash=sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be

--- a/pushapkscript/requirements/local.txt
+++ b/pushapkscript/requirements/local.txt
@@ -742,10 +742,6 @@ httplib2==0.22.0 \
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-humanize==4.12.3 \
-    --hash=sha256:2cbf6370af06568fa6d2da77c86edb7886f3160ecd19ee1ffef07979efc597f6 \
-    --hash=sha256:8430be3a615106fdfceb0b2c1b41c4c98c6b0fc5cc59663a5539b111dd325fb0
-    # via mozapkpublisher
 idna==3.10 \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
@@ -1130,9 +1126,9 @@ mohawk==1.1.0 \
     --hash=sha256:3ed296a30453d0b724679e0fd41e4e940497f8e461a9a9c3b7f36e43bab0fa09 \
     --hash=sha256:d2a0e3ab10a209cc79e95e28f2dd54bd4a73fd1998ffe27b7ba0f962b6be9723
     # via taskcluster
-mozapkpublisher==7.0.2 \
-    --hash=sha256:0e7a56010f0663e0ee29ac2223454198e943ab5a985e9f60a0bd7eb0eb13062d \
-    --hash=sha256:be083c26244028fc178f5bd95533c5270405be86df6c39dcc33cbab264e1bd63
+mozapkpublisher==9.0.1 \
+    --hash=sha256:6cdc3871e9f847364cccfca975ae85b9e48988a799f0720ab6cd1dd820176aed \
+    --hash=sha256:c264333be9be698755be14e288085520886d7c3c221845d26ffc17dc8ed74374
     # via -r requirements/base.in
 mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
@@ -1598,7 +1594,9 @@ pygments==2.19.1 \
 pyjwt==2.10.1 \
     --hash=sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953 \
     --hash=sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb
-    # via github3-py
+    # via
+    #   github3-py
+    #   mozapkpublisher
 pyparsing==3.2.3 \
     --hash=sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf \
     --hash=sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be

--- a/pushapkscript/requirements/test.txt
+++ b/pushapkscript/requirements/test.txt
@@ -727,10 +727,6 @@ httplib2==0.22.0 \
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-humanize==4.12.3 \
-    --hash=sha256:2cbf6370af06568fa6d2da77c86edb7886f3160ecd19ee1ffef07979efc597f6 \
-    --hash=sha256:8430be3a615106fdfceb0b2c1b41c4c98c6b0fc5cc59663a5539b111dd325fb0
-    # via mozapkpublisher
 idna==3.10 \
     --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
     --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
@@ -1115,9 +1111,9 @@ mohawk==1.1.0 \
     --hash=sha256:3ed296a30453d0b724679e0fd41e4e940497f8e461a9a9c3b7f36e43bab0fa09 \
     --hash=sha256:d2a0e3ab10a209cc79e95e28f2dd54bd4a73fd1998ffe27b7ba0f962b6be9723
     # via taskcluster
-mozapkpublisher==7.0.2 \
-    --hash=sha256:0e7a56010f0663e0ee29ac2223454198e943ab5a985e9f60a0bd7eb0eb13062d \
-    --hash=sha256:be083c26244028fc178f5bd95533c5270405be86df6c39dcc33cbab264e1bd63
+mozapkpublisher==9.0.1 \
+    --hash=sha256:6cdc3871e9f847364cccfca975ae85b9e48988a799f0720ab6cd1dd820176aed \
+    --hash=sha256:c264333be9be698755be14e288085520886d7c3c221845d26ffc17dc8ed74374
     # via -r requirements/base.in
 mozilla-repo-urls==0.1.1 \
     --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
@@ -1573,7 +1569,9 @@ pygments==2.19.1 \
 pyjwt==2.10.1 \
     --hash=sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953 \
     --hash=sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb
-    # via github3-py
+    # via
+    #   github3-py
+    #   mozapkpublisher
 pyparsing==3.2.3 \
     --hash=sha256:a749938e02d6fd0b59b356ca504a24982314bb090c383e3cf201c95ef7e2bfcf \
     --hash=sha256:b9c13f1ab8b3b542f72e28f634bad4de758ab3ce4546e4301970ad6fa77c38be

--- a/pushapkscript/src/pushapkscript/data/config_schema.json
+++ b/pushapkscript/src/pushapkscript/data/config_schema.json
@@ -125,6 +125,22 @@
                                             "type": "string"
                                         }
                                     }
+                                },
+                                "samsung": {
+                                    "type": "object",
+                                    "required": [
+                                        "service_account_id",
+                                        "access_token"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "service_account_id": {
+                                            "type": "string"
+                                        },
+                                        "access_token": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/pushapkscript/src/pushapkscript/publish.py
+++ b/pushapkscript/src/pushapkscript/publish.py
@@ -6,15 +6,16 @@ from mozapkpublisher.push_apk import push_apk
 log = logging.getLogger(__name__)
 
 
-def publish(product_config, publish_config, apk_files, contact_server):
+async def publish(product_config, publish_config, apk_files, contact_server):
     if apk_files:
-        push_apk(
+        await push_apk(
             apks=apk_files,
-            secret=publish_config["secret"],
+            secret=publish_config.get("secret"),
             expected_package_names=publish_config["package_names"],
             track=publish_config.get("google_track"),
-            rollout_percentage=publish_config.get("google_rollout_percentage"),
+            rollout_percentage=publish_config.get("rollout_percentage"),
             dry_run=publish_config["dry_run"],
+            store=publish_config.get("target_store", "google"),
             # Only allowed to connect to store server if the configuration of the pushapkscript
             # instance allows it
             contact_server=contact_server,
@@ -22,16 +23,18 @@ def publish(product_config, publish_config, apk_files, contact_server):
             skip_check_multiple_locales=bool(product_config.get("skip_check_multiple_locales")),
             skip_check_same_locales=bool(product_config.get("skip_check_same_locales")),
             skip_checks_fennec=bool(product_config.get("skip_checks_fennec")),
+            sgs_service_account_id=publish_config.get("sgs_service_account_id"),
+            sgs_access_token=publish_config.get("sgs_access_token"),
         )
 
 
-def publish_aab(product_config, publish_config, aab_files, contact_server):
+async def publish_aab(product_config, publish_config, aab_files, contact_server):
     if aab_files:
-        push_aab(
+        await push_aab(
             aabs=aab_files,
-            secret=publish_config["secret"],
+            secret=publish_config.get("secret"),
             track=publish_config.get("google_track"),
-            rollout_percentage=publish_config.get("google_rollout_percentage"),
+            rollout_percentage=publish_config.get("rollout_percentage"),
             dry_run=publish_config["dry_run"],
             # Only allowed to connect to store server if the configuration of the pushapkscript
             # instance allows it

--- a/pushapkscript/src/pushapkscript/script.py
+++ b/pushapkscript/src/pushapkscript/script.py
@@ -54,9 +54,9 @@ async def async_main(context):
         socket.setdefaulttimeout(300)
 
         files = [stack.enter_context(open(apk_file_name)) for apk_file_name in all_apks_paths]
-        publish.publish(product_config, publish_config, files, contact_server)
+        await publish.publish(product_config, publish_config, files, contact_server)
         files = [stack.enter_context(open(aab_file_name)) for aab_file_name in all_aabs_paths]
-        publish.publish_aab(product_config, publish_config, files, contact_server)
+        await publish.publish_aab(product_config, publish_config, files, contact_server)
 
     log.info("Done!")
 

--- a/pushapkscript/tests/helpers/task_generator.py
+++ b/pushapkscript/tests/helpers/task_generator.py
@@ -1,9 +1,10 @@
 class TaskGenerator(object):
-    def __init__(self, rollout_percentage=None, should_commit_transaction=False):
+    def __init__(self, rollout_percentage=None, should_commit_transaction=False, store=None):
         self.arm_task_id = "fwk3elTDSe6FLoqg14piWg"
         self.x86_task_id = "PKP2v4y0RdqOuLCqhevD2A"
         self.should_commit_transaction = should_commit_transaction
         self.rollout_percentage = rollout_percentage
+        self.store = store
 
     def generate_task(self, product_name, channel=None):
         arm_task_id = self.arm_task_id
@@ -36,5 +37,8 @@ class TaskGenerator(object):
 
         if self.should_commit_transaction:
             task["payload"]["commit"] = True
+
+        if self.store:
+            task["payload"]["target_store"] = self.store
 
         return task

--- a/pushapkscript/tests/integration/test_integration_script.py
+++ b/pushapkscript/tests/integration/test_integration_script.py
@@ -161,6 +161,10 @@ class ConfigFileGenerator(object):
                                     "default_track": "production",
                                     "credentials_file": "/fenix-production.json",
                                 },
+                                "samsung": {
+                                    "service_account_id": "123",
+                                    "access_token": "456",
+                                },
                             },
                         },
                     }
@@ -223,6 +227,7 @@ class MainTest(unittest.TestCase):
             secret="/firefox-nightly.json",
             track="beta",
             expected_package_names=["org.mozilla.fennec_aurora"],
+            store="google",
             rollout_percentage=None,
             dry_run=True,
             contact_server=True,
@@ -230,6 +235,8 @@ class MainTest(unittest.TestCase):
             skip_check_ordered_version_codes=False,
             skip_check_same_locales=False,
             skip_checks_fennec=False,
+            sgs_service_account_id=None,
+            sgs_access_token=None,
         )
 
     @unittest.mock.patch("pushapkscript.publish.push_apk")
@@ -249,6 +256,7 @@ class MainTest(unittest.TestCase):
             secret="/focus.json",
             track="production",
             expected_package_names=["org.mozilla.focus", "org.mozilla.klar"],
+            store="google",
             rollout_percentage=None,
             dry_run=True,
             contact_server=True,
@@ -256,6 +264,8 @@ class MainTest(unittest.TestCase):
             skip_check_ordered_version_codes=True,
             skip_check_same_locales=False,
             skip_checks_fennec=True,
+            sgs_service_account_id=None,
+            sgs_access_token=None,
         )
 
     @unittest.mock.patch("pushapkscript.publish.push_apk")
@@ -275,6 +285,7 @@ class MainTest(unittest.TestCase):
             secret="/fenix-nightly.json",
             track="beta",
             expected_package_names=["org.mozilla.fenix.nightly"],
+            store="google",
             rollout_percentage=None,
             dry_run=True,
             contact_server=True,
@@ -282,6 +293,8 @@ class MainTest(unittest.TestCase):
             skip_check_ordered_version_codes=False,
             skip_check_same_locales=True,
             skip_checks_fennec=True,
+            sgs_service_account_id=None,
+            sgs_access_token=None,
         )
 
     @unittest.mock.patch("pushapkscript.publish.push_apk")
@@ -301,6 +314,7 @@ class MainTest(unittest.TestCase):
             secret="/firefox-nightly.json",
             track="beta",
             expected_package_names=["org.mozilla.fennec_aurora"],
+            store="google",
             rollout_percentage=None,
             dry_run=True,
             contact_server=True,
@@ -308,6 +322,8 @@ class MainTest(unittest.TestCase):
             skip_check_ordered_version_codes=False,
             skip_check_same_locales=False,
             skip_checks_fennec=False,
+            sgs_service_account_id=None,
+            sgs_access_token=None,
         )
 
     @unittest.mock.patch("pushapkscript.publish.push_apk")
@@ -327,6 +343,7 @@ class MainTest(unittest.TestCase):
             secret="/firefox-nightly.json",
             track="beta",
             expected_package_names=["org.mozilla.fennec_aurora"],
+            store="google",
             rollout_percentage=25,
             dry_run=True,
             contact_server=True,
@@ -334,6 +351,8 @@ class MainTest(unittest.TestCase):
             skip_check_ordered_version_codes=False,
             skip_check_same_locales=False,
             skip_checks_fennec=False,
+            sgs_service_account_id=None,
+            sgs_access_token=None,
         )
 
     @unittest.mock.patch("pushapkscript.publish.push_apk")
@@ -354,6 +373,7 @@ class MainTest(unittest.TestCase):
             secret="/firefox-nightly.json",
             track="beta",
             expected_package_names=["org.mozilla.fennec_aurora"],
+            store="google",
             rollout_percentage=None,
             dry_run=False,
             contact_server=True,
@@ -361,4 +381,36 @@ class MainTest(unittest.TestCase):
             skip_check_ordered_version_codes=False,
             skip_check_same_locales=False,
             skip_checks_fennec=False,
+            sgs_service_account_id=None,
+            sgs_access_token=None,
+        )
+
+    @unittest.mock.patch("pushapkscript.publish.push_apk")
+    def test_main_with_samsung_store(self, push_apk):
+        task_generator = TaskGenerator(should_commit_transaction=True, store="samsung")
+
+        self.write_task_file(task_generator.generate_task("fenix", channel="release"))
+
+        self._copy_all_apks_to_test_temp_dir(task_generator)
+        self.keystore_manager.add_certificate("nightly")
+        main(config_path=self.config_generator.generate_fenix_config())
+
+        push_apk.assert_called_with(
+            apks=[
+                MockFile("{}/work/cot/{}/public/build/target.apk".format(self.test_temp_dir, task_generator.arm_task_id)),
+                MockFile("{}/work/cot/{}/public/build/target.apk".format(self.test_temp_dir, task_generator.x86_task_id)),
+            ],
+            secret=None,
+            track=None,
+            expected_package_names=["org.mozilla.fenix"],
+            store="samsung",
+            rollout_percentage=None,
+            dry_run=False,
+            contact_server=True,
+            skip_check_multiple_locales=True,
+            skip_check_ordered_version_codes=False,
+            skip_check_same_locales=True,
+            skip_checks_fennec=True,
+            sgs_service_account_id="123",
+            sgs_access_token="456",
         )

--- a/pushapkscript/tests/test_config.py
+++ b/pushapkscript/tests/test_config.py
@@ -65,5 +65,21 @@ def test_firefox_fake_prod():
         "ENV": "fake-prod",
         "GOOGLE_CREDENTIALS_FENIX_DEP_PATH": "fenix",
         "GOOGLE_CREDENTIALS_FOCUS_DEP_PATH": "focus",
+        "SGS_SERVICE_ACCOUNT_ID_DEP": "123456",
+        "SGS_ACCESS_TOKEN_DEP": "abcdef",
+    }
+    _validate_config(context)
+
+
+def test_firefox_prod():
+    context = {
+        "COT_PRODUCT": "firefox",
+        "ENV": "prod",
+        "GOOGLE_CREDENTIALS_FENIX_BETA_PATH": "beta",
+        "GOOGLE_CREDENTIALS_FENIX_RELEASE_PATH": "release",
+        "GOOGLE_CREDENTIALS_FENIX_NIGHTLY_PATH": "nightly",
+        "GOOGLE_CREDENTIALS_FOCUS_PATH": "focus",
+        "SGS_SERVICE_ACCOUNT_ID": "123456",
+        "SGS_ACCESS_TOKEN": "abcdef",
     }
     _validate_config(context)

--- a/pushapkscript/tests/test_publish.py
+++ b/pushapkscript/tests/test_publish.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch
 
+import pytest
+import asyncio
 from pushapkscript.publish import publish, publish_aab
 
 from .helpers.mock_file import MockFile, mock_open
@@ -10,7 +12,8 @@ from .helpers.mock_file import MockFile, mock_open
 @patch("pushapkscript.publish.open", new=mock_open)
 @patch("pushapkscript.publish.push_apk")
 @patch("pushapkscript.publish.push_aab")
-class PublishTest(unittest.TestCase):
+@pytest.mark.asyncio
+class PublishTest:
     def setUp(self):
         self.publish_config = {
             "target_store": "google",
@@ -22,14 +25,15 @@ class PublishTest(unittest.TestCase):
         self.apks = [MockFile("/path/to/x86.apk"), MockFile("/path/to/arm_v15.apk")]
         self.aabs = [MockFile("/path/to/aab1.aab"), MockFile("/path/to/aab2.aab")]
 
-    def test_publish_config(self, mock_push_aab, mock_push_apk):
-        publish({}, self.publish_config, self.apks, contact_server=True)
+    async def test_publish_config(self, mock_push_aab, mock_push_apk):
+        await publish({}, self.publish_config, self.apks, contact_server=True)
 
         mock_push_apk.assert_called_with(
             apks=[MockFile("/path/to/x86.apk"), MockFile("/path/to/arm_v15.apk")],
             secret="/google_credentials.json",
             track="beta",
             expected_package_names=["org.mozilla.fennec_aurora"],
+            store="google",
             rollout_percentage=None,
             dry_run=True,
             contact_server=True,
@@ -37,10 +41,12 @@ class PublishTest(unittest.TestCase):
             skip_check_ordered_version_codes=False,
             skip_check_same_locales=False,
             skip_checks_fennec=False,
+            sgs_service_account_id=None,
+            sgs_access_token=None,
         )
 
-    def test_publish_aab_config(self, mock_push_aab, mock_push_apk):
-        publish_aab({}, self.publish_config, self.aabs, contact_server=True)
+    async def test_publish_aab_config(self, mock_push_aab, mock_push_apk):
+        await publish_aab({}, self.publish_config, self.aabs, contact_server=True)
 
         mock_push_aab.assert_called_with(
             aabs=[MockFile("/path/to/aab1.aab"), MockFile("/path/to/aab2.aab")],
@@ -51,44 +57,44 @@ class PublishTest(unittest.TestCase):
             contact_server=True,
         )
 
-    def test_publish_allows_rollout_percentage(self, mock_push_aab, mock_push_apk):
+    async def test_publish_allows_rollout_percentage(self, mock_push_aab, mock_push_apk):
         publish_config = {
             "target_store": "google",
             "dry_run": True,
             "google_track": "production",
-            "google_rollout_percentage": 10,
+            "rollout_percentage": 10,
             "package_names": ["org.mozilla.fennec_aurora"],
             "secret": "/google_credentials.json",
         }
-        publish({}, publish_config, self.apks, contact_server=True)
+        await publish({}, publish_config, self.apks, contact_server=True)
         _, args = mock_push_apk.call_args
         assert args["track"] == "production"
         assert args["rollout_percentage"] == 10
 
-    def test_publish_aab_allows_rollout_percentage(self, mock_push_aab, mock_push_apk):
+    async def test_publish_aab_allows_rollout_percentage(self, mock_push_aab, mock_push_apk):
         publish_config = {
             "dry_run": True,
             "google_track": "production",
-            "google_rollout_percentage": 10,
+            "rollout_percentage": 10,
             "package_names": ["org.mozilla.fennec_aurora"],
             "secret": "/google_credentials.json",
         }
-        publish_aab({}, publish_config, self.aabs, contact_server=True)
+        await publish_aab({}, publish_config, self.aabs, contact_server=True)
         _, args = mock_push_aab.call_args
         assert args["track"] == "production"
         assert args["rollout_percentage"] == 10
 
-    def test_craft_push_config_allows_to_contact_google_play_or_not(self, mock_push_aab, mock_push_apk):
-        publish({}, self.publish_config, self.apks, contact_server=True)
+    async def test_craft_push_config_allows_to_contact_google_play_or_not(self, mock_push_aab, mock_push_apk):
+        await publish({}, self.publish_config, self.apks, contact_server=True)
         _, args = mock_push_apk.call_args
         assert args["contact_server"] is True
 
-        publish({}, self.publish_config, self.apks, False)
+        await publish({}, self.publish_config, self.apks, False)
         _, args = mock_push_apk.call_args
         assert args["contact_server"] is False
 
-    def test_craft_push_aab_config_allows_to_contact_google_play_or_not(self, mock_push_aab, mock_push_apk):
-        publish_aab({}, self.publish_config, self.aabs, contact_server=True)
+    async def test_craft_push_aab_config_allows_to_contact_google_play_or_not(self, mock_push_aab, mock_push_apk):
+        await publish_aab({}, self.publish_config, self.aabs, contact_server=True)
         _, args = mock_push_aab.call_args
         assert args["contact_server"] is True
 
@@ -96,19 +102,19 @@ class PublishTest(unittest.TestCase):
         _, args = mock_push_aab.call_args
         assert args["contact_server"] is False
 
-    def test_craft_push_config_skip_checking_multiple_locales(self, mock_push_aab, mock_push_apk):
+    async def test_craft_push_config_skip_checking_multiple_locales(self, mock_push_aab, mock_push_apk):
         product_config = {"skip_check_multiple_locales": True}
-        publish(product_config, self.publish_config, self.apks, contact_server=True)
+        await publish(product_config, self.publish_config, self.apks, contact_server=True)
         _, args = mock_push_apk.call_args
         assert args["skip_check_multiple_locales"] is True
 
-    def test_craft_push_config_skip_checking_same_locales(self, mock_push_aab, mock_push_apk):
+    async def test_craft_push_config_skip_checking_same_locales(self, mock_push_aab, mock_push_apk):
         product_config = {"skip_check_same_locales": True}
-        publish(product_config, self.publish_config, self.apks, contact_server=True)
+        await publish(product_config, self.publish_config, self.apks, contact_server=True)
         _, args = mock_push_apk.call_args
         assert args["skip_check_same_locales"] is True
 
-    def test_craft_push_config_expect_package_names(self, mock_push_aab, mock_push_apk):
+    async def test_craft_push_config_expect_package_names(self, mock_push_aab, mock_push_apk):
         publish_config = {
             "target_store": "google",
             "dry_run": True,
@@ -116,11 +122,11 @@ class PublishTest(unittest.TestCase):
             "package_names": ["org.mozilla.focus", "org.mozilla.klar"],
             "secret": "/google_credentials.json",
         }
-        publish({}, publish_config, self.apks, contact_server=True)
+        await publish({}, publish_config, self.apks, contact_server=True)
         _, args = mock_push_apk.call_args
         assert args["expected_package_names"] == ["org.mozilla.focus", "org.mozilla.klar"]
 
-    def test_craft_push_config_allows_committing_apks(self, mock_push_aab, mock_push_apk):
+    async def test_craft_push_config_allows_committing_apks(self, mock_push_aab, mock_push_apk):
         publish_config = {
             "target_store": "google",
             "dry_run": False,
@@ -128,17 +134,17 @@ class PublishTest(unittest.TestCase):
             "package_names": ["org.mozilla.focus", "org.mozilla.klar"],
             "secret": "/google_credentials.json",
         }
-        publish({}, publish_config, self.apks, contact_server=True)
+        await publish({}, publish_config, self.apks, contact_server=True)
         _, args = mock_push_apk.call_args
         assert args["dry_run"] is False
 
-    def test_craft_push_aab_config_allows_committing_apks(self, mock_push_aab, mock_push_apk):
+    async def test_craft_push_aab_config_allows_committing_apks(self, mock_push_aab, mock_push_apk):
         publish_config = {
             "dry_run": False,
             "google_track": "beta",
             "package_names": ["org.mozilla.focus", "org.mozilla.klar"],
             "secret": "/google_credentials.json",
         }
-        publish_aab({}, publish_config, self.aabs, contact_server=True)
+        await publish_aab({}, publish_config, self.aabs, contact_server=True)
         _, args = mock_push_aab.call_args
         assert args["dry_run"] is False

--- a/pushapkscript/tests/test_script.py
+++ b/pushapkscript/tests/test_script.py
@@ -53,6 +53,7 @@ async def test_async_main(monkeypatch, android_product, upstream_artifacts, is_a
     context.task = {"payload": {"channel": android_product}}
 
     if is_aab:
+
         async def assert_google_play_call_aab(_, __, all_aabs_files, ___):
             assert sorted([file.name for file in all_aabs_files]) == ["/some/path/to/another.aab", "/some/path/to/one.aab", "/some/path/to/yet_another.aab"]
 

--- a/pushapkscript/tests/test_script.py
+++ b/pushapkscript/tests/test_script.py
@@ -53,14 +53,13 @@ async def test_async_main(monkeypatch, android_product, upstream_artifacts, is_a
     context.task = {"payload": {"channel": android_product}}
 
     if is_aab:
-
-        def assert_google_play_call_aab(_, __, all_aabs_files, ___):
+        async def assert_google_play_call_aab(_, __, all_aabs_files, ___):
             assert sorted([file.name for file in all_aabs_files]) == ["/some/path/to/another.aab", "/some/path/to/one.aab", "/some/path/to/yet_another.aab"]
 
         monkeypatch.setattr(publish, "publish_aab", assert_google_play_call_aab)
     else:
 
-        def assert_google_play_call_apk(_, __, all_apks_files, ___):
+        async def assert_google_play_call_apk(_, __, all_apks_files, ___):
             assert sorted([file.name for file in all_apks_files]) == ["/some/path/to/another.apk", "/some/path/to/one.apk", "/some/path/to/yet_another.apk"]
 
         monkeypatch.setattr(publish, "publish", assert_google_play_call_apk)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -70,6 +70,8 @@ CONTEXT = {
         "GOOGLE_SERVICE_ACCOUNT_FOCUS": "Zm9vYmFyCg==",
         "GOOGLE_SERVICE_ACCOUNT_MOZILLAVPN": "Zm9vYmFyCg==",
         "GOOGLE_SERVICE_ACCOUNT_REFERENCE_BROWSER": "Zm9vYmFyCg==",
+        "SGS_SERVICE_ACCOUNT_ID": "Zm9vYmFyCg==",
+        "SGS_ACCESS_TOKEN": "Zm9vYmFyCg==",
     },
     re.compile(r"pushflatpak:.*"): {
         "FLATHUB_URL": "https://flathub.example.com",


### PR DESCRIPTION
The target store was already part of the task schema as a leftover from amazon. I just added support for samsung there. Because it also has support for rollouts, I made that non google specific. I also overloaded the `commit` parameter although a dry run on the samsung galaxy store won't do anything beside checking that the arguments passed in and the APKs are correct.