### PR TITLE
landoscript diffs should have sorted filenames

### DIFF
--- a/landoscript/src/landoscript/actions/android_l10n_sync.py
+++ b/landoscript/src/landoscript/actions/android_l10n_sync.py
@@ -82,7 +82,7 @@ async def run(github_client: GithubClient, public_artifact_dir: str, android_l10
     log.info(f"fetching original files from l10n repository: {dst_files}")
     orig_files = await github_client.get_files(dst_files, branch=to_branch)
 
-    diffs = []
+    files_to_diff = []
     for l10n_file in l10n_files:
         if l10n_file.dst_name not in orig_files:
             log.warning(f"WEIRD: {l10n_file.dst_name} not in orig_files, continuing anyways...")
@@ -98,7 +98,7 @@ async def run(github_client: GithubClient, public_artifact_dir: str, android_l10
             log.warning(f"old and new contents of {l10n_file.dst_name} are the same, skipping bump...")
             continue
 
-        diffs.append(diff_contents(orig_file, new_file, l10n_file.dst_name))
+        files_to_diff.append((l10n_file.dst_name, orig_file, new_file))
 
     for toml_info in android_l10n_sync_info.toml_info:
         if toml_info.toml_path not in new_files or toml_info.toml_path not in orig_files:
@@ -111,10 +111,17 @@ async def run(github_client: GithubClient, public_artifact_dir: str, android_l10
             log.warning(f"old and new contents of {toml_info.toml_path} are the same, skipping bump...")
             continue
 
-        diffs.append(diff_contents(orig_file, new_file, toml_info.toml_path))
+        files_to_diff.append((toml_info.toml_path, orig_file, new_file))
 
-    if not diffs:
+    if not files_to_diff:
         return []
+
+    # Sort files by path
+    files_to_diff.sort(key=lambda x: x[0])
+
+    diffs = []
+    for file_path, orig_file, new_file in files_to_diff:
+        diffs.append(diff_contents(orig_file, new_file, file_path))
 
     diff = "\n".join(diffs)
 

--- a/landoscript/src/landoscript/actions/version_bump.py
+++ b/landoscript/src/landoscript/actions/version_bump.py
@@ -98,6 +98,10 @@ async def run(
         log.info("no files to bump")
         return []
 
+    def extract_path(diff_text):
+        return diff_text.split("\n", 1)[0].split(" ")[2][2:]
+
+    diffs = sorted(diffs, key=extract_path)
     diff = "\n".join(diffs)
 
     with open(os.path.join(public_artifact_dir, "version-bump.diff"), "w+") as f:

--- a/landoscript/src/landoscript/actions/version_bump.py
+++ b/landoscript/src/landoscript/actions/version_bump.py
@@ -69,7 +69,10 @@ async def run(
             log.info(f"{file} contents:")
             log_file_contents(str(contents))
 
-        for file, orig in orig_files.items():
+        # Sort files by path to ensure consistent diff ordering
+        sorted_files = sorted(orig_files.keys())
+        for file in sorted_files:
+            orig = orig_files[file]
             if not orig:
                 raise LandoscriptError(f"{file} does not exist!")
 

--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -216,7 +216,7 @@ def assert_add_commit_response(action, commit_msg_strings, initial_values, expec
         assert msg in action["commitmsg"]
 
     diffs = action["diff"].split("\ndiff")
-    
+
     # Extract file paths from diffs and verify they are sorted
     file_paths = []
     for diff in diffs:

--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -216,6 +216,19 @@ def assert_add_commit_response(action, commit_msg_strings, initial_values, expec
         assert msg in action["commitmsg"]
 
     diffs = action["diff"].split("\ndiff")
+    
+    # Extract file paths from diffs and verify they are sorted
+    file_paths = []
+    for diff in diffs:
+        if not diff:
+            continue
+
+        path_line = diff.split("\n")[0]
+        if path_line.startswith("diff --git"):
+            file_path = path_line.split(" ")[2][2:]
+            file_paths.append(file_path)
+
+    assert file_paths == sorted(file_paths), f"Files in diff are not sorted. Got: {file_paths}"
 
     # ensure expected bumps are present to a reasonable degree of certainty
     for file, after in expected_bumps.items():

--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -219,14 +219,17 @@ def assert_add_commit_response(action, commit_msg_strings, initial_values, expec
 
     # Extract file paths from diffs and verify they are sorted
     file_paths = []
-    for diff in diffs:
+    for i, diff in enumerate(diffs):
         if not diff:
             continue
 
-        path_line = diff.split("\n")[0]
-        if path_line.startswith("diff --git"):
-            file_path = path_line.split(" ")[2][2:]
-            file_paths.append(file_path)
+        if i == 0:
+            path_line = diff.split("\n")[0]
+        else:
+            path_line = "diff" + diff.split("\n")[0]
+
+        file_path = path_line.split(" ")[2][2:]
+        file_paths.append(file_path)
 
     assert file_paths == sorted(file_paths), f"Files in diff are not sorted. Got: {file_paths}"
 


### PR DESCRIPTION
This addresses this bugzilla ticket: https://bugzilla.mozilla.org/show_bug.cgi?id=1967637:

> A typical diff is sorted by filename/path. The diffs that [landoscript](https://github.com/mozilla-releng/scriptworker-scripts/tree/master/landoscript) generates are not. This can plausibly happen in any action that calls diff_contents more than once, but I've certainly seen it in the android_l10n and merge_day actions.
> 
> It's an extremely minor thing, but it can be confusing to someone that's not aware that it may happen.