### PR TITLE
Always use a python binary from the python image instead of using uv managed ones

### DIFF
--- a/taskcluster/docker/base-test/Dockerfile
+++ b/taskcluster/docker/base-test/Dockerfile
@@ -2,14 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM ghcr.io/astral-sh/uv:0.7.15-bookworm
-ARG  PYTHON_VERSION
+ARG PYTHON_VERSION
+ARG UV_VERSION
 
-ENV UV_PYTHON_INSTALL_DIR=/python
-ENV UV_PYTHON_PREFERENCE=only-managed
+FROM ghcr.io/astral-sh/uv:$UV_VERSION AS uv
+FROM python:$PYTHON_VERSION
+
+COPY --from=uv /uv /bin
+
 ENV UV_LINK_MODE=copy
-ENV UV_PYTHON=${PYTHON_VERSION}
-RUN uv python install ${UV_PYTHON}
 
 # Add worker user
 RUN mkdir /builds && \

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -2,8 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM ghcr.io/astral-sh/uv:0.7.15-bookworm
 ARG PYTHON_VERSION
+ARG UV_VERSION
+
+FROM ghcr.io/astral-sh/uv:$UV_VERSION AS uv
+FROM python:$PYTHON_VERSION
+
+COPY --from=uv /uv /bin
 
 RUN ln -s /app/docker.d/healthcheck /bin/healthcheck \
  && groupadd --gid 10001 app \
@@ -26,7 +31,7 @@ USER app
 WORKDIR /app
 
 # Install configloader and create app venv
-RUN uv venv --python ${PYTHON_VERSION} /app/.venv \
+RUN uv venv /app/.venv \
  && uv venv /app/configloader_venv \
  && . /app/configloader_venv/bin/activate \
  &&  uv sync --no-dev --active --frozen --package configloader \

--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -15,6 +15,7 @@ tasks:
         definition: base-test
         args:
             PYTHON_VERSION: "3.11.9"
+            UV_VERSION: "0.7.15"
 
     # Used by push-image kind
     skopeo: {}
@@ -22,6 +23,7 @@ tasks:
     base:
         args:
             PYTHON_VERSION: "3.11.9"
+            UV_VERSION: "0.7.15"
     addonscript:
         definition: script
         parent: base


### PR DESCRIPTION
This feels more appropriate and is more in line with what shipit does