### PR TITLE
fix(landoscript): don't require replacements and merge_old_head for merge day payloads

### DIFF
--- a/landoscript/src/landoscript/data/landoscript_task_schema.json
+++ b/landoscript/src/landoscript/data/landoscript_task_schema.json
@@ -5,9 +5,7 @@
         "merge_day_payload": {
             "type": "object",
             "required": [
-                "replacements",
-                "to_branch",
-                "merge_old_head"
+                "to_branch"
             ],
             "properties": {
                 "fetch_version_from": {
@@ -48,6 +46,7 @@
                 "replacements": {
                     "type": "array",
                     "minItems": 0,
+                    "default": [],
                     "items": {
                         "type": "array",
                         "minItems": 3,


### PR DESCRIPTION
Both of these have default values; they are not required.