### PR TITLE
feat: disallow overwrites when uploading translations files

### DIFF
--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -927,7 +927,14 @@ async def retry_upload(context, destinations, path, expiry=None, fail_on_unknown
         if is_cloud_enabled(context.config, "gcloud", context.resource):
             cloud_uploads["gcloud"].append(
                 asyncio.ensure_future(
-                    upload_to_gcs(context=context, target_path=dest, path=path, expiry=expiry, fail_on_unknown_mimetype=fail_on_unknown_mimetype, allow_overwrites=allow_overwrites)
+                    upload_to_gcs(
+                        context=context,
+                        target_path=dest,
+                        path=path,
+                        expiry=expiry,
+                        fail_on_unknown_mimetype=fail_on_unknown_mimetype,
+                        allow_overwrites=allow_overwrites,
+                    )
                 )
             )
 

--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -504,7 +504,7 @@ async def upload_translations_artifacts(context):
     for map_ in concreteArtifactMap:
         for input_path, outputs in map_["paths"].items():
             log.info(f"Uploading {input_path} to {outputs['destinations']}")
-            await retry_upload(context, outputs["destinations"], input_path, fail_on_unknown_mimetype=False)
+            await retry_upload(context, outputs["destinations"], input_path, fail_on_unknown_mimetype=False, allow_overwrites=False)
 
 
 # copy_beets {{{1
@@ -907,7 +907,7 @@ async def retry_data_upload(context, destinations, data, contentType):
 
 
 # retry_upload {{{1
-async def retry_upload(context, destinations, path, expiry=None, fail_on_unknown_mimetype=True):
+async def retry_upload(context, destinations, path, expiry=None, fail_on_unknown_mimetype=True, allow_overwrites=True):
     """Manage upload of `path` to `destinations`."""
     cloud_uploads = {key: [] for key in context.config["clouds"]}
 
@@ -918,6 +918,7 @@ async def retry_upload(context, destinations, path, expiry=None, fail_on_unknown
         # S3 upload
         enabled = is_cloud_enabled(context.config, "aws", context.resource)
         if enabled is True or (enabled == "buildhub-only" and path.endswith("buildhub.json")):
+            # aws is legacy; `new_only` is not supported here
             cloud_uploads["aws"].append(
                 asyncio.ensure_future(upload_to_s3(context=context, s3_key=dest, path=path, fail_on_unknown_mimetype=fail_on_unknown_mimetype))
             )
@@ -926,7 +927,7 @@ async def retry_upload(context, destinations, path, expiry=None, fail_on_unknown
         if is_cloud_enabled(context.config, "gcloud", context.resource):
             cloud_uploads["gcloud"].append(
                 asyncio.ensure_future(
-                    upload_to_gcs(context=context, target_path=dest, path=path, expiry=expiry, fail_on_unknown_mimetype=fail_on_unknown_mimetype)
+                    upload_to_gcs(context=context, target_path=dest, path=path, expiry=expiry, fail_on_unknown_mimetype=fail_on_unknown_mimetype, allow_overwrites=allow_overwrites)
                 )
             )
 

--- a/beetmoverscript/tests/test_script.py
+++ b/beetmoverscript/tests/test_script.py
@@ -1401,38 +1401,38 @@ async def test_upload_translations_artifacts(aioresponses, monkeypatch, context,
 @pytest.mark.asyncio
 async def test_upload_translations_artifacts_overwrites(aioresponses, monkeypatch, context, exists_upfront, upload_from_filename_err, expected_err):
     upstream_artifacts = [
-                {
-                    "paths": [
-                        "public/build/*",
-                        "public/logs/*",
-                    ],
-                    "taskId": "dep1",
-                },
-            ]
+        {
+            "paths": [
+                "public/build/*",
+                "public/logs/*",
+            ],
+            "taskId": "dep1",
+        },
+    ]
     artifact_map = [
-                {
-                    "paths": {
-                        "*.log": {
-                            "destinations": [
-                                "some/dir/",
-                                "some/log/",
-                            ]
-                        },
-                        "*": {
-                            "destinations": [
-                                "some/dir/",
-                                "some/other/",
-                            ]
-                        },
-                    },
-                    "taskId": "dep1",
+        {
+            "paths": {
+                "*.log": {
+                    "destinations": [
+                        "some/dir/",
+                        "some/log/",
+                    ]
                 },
-            ]
+                "*": {
+                    "destinations": [
+                        "some/dir/",
+                        "some/other/",
+                    ]
+                },
+            },
+            "taskId": "dep1",
+        },
+    ]
     expected_uploads = {
-                "public/build/foo": ["some/dir/foo", "some/other/foo"],
-                "public/build/bar": ["some/dir/bar", "some/other/bar"],
-                "public/logs/live.log": ["some/dir/live.log", "some/log/live.log"],
-            }
+        "public/build/foo": ["some/dir/foo", "some/other/foo"],
+        "public/build/bar": ["some/dir/bar", "some/other/bar"],
+        "public/logs/live.log": ["some/dir/live.log", "some/log/live.log"],
+    }
     with tempfile.TemporaryDirectory() as tmp:
         context.config["work_dir"] = tmp
         for artifact in expected_uploads.keys():

--- a/beetmoverscript/tests/test_script.py
+++ b/beetmoverscript/tests/test_script.py
@@ -9,6 +9,7 @@ from io import BytesIO
 
 import aiohttp
 import boto3
+from google.cloud.exceptions import GoogleCloudError
 import mock
 import pytest
 from scriptworker.context import Context
@@ -1378,6 +1379,97 @@ async def test_upload_translations_artifacts(aioresponses, monkeypatch, context,
             # verify GCS expectations
             expected_call_count = sum([len(uploads) for uploads in expected_uploads.values()])
             assert blob.upload_from_filename.call_count == expected_call_count
+
+
+@pytest.mark.parametrize(
+    "exists_upfront,upload_from_filename_err,expected_err",
+    (
+        pytest.param(
+            True,
+            None,
+            ScriptWorkerTaskException,
+            id="exists_upfront",
+        ),
+        pytest.param(
+            False,
+            GoogleCloudError("exists"),
+            GoogleCloudError,
+            id="exists_at_upload_time",
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_upload_translations_artifacts_overwrites(aioresponses, monkeypatch, context, exists_upfront, upload_from_filename_err, expected_err):
+    upstream_artifacts = [
+                {
+                    "paths": [
+                        "public/build/*",
+                        "public/logs/*",
+                    ],
+                    "taskId": "dep1",
+                },
+            ]
+    artifact_map = [
+                {
+                    "paths": {
+                        "*.log": {
+                            "destinations": [
+                                "some/dir/",
+                                "some/log/",
+                            ]
+                        },
+                        "*": {
+                            "destinations": [
+                                "some/dir/",
+                                "some/other/",
+                            ]
+                        },
+                    },
+                    "taskId": "dep1",
+                },
+            ]
+    expected_uploads = {
+                "public/build/foo": ["some/dir/foo", "some/other/foo"],
+                "public/build/bar": ["some/dir/bar", "some/other/bar"],
+                "public/logs/live.log": ["some/dir/live.log", "some/log/live.log"],
+            }
+    with tempfile.TemporaryDirectory() as tmp:
+        context.config["work_dir"] = tmp
+        for artifact in expected_uploads.keys():
+            artifact_path = os.path.join(tmp, "cot", "dep1", artifact)
+            artifact_dir = os.path.dirname(artifact_path)
+            os.makedirs(artifact_dir, exist_ok=True)
+            pathlib.Path(artifact_path).touch()
+
+        async with aiohttp.ClientSession() as session:
+            # needed for mocking AWS uploads
+            context.session = session
+            for uploads in expected_uploads.values():
+                for upload in uploads:
+                    aioresponses.put(re.compile(f"https://dummy.s3.amazonaws.com/{upload}?.*"), status=200)
+
+            # needed for mocking GCS uploads
+            context.gcs_client = FakeClient()
+            blob = FakeClient.FakeBlob()
+            blob._exists = exists_upfront
+            blob.upload_from_filename = mock.MagicMock(side_effect=upload_from_filename_err)
+            bucket = FakeClient.FakeBucket(FakeClient, "foobucket")
+            bucket.blob = mock.MagicMock()
+            bucket.blob.return_value = blob
+            monkeypatch.setattr(beetmoverscript.gcloud, "Bucket", lambda client, name: bucket)
+
+            context.action = "upload-translations-artifacts"
+            context.task = {
+                "payload": {"releaseProperties": {"appName": "fake"}, "upstreamArtifacts": upstream_artifacts, "artifactMap": artifact_map},
+                "scopes": ["project:releng:beetmover:action:upload-translations-artifacts"],
+            }
+            with pytest.raises(expected_err):
+                await upload_translations_artifacts(context)
+
+            if exists_upfront:
+                assert blob.upload_from_filename.call_count == 0
+            else:
+                assert blob.upload_from_filename.call_args[1]["if_generation_match"] == 0
 
 
 # async_main {{{1


### PR DESCRIPTION
In my original work on this I ensured that no single task could write to the same file twice. Unfortunately, this didn't cover different tasks trying to write to the same location, which is being guarded against here.