### PR TITLE
fix: use gcp prod for dev/fake-prod vpn signing

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -259,10 +259,13 @@ in:
              ["gcp_prod_autograph_authenticode_202412", "gcp_prod_autograph_authenticode_202412_stub"],
              "authenticode_dep_sha256"
           ]
-          - ["https://autograph-external.prod.autograph.services.mozaws.net",
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
              {"$eval": "AUTOGRAPH_MOZILLAVPN_USERNAME"},
              {"$eval": "AUTOGRAPH_MOZILLAVPN_PASSWORD"},
              ["gcp_prod_autograph_apk"],
+             # This is a weird keyid to use here, but we don't have a
+             # VPN-specific key signer for dep signing. We just need _any_
+             # APK signer for testing, and this fits that bill.
              "geckoview_reference_browser_dep_apk"
           ]
           - ["https://prod.autograph.prod.webservices.mozgcp.net",


### PR DESCRIPTION
...and add a note about why we don't use a VPN-looking keyid.

Additional context on that that doesn't belong in the comments is that prior to #1099, we didn't have _any_ entry for apk signing in dev and fake-prod. In a more ideal world we might consider using a single, generically named, key for all dep apk signing. I'm not sure it's worth pursuing that at the moment.