### PR TITLE
Respect the uv.lock file when installing packages in docker container

### DIFF
--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -17,20 +17,19 @@ ADD --chown=app:app topsrcdir/configloader /app/configloader
 ADD --chown=app:app topsrcdir/docker.d /app/docker.d
 # %include .dockerignore
 ADD --chown=app:app topsrcdir/.dockerignore /app/.dockerignore
+# %include uv.lock
+ADD --chown=app:app topsrcdir/uv.lock /app/uv.lock
+# %include pyproject.toml
+ADD --chown=app:app topsrcdir/pyproject.toml /app/pyproject.toml
 
 USER app
 WORKDIR /app
 
-# Install scriptworker_client and configloader
+# Install configloader and create app venv
 RUN uv venv --python ${PYTHON_VERSION} /app/.venv \
- && . /app/.venv/bin/activate \
- && cd /app/scriptworker_client \
- && uv pip install . \
- && deactivate \
  && uv venv /app/configloader_venv \
  && . /app/configloader_venv/bin/activate \
- && cd /app/configloader \
- && uv pip install . \
+ &&  uv sync --no-dev --active --frozen --package configloader \
  && deactivate
 
 CMD ["/app/docker.d/init.sh"]

--- a/taskcluster/docker/pushapkscript/Dockerfile
+++ b/taskcluster/docker/pushapkscript/Dockerfile
@@ -16,9 +16,7 @@ USER app
 
 RUN cp -R /app/pushapkscript/docker.d/* /app/docker.d/ \
  && . /app/.venv/bin/activate \
- && cd /app/pushapkscript \
- && uv pip install . \
- && cd /app \
+ && uv sync --no-dev --active --frozen --package pushapkscript \
  && curl -L https://github.com/google/bundletool/releases/download/1.15.4/bundletool-all-1.15.4.jar -o /app/bundletool.jar \
  && echo "e5f54597dbb5211f050e8ddd03d4d731a9b4dfa5684c7687928b654a8ddc212a bundletool.jar" > shasum \
  && sha256sum --check --status shasum

--- a/taskcluster/docker/pushflatpakscript/Dockerfile
+++ b/taskcluster/docker/pushflatpakscript/Dockerfile
@@ -14,12 +14,11 @@ USER app
 
 RUN cp -R /app/pushflatpakscript/docker.d/* /app/docker.d/ \
  && . /app/.venv/bin/activate \
- && cd pushflatpakscript \
- && uv pip install . \
+ && uv sync --no-dev --active --frozen --package pushflatpakscript \
  && deactivate \
  && uv venv /app/flat_manager_venv \
  && . /app/flat_manager_venv/bin/activate \
- && uv pip install --group flat-manager \
+ && uv sync --no-dev --active --frozen --package pushflatpakscript --only-group flat-manager \
  && curl -Ls \
     https://github.com/flatpak/flat-manager/raw/100d44f761ba765552d2a799b5b7254b6a8b1e38/flat-manager-client | \
     sed -e '1i#!/app/flat_manager_venv/bin/python' -e '1d' > /app/flat_manager_venv/bin/flat-manager-client \

--- a/taskcluster/docker/script/Dockerfile
+++ b/taskcluster/docker/script/Dockerfile
@@ -8,7 +8,6 @@ FROM $DOCKER_IMAGE_PARENT
 # %include $SCRIPT_NAME
 ADD --chown=app:app topsrcdir/$SCRIPT_NAME /app/$SCRIPT_NAME
 
-RUN cd /app/$SCRIPT_NAME \
- && ([ -d docker.d ] && cp -R docker.d/* /app/docker.d/) \
+RUN ([ -d /app/$SCRIPT_NAME/docker.d ] && cp -R /app/$SCRIPT_NAME/docker.d/* /app/docker.d/) \
  && . /app/.venv/bin/activate \
- && uv pip install .
+ &&  uv sync --no-dev --active --frozen --package $SCRIPT_NAME

--- a/taskcluster/docker/signingscript/Dockerfile
+++ b/taskcluster/docker/signingscript/Dockerfile
@@ -37,8 +37,5 @@ WORKDIR /app
 # Install signingscript + widevine
 RUN cp -R /app/signingscript/docker.d/* /app/docker.d/ \
  && . /app/.venv/bin/activate \
- && cd /app/vendored/mozbuild \
- && uv pip install . \
- && cd /app/signingscript \
- && uv pip install . \
+ && uv sync --no-dev --active --frozen --package signingscript \
  && ln -sf /etc/widevine.py $(/app/.venv/bin/python -c "import site; print(site.getsitepackages()[0])")/widevine.py

--- a/taskcluster/docker/treescript/Dockerfile
+++ b/taskcluster/docker/treescript/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /app
 
 RUN cp -R /app/treescript/docker.d/* /app/docker.d/ \
  && . /app/.venv/bin/activate \
- && cd /app/treescript \
- && uv pip install . \
+ && uv sync --no-dev --active --frozen --package treescript \
  && cd /app \
  && hg clone -r 90302f015ac8dd8877ef3ee24b5a62541142378b https://hg.mozilla.org/hgcustom/version-control-tools /app/version-control-tools


### PR DESCRIPTION
This works by copying the workspace definition and the uv.lock file within the container and then syncing only the package that is interesting to us ($SCRIPT_NAME). This also gets rid of the manual installation of scriptworker_client which is now unnecessary and should've been a red flag in the first place but I completely missed it, it will now only be installed when a package requires it, and because it is contained in the workspace, it will just work (tm). We could probably avoid copying scriptworker_client in the container for most scripts but the gain is not worth splitting the image definition between scripts with and without the client lib installed.

Fixes #1251