### PR TITLE
fix(landoscript): ensure a newline exists between diff sections

### DIFF
--- a/landoscript/src/landoscript/actions/android_l10n_import.py
+++ b/landoscript/src/landoscript/actions/android_l10n_import.py
@@ -90,7 +90,7 @@ async def run(
         log.info(f"fetching original files from l10n repository: {dst_files}")
         orig_files = await github_client.get_files(dst_files, branch=to_branch)
 
-        diff = ""
+        diffs = []
         for l10n_file in l10n_files:
             if l10n_file.dst_name not in orig_files:
                 log.warning(f"WEIRD: {l10n_file.dst_name} not in orig_files, continuing anyways...")
@@ -106,7 +106,7 @@ async def run(
                 log.warning(f"old and new contents of {l10n_file.dst_name} are the same, skipping bump...")
                 continue
 
-            diff += diff_contents(orig_file, new_file, l10n_file.dst_name)
+            diffs.append(diff_contents(orig_file, new_file, l10n_file.dst_name))
 
         for toml_info in android_l10n_import_info.toml_info:
             src_path = toml_info.toml_path
@@ -122,10 +122,12 @@ async def run(
                 log.warning(f"old and new contents of {dst_path} are the same, skipping bump...")
                 continue
 
-            diff += diff_contents(orig_file, new_file, dst_path)
+            diffs.append(diff_contents(orig_file, new_file, dst_path))
 
-        if not diff:
+        if not diffs:
             return []
+
+        diff = "\n".join(diffs)
 
         with open(os.path.join(public_artifact_dir, "android-import.diff"), "w+") as f:
             f.write(diff)

--- a/landoscript/src/landoscript/actions/merge_day.py
+++ b/landoscript/src/landoscript/actions/merge_day.py
@@ -150,7 +150,7 @@ async def run(
     # process replacements, regex-replacements, and update clobber file
     replacements = merge_info.replacements
     regex_replacements = merge_info.regex_replacements
-    diff = ""
+    diffs = []
     if replacements or regex_replacements:
         log.info("Performing replacements and regex_replacements")
         needed_files = []
@@ -167,7 +167,7 @@ async def run(
             if orig_contents[fn] is None:
                 raise LandoscriptError(f"Couldn't find file '{fn}' in repository!")
 
-            diff += diff_contents(str(orig_contents[fn]), new_contents[fn], fn)
+            diffs.append(diff_contents(str(orig_contents[fn]), new_contents[fn], fn))
 
     log.info("Touching clobber file")
     orig_clobber_file = (await github_client.get_files("CLOBBER", bump_branch))["CLOBBER"]
@@ -175,7 +175,9 @@ async def run(
         raise LandoscriptError("Couldn't find CLOBBER file in repository!")
 
     new_clobber_file = get_new_clobber_file(orig_clobber_file)
-    diff += diff_contents(orig_clobber_file, new_clobber_file, "CLOBBER")
+    diffs.append(diff_contents(orig_clobber_file, new_clobber_file, "CLOBBER"))
+
+    diff = "\n".join(diffs)
 
     log.info("replacements and clobber diff is:")
     log_file_contents(diff)

--- a/landoscript/src/landoscript/actions/version_bump.py
+++ b/landoscript/src/landoscript/actions/version_bump.py
@@ -49,7 +49,7 @@ async def run(
     the time of writing is when running the `release-to-esr` merge automation. Future uses
     are discouraged, and should be avoided if at all possible."""
 
-    diff = ""
+    diffs = []
 
     for version_bump_info in version_bump_infos:
         next_version = version_bump_info.next_version
@@ -89,11 +89,13 @@ async def run(
             log.info(f"{file}: successfully bumped! new contents are:")
             log_file_contents(modified)
 
-            diff += diff_contents(orig, modified, file)
+            diffs.append(diff_contents(orig, modified, file))
 
-    if not diff:
+    if not diffs:
         log.info("no files to bump")
         return []
+
+    diff = "\n".join(diffs)
 
     with open(os.path.join(public_artifact_dir, "version-bump.diff"), "w+") as f:
         f.write(diff)

--- a/landoscript/tests/conftest.py
+++ b/landoscript/tests/conftest.py
@@ -215,7 +215,7 @@ def assert_add_commit_response(action, commit_msg_strings, initial_values, expec
     for msg in commit_msg_strings:
         assert msg in action["commitmsg"]
 
-    diffs = action["diff"].split("diff\n")
+    diffs = action["diff"].split("\ndiff")
 
     # ensure expected bumps are present to a reasonable degree of certainty
     for file, after in expected_bumps.items():
@@ -244,7 +244,7 @@ def assert_add_commit_response(action, commit_msg_strings, initial_values, expec
                     if "\n" in before or "\n" in after:
                         break
 
-                    if f"-{before}" in diff and f"+{after}":
+                    if f"-{before}" in diff and f"+{after}" in diff:
                         break
         else:
             assert False, f"no bump found for {file}: {diffs}"


### PR DESCRIPTION
I believe this broke with https://github.com/mozilla-releng/scriptworker-scripts/pull/1203, where `diff_contents` (correctly) stopped always having a newline character at the end of a diff, but callers were not updated to handle it.

Unfortunately, this was masked by a bug in the tests where we split on `diff\n` instead of `\ndiff` - resulting in the diffed files not being split correctly.