### PR TITLE
Remove coverall deps/jobs/mentions

### DIFF
--- a/addonscript/README.md
+++ b/addonscript/README.md
@@ -1,7 +1,7 @@
 Addonscript
 ==============
 
-[![Build Status](https://travis-ci.org/mozilla-releng/addonscript.svg?branch=master)](https://travis-ci.org/mozilla-releng/addonscript) [![Coverage Status](https://coveralls.io/repos/github/mozilla-releng/addonscript/badge.svg?branch=master)](https://coveralls.io/github/mozilla-releng/addonscript?branch=master)
+[![Build Status](https://travis-ci.org/mozilla-releng/addonscript.svg?branch=master)](https://travis-ci.org/mozilla-releng/addonscript)
 
 This is designed to be run from scriptworker, but runs perfectly fine as a standalone script.
 

--- a/addonscript/README.rst
+++ b/addonscript/README.rst
@@ -1,7 +1,7 @@
 Addonscript
 ===========
 
-|Build Status| |Coverage Status|
+|Build Status|
 
 This is designed to be run from scriptworker, but runs perfectly fine as
 a standalone script.
@@ -34,5 +34,3 @@ The easiest way to do this is to run ``pin.sh``:
 
 .. |Build Status| image:: https://travis-ci.org/mozilla-releng/addonscript.svg?branch=master
    :target: https://travis-ci.org/mozilla-releng/addonscript
-.. |Coverage Status| image:: https://coveralls.io/repos/github/mozilla-releng/addonscript/badge.svg?branch=master
-   :target: https://coveralls.io/github/mozilla-releng/addonscript?branch=master

--- a/balrogscript/README.md
+++ b/balrogscript/README.md
@@ -1,7 +1,6 @@
 # Balrogscript
 
 [![Build Status](https://travis-ci.org/mozilla-releng/balrogscript.svg?branch=master)](https://travis-ci.org/mozilla-releng/balrogscript)
-[![Coverage Status](https://coveralls.io/repos/github/mozilla-releng/balrogscript/badge.svg?branch=master)](https://coveralls.io/github/mozilla-releng/balrogscript?branch=master)
 
 A [scriptworker](https://github.com/mozilla-releng/scriptworker) script for submitting metadata to [balrog](https://wiki.mozilla.org/Balrog).
 

--- a/balrogscript/pyproject.toml
+++ b/balrogscript/pyproject.toml
@@ -32,7 +32,6 @@ dev-dependencies = [
     "tox",
     "tox-uv",
     "coverage",
-    "coveralls",
     "lockfile",
     "minimock",
     "mock",

--- a/balrogscript/tox.ini
+++ b/balrogscript/tox.ini
@@ -22,9 +22,6 @@ commands = coverage report -m
 depends = py311
 parallel_show_output = true
 
-[testenv:coveralls]
-commands=coveralls
-
 [pytest]
 addopts = -vv -s --color=yes
 asyncio_default_fixture_loop_scope = function

--- a/beetmoverscript/README.md
+++ b/beetmoverscript/README.md
@@ -1,7 +1,6 @@
 Beetmoverscript README
 
 [![Build Status](https://travis-ci.org/mozilla-releng/beetmoverscript.svg?branch=master)](https://travis-ci.org/mozilla-releng/beetmoverscript)
-[![Coverage Status](https://coveralls.io/repos/github/mozilla-releng/beetmoverscript/badge.svg?branch=master)](https://coveralls.io/github/mozilla-releng/beetmoverscript?branch=master)
 
 
 ## deploy a new version to staging

--- a/beetmoverscript/tox.ini
+++ b/beetmoverscript/tox.ini
@@ -22,13 +22,6 @@ commands = coverage report -m
 depends = py311
 parallel_show_output = true
 
-[testenv:coveralls]
-deps =
-    coveralls
-    coverage>=4.2
-commands =
-    coveralls
-
 [pytest]
 addopts = -vv -s --color=yes
 asyncio_default_fixture_loop_scope = function

--- a/bitrisescript/tox.ini
+++ b/bitrisescript/tox.ini
@@ -22,14 +22,6 @@ commands = coverage report -m
 depends = py311
 parallel_show_output = true
 
-[testenv:coveralls]
-deps=
-    coveralls
-    coverage
-    -e {toxinidir}/../scriptworker_client
-commands=
-    coveralls
-
 [pytest]
 asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox

--- a/bouncerscript/README.md
+++ b/bouncerscript/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/mozilla-releng/bouncerscript.svg?branch=master)](https://travis-ci.org/mozilla-releng/bouncerscript)
-[![Coverage Status](https://coveralls.io/repos/github/mozilla-releng/bouncerscript/badge.svg?branch=master)](https://coveralls.io/github/mozilla-releng/bouncerscript?branch=master)
 
 
 ## Bouncer behaviors in a nutshell

--- a/bouncerscript/pyproject.toml
+++ b/bouncerscript/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
 dev-dependencies = [
     "tox",
     "tox-uv",
-    "coveralls",
     "coverage>=4.2",
     "coverage",
     "mock",

--- a/bouncerscript/tox.ini
+++ b/bouncerscript/tox.ini
@@ -22,9 +22,6 @@ commands = coverage report -m
 depends = py311
 parallel_show_output = true
 
-[testenv:coveralls]
-commands=coveralls
-
 [pytest]
 addopts = -vv -s --color=yes
 asyncio_default_fixture_loop_scope = function

--- a/githubscript/tox.ini
+++ b/githubscript/tox.ini
@@ -22,14 +22,6 @@ commands = coverage report -m
 depends = py311
 parallel_show_output = true
 
-[testenv:coveralls]
-deps=
-    coveralls
-    coverage
-    -e {toxinidir}/../scriptworker_client
-commands=
-    coveralls
-
 [pytest]
 asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox

--- a/iscript/pyproject.toml
+++ b/iscript/pyproject.toml
@@ -34,7 +34,6 @@ dev-dependencies = [
     "coverage",
     "mock",
     "mypy",
-    "python-coveralls",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",

--- a/iscript/tox.ini
+++ b/iscript/tox.ini
@@ -25,9 +25,6 @@ commands = coverage report -m
 depends = py38
 parallel_show_output = true
 
-[testenv:coveralls]
-commands=coveralls
-
 [pytest]
 addopts = -vv -s --color=yes
 asyncio_default_fixture_loop_scope = function

--- a/landoscript/pyproject.toml
+++ b/landoscript/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
 dev-dependencies = [
     "tox",
     "tox-uv",
-    "coveralls",
     "coverage",
     "pytest",
     "pytest-aioresponses",

--- a/landoscript/tox.ini
+++ b/landoscript/tox.ini
@@ -25,8 +25,5 @@ parallel_show_output = true
 [coverage:run]
 branch = true
 
-[testenv:coveralls]
-commands=coveralls
-
 [pytest]
 asyncio_default_fixture_loop_scope = function

--- a/notarization_poller/pyproject.toml
+++ b/notarization_poller/pyproject.toml
@@ -35,7 +35,6 @@ dev-dependencies = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-mock",
-    "python-coveralls",
 ]
 
 [build-system]

--- a/pushapkscript/README.md
+++ b/pushapkscript/README.md
@@ -1,6 +1,6 @@
 # pushapkscript
 
-[![Build Status](https://travis-ci.org/mozilla-releng/pushapkscript.svg?branch=master)](https://travis-ci.org/mozilla-releng/pushapkscript) [![Coverage Status](https://coveralls.io/repos/github/mozilla-releng/pushapkscript/badge.svg?branch=master)](https://coveralls.io/github/mozilla-releng/pushapkscript?branch=master)
+[![Build Status](https://travis-ci.org/mozilla-releng/pushapkscript.svg?branch=master)](https://travis-ci.org/mozilla-releng/pushapkscript)
 
 Main script that is aimed to be run with [scriptworker](https://github.com/mozilla-releng/scriptworker) (but runs perfectly fine as a standalone script). This project is a fork of [signingscript](https://github.com/mozilla-releng/signingscript). Most of the documentation from signing script applies to this project.
 

--- a/pushapkscript/tox.ini
+++ b/pushapkscript/tox.ini
@@ -21,9 +21,6 @@ commands = coverage report -m
 depends = py311
 parallel_show_output = true
 
-[testenv:coveralls]
-commands=coveralls
-
 [pytest]
 asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox

--- a/pushflatpakscript/pyproject.toml
+++ b/pushflatpakscript/pyproject.toml
@@ -22,7 +22,6 @@ dev-dependencies = [
     "tox",
     "tox-uv",
     "coverage>=4.2b1",
-    "coveralls",
     "mock",
     "pytest",
     "pytest-asyncio",

--- a/pushflatpakscript/tox.ini
+++ b/pushflatpakscript/tox.ini
@@ -23,9 +23,6 @@ commands = coverage report -m
 depends = py311
 parallel_show_output = true
 
-[testenv:coveralls]
-commands=coveralls
-
 [pytest]
 asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox

--- a/pushmsixscript/README.md
+++ b/pushmsixscript/README.md
@@ -1,6 +1,6 @@
 # pushmsixscript
 
-[![Build Status](https://travis-ci.org/mozilla-releng/pushmsixscript.svg?branch=master)](https://travis-ci.org/mozilla-releng/pushmsixscript) [![Coverage Status](https://coveralls.io/repos/github/mozilla-releng/pushmsixscript/badge.svg?branch=master)](https://coveralls.io/github/mozilla-releng/pushmsixscript?branch=master)
+[![Build Status](https://travis-ci.org/mozilla-releng/pushmsixscript.svg?branch=master)](https://travis-ci.org/mozilla-releng/pushmsixscript)
 
 Main script that is aimed to be run with [scriptworker](https://github.com/mozilla-releng/scriptworker) (but runs perfectly fine as a standalone script).
 

--- a/pushmsixscript/pyproject.toml
+++ b/pushmsixscript/pyproject.toml
@@ -24,7 +24,6 @@ dev-dependencies = [
     "tox",
     "tox-uv",
     "coverage>=4.2b1",
-    "coveralls",
     "flake8",
     "mock",
     "pytest",

--- a/pushmsixscript/tox.ini
+++ b/pushmsixscript/tox.ini
@@ -21,9 +21,6 @@ commands = coverage report -m
 depends = py311
 parallel_show_output = true
 
-[testenv:coveralls]
-commands=coveralls
-
 [pytest]
 asyncio_default_fixture_loop_scope = function
 norecursedirs = .tox .git .hg sandbox

--- a/scriptworker_client/tox.ini
+++ b/scriptworker_client/tox.ini
@@ -14,13 +14,6 @@ commands =
     pytest --cov-config .coveragerc --cov={toxinidir}/src/scriptworker_client --cov-report term-missing
     coverage html
 
-[testenv:coveralls]
-# TODO: Remove the manual uv sync once we drop python3.8
-# See https://github.com/tox-dev/tox-uv/issues/209
-commands =
-    uv sync --frozen
-    coveralls
-
 [testenv:mypy]
 usedevelop = true
 # TODO: Remove the manual uv sync once we drop python3.8

--- a/shipitscript/README.rst
+++ b/shipitscript/README.rst
@@ -1,7 +1,7 @@
 Shipitscript
 ============
 
-|Build Status| |Coverage Status|
+|Build Status|
 
 
 Deployment
@@ -69,7 +69,5 @@ this repository.
 
 .. |Build Status| image:: https://travis-ci.org/mozilla-releng/shipitscript.svg?branch=master
    :target: https://travis-ci.org/mozilla-releng/shipitscript
-.. |Coverage Status| image:: https://coveralls.io/repos/github/mozilla-releng/shipitscript/badge.svg?branch=master
-   :target: https://coveralls.io/github/mozilla-releng/shipitscript?branch=master
 .. _`mozilla/shipitscript`: https://hub.docker.com/r/mozilla/shipitscript
 

--- a/shipitscript/pyproject.toml
+++ b/shipitscript/pyproject.toml
@@ -24,7 +24,6 @@ dev-dependencies = [
     "tox",
     "tox-uv",
     "coverage",
-    "coveralls",
     "mock",
     "pytest",
     "pytest-asyncio",

--- a/shipitscript/tox.ini
+++ b/shipitscript/tox.ini
@@ -21,9 +21,6 @@ commands = coverage report -m
 depends = py311
 parallel_show_output = true
 
-[testenv:coveralls]
-commands = coveralls
-
 [pytest]
 addopts = -vv -s --color=yes
 asyncio_default_fixture_loop_scope = function

--- a/signingscript/README.md
+++ b/signingscript/README.md
@@ -1,7 +1,7 @@
 Signingscript
 ==============
 
-[![Build Status](https://travis-ci.org/mozilla-releng/signingscript.svg?branch=master)](https://travis-ci.org/mozilla-releng/signingscript) [![Coverage Status](https://coveralls.io/repos/github/mozilla-releng/signingscript/badge.svg?branch=master)](https://coveralls.io/github/mozilla-releng/signingscript?branch=master)
+[![Build Status](https://travis-ci.org/mozilla-releng/signingscript.svg?branch=master)](https://travis-ci.org/mozilla-releng/signingscript)
 
 This is designed to be run from scriptworker, but runs perfectly fine as a standalone script.
 

--- a/signingscript/pyproject.toml
+++ b/signingscript/pyproject.toml
@@ -33,7 +33,6 @@ dev-dependencies = [
     "tox",
     "tox-uv",
     "coverage",
-    "coveralls",
     "mock",
     "pytest",
     "pytest-asyncio>=0.6.0",

--- a/signingscript/tox.ini
+++ b/signingscript/tox.ini
@@ -23,9 +23,6 @@ commands = coverage report -m
 depends = py311
 parallel_show_output = true
 
-[testenv:coveralls]
-commands=coveralls
-
 [pytest]
 addopts = -vv --color=yes
 asyncio_default_fixture_loop_scope = function

--- a/tox.ini
+++ b/tox.ini
@@ -32,31 +32,26 @@ runner = uv-venv-lock-runner
 changedir = {toxinidir}/addonscript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:balrogscript-py311]
 changedir = {toxinidir}/balrogscript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:beetmoverscript-py311]
 changedir = {toxinidir}/beetmoverscript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:bitrisescript-py311]
 changedir = {toxinidir}/bitrisescript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:bouncerscript-py311]
 changedir = {toxinidir}/bouncerscript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:configloader-py38]
 changedir = {toxinidir}/configloader
@@ -67,7 +62,6 @@ commands =
 changedir = {toxinidir}/configloader
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:init-py311]
 commands =
@@ -77,43 +71,36 @@ commands =
 changedir = {toxinidir}/iscript
 commands =
     tox -e py38
-    - tox -e coveralls
 
 [testenv:githubscript-py311]
 changedir = {toxinidir}/githubscript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:landoscript-py311]
 changedir = {toxinidir}/landoscript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:notarization_poller-py38]
 changedir = {toxinidir}/notarization_poller
 commands =
     tox -e py38
-    - tox -e coveralls
 
 [testenv:pushapkscript-py311]
 changedir = {toxinidir}/pushapkscript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:pushflatpakscript-py311]
 changedir = {toxinidir}/pushflatpakscript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:pushmsixscript-py311]
 changedir = {toxinidir}/pushmsixscript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:scriptworker_client-py38]
 changedir = {toxinidir}/scriptworker_client
@@ -124,7 +111,6 @@ commands =
 changedir = {toxinidir}/scriptworker_client
 commands =
     tox -e py311,mypy
-    - tox -e coveralls
 
 [testenv:shipitscript-py311]
 changedir = {toxinidir}/shipitscript
@@ -135,13 +121,11 @@ commands =
 changedir = {toxinidir}/signingscript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:treescript-py311]
 changedir = {toxinidir}/treescript
 commands =
     tox -e py311
-    - tox -e coveralls
 
 [testenv:ruff-py311]
 deps =

--- a/treescript/pyproject.toml
+++ b/treescript/pyproject.toml
@@ -26,7 +26,6 @@ dev-dependencies = [
     "tox",
     "tox-uv",
     "coverage>=4.2",
-    "coveralls",
     "hglib",
     "json-e",
     "mock",

--- a/treescript/tox.ini
+++ b/treescript/tox.ini
@@ -22,9 +22,6 @@ commands = coverage report -m
 depends = py311
 parallel_show_output = true
 
-[testenv:coveralls]
-commands=coveralls
-
 [pytest]
 addopts = -vv -s --color=yes
 asyncio_default_fixture_loop_scope = function

--- a/uv.lock
+++ b/uv.lock
@@ -765,7 +765,6 @@ dependencies = [
 dev = [
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "coverage", version = "7.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "coveralls" },
     { name = "lockfile" },
     { name = "minimock" },
     { name = "mock" },
@@ -801,7 +800,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage" },
-    { name = "coveralls" },
     { name = "lockfile" },
     { name = "minimock" },
     { name = "mock" },
@@ -1128,7 +1126,6 @@ dependencies = [
 dev = [
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "coverage", version = "7.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "coveralls" },
     { name = "mock" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -1154,7 +1151,6 @@ requires-dist = [
 dev = [
     { name = "coverage" },
     { name = "coverage", specifier = ">=4.2" },
-    { name = "coveralls" },
     { name = "mock" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = "<1.0" },
@@ -2017,21 +2013,6 @@ toml = [
 ]
 
 [[package]]
-name = "coveralls"
-version = "4.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.9'" },
-    { name = "coverage", version = "7.9.1", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.9'" },
-    { name = "docopt" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/75/a454fb443eb6a053833f61603a432ffbd7dd6ae53a11159bacfadb9d6219/coveralls-4.0.1.tar.gz", hash = "sha256:7b2a0a2bcef94f295e3cf28dcc55ca40b71c77d1c2446b538e85f0f7bc21aa69", size = 12419, upload-time = "2024-05-15T12:56:14.297Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/e5/6708c75e2a4cfca929302d4d9b53b862c6dc65bd75e6933ea3d20016d41d/coveralls-4.0.1-py3-none-any.whl", hash = "sha256:7a6b1fa9848332c7b2221afb20f3df90272ac0167060f41b5fe90429b30b1809", size = 13599, upload-time = "2024-05-15T12:56:12.342Z" },
-]
-
-[[package]]
 name = "cryptography"
 version = "45.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2126,12 +2107,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
 ]
-
-[[package]]
-name = "docopt"
-version = "0.6.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
 
 [[package]]
 name = "docutils"
@@ -3517,7 +3492,6 @@ dev = [
     { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest-cov", version = "6.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest-mock" },
-    { name = "python-coveralls" },
     { name = "tox", version = "4.25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "tox", version = "4.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "tox-uv", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -3550,7 +3524,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
-    { name = "python-coveralls" },
     { name = "tox" },
     { name = "tox-uv" },
     { name = "types-requests" },
@@ -4004,7 +3977,6 @@ dependencies = [
 dev = [
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "coverage", version = "7.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "coveralls" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest-aioresponses" },
@@ -4035,7 +4007,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage" },
-    { name = "coveralls" },
     { name = "pytest" },
     { name = "pytest-aioresponses" },
     { name = "pytest-asyncio" },
@@ -5188,7 +5159,6 @@ dev = [
     { name = "pytest-cov", version = "5.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest-cov", version = "6.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pytest-mock" },
-    { name = "python-coveralls" },
     { name = "tox", version = "4.25.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "tox", version = "4.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "tox-uv", version = "1.13.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -5216,7 +5186,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
-    { name = "python-coveralls" },
     { name = "tox" },
     { name = "tox-uv" },
 ]
@@ -6056,7 +6025,6 @@ dependencies = [
 dev = [
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "coverage", version = "7.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "coveralls" },
     { name = "mock" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -6087,7 +6055,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=4.2b1" },
-    { name = "coveralls" },
     { name = "mock" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -6116,7 +6083,6 @@ dependencies = [
 dev = [
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "coverage", version = "7.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "coveralls" },
     { name = "flake8", version = "5.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
     { name = "flake8", version = "7.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1' and python_full_version < '3.9'" },
     { name = "flake8", version = "7.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -6145,7 +6111,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=4.2b1" },
-    { name = "coveralls" },
     { name = "flake8" },
     { name = "mock" },
     { name = "pytest" },
@@ -6859,22 +6824,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/dc/865845cfe987b21658e871d16e0a24e871e00884c545f246dd8f6f69edda/pytest_xdist-3.7.0.tar.gz", hash = "sha256:f9248c99a7c15b7d2f90715df93610353a485827bc06eefb6566d23f6400f126", size = 87550, upload-time = "2025-05-26T21:18:20.251Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/b2/0e802fde6f1c5b2f7ae7e9ad42b83fd4ecebac18a8a8c2f2f14e39dce6e1/pytest_xdist-3.7.0-py3-none-any.whl", hash = "sha256:7d3fbd255998265052435eb9daa4e99b62e6fb9cfb6efd1f858d4d8c0c7f0ca0", size = 46142, upload-time = "2025-05-26T21:18:18.759Z" },
-]
-
-[[package]]
-name = "python-coveralls"
-version = "2.9.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "coverage", version = "7.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/55/9db73eeecbb832252e763dc66aa60551fb4560deffda493b56e83602429c/python-coveralls-2.9.3.tar.gz", hash = "sha256:bfaf7811e7dc5628e83b6b162962a4e2485dbff184b30e49f380374ed1bcee55", size = 9036, upload-time = "2019-08-01T19:12:17.54Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/2d/8c4cefb1de18817d9e05552e29b3780a713122d6fff6c535461836c90186/python_coveralls-2.9.3-py2.py3-none-any.whl", hash = "sha256:fb0ff49bb1551dac10b06bd55e9790287d898a0f1e2c959802235cae08dd0bff", size = 9878, upload-time = "2019-08-01T19:12:20.159Z" },
 ]
 
 [[package]]
@@ -7622,7 +7571,6 @@ dependencies = [
 dev = [
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "coverage", version = "7.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "coveralls" },
     { name = "mock" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -7649,7 +7597,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage" },
-    { name = "coveralls" },
     { name = "mock" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -7683,7 +7630,6 @@ dependencies = [
 dev = [
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "coverage", version = "7.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "coveralls" },
     { name = "mock" },
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -7716,7 +7662,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage" },
-    { name = "coveralls" },
     { name = "mock" },
     { name = "pytest" },
     { name = "pytest-asyncio", specifier = ">=0.6.0" },
@@ -8368,7 +8313,6 @@ dependencies = [
 dev = [
     { name = "coverage", version = "7.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "coverage", version = "7.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
-    { name = "coveralls" },
     { name = "hglib" },
     { name = "json-e" },
     { name = "mock" },
@@ -8403,7 +8347,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=4.2" },
-    { name = "coveralls" },
     { name = "hglib" },
     { name = "json-e" },
     { name = "mock" },


### PR DESCRIPTION
As #450 says, this has been busted since this got merged into a monorepo. And we probably want to use codecov instead.

Fixes #1043