### PR TITLE
fix: don't return earlier lando status for merge conflicts

### DIFF
--- a/landoscript/src/landoscript/lando.py
+++ b/landoscript/src/landoscript/lando.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import logging
+from dataclasses import dataclass
 from typing import Any, Callable, Tuple
 
 from aiohttp import ClientResponseError, ClientSession
@@ -13,6 +14,12 @@ log = logging.getLogger(__name__)
 
 
 LandoAction = dict[str, str]
+
+
+@dataclass
+class LandoStatus:
+    status_url: str
+    failure_reason: str
 
 
 def create_commit_action(commitmsg: str, diff: str) -> LandoAction:

--- a/landoscript/tests/test_rerun_handling.py
+++ b/landoscript/tests/test_rerun_handling.py
@@ -60,7 +60,7 @@ async def test_rerun_previous_lando_job_not_found(monkeypatch, aioresponses, res
     )
     artifact_info_resps = []
     for i in range(4):
-        artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/{i}/artifacts/public%2Fbuild%2Flando-status.txt"
+        artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/{i}/artifacts/public%2Fbuild%2Flando-status.json"
         artifact_info_resps.append(
             responses.get(
                 artifact_url,
@@ -115,14 +115,17 @@ async def test_rerun_previous_lando_job_succeeded(monkeypatch, aioresponses, res
     )
 
     # previous run's status artifact info
-    artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/0/artifacts/public%2Fbuild%2Flando-status.txt"
+    artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/0/artifacts/public%2Fbuild%2Flando-status.json"
     artifact_info_resp = responses.get(artifact_url, status=303, json={"storageType": "s3", "url": "https://s3.fake/artifact"})
 
     # the actual artifact
     aioresponses.get(
         "https://s3.fake/artifact",
         status=200,
-        body=str(status_uri),
+        payload={
+            "url": str(status_uri),
+            "failure_reason": "",
+        },
     )
 
     # response from lando when this run checks on the job
@@ -149,6 +152,86 @@ async def test_rerun_previous_lando_job_succeeded(monkeypatch, aioresponses, res
 
 @pytest.mark.asyncio
 async def test_rerun_previous_lando_job_failed(monkeypatch, aioresponses, responses, github_installation_responses, context):
+    """A rerun that finds a lando job that failed should return failure
+    for a reason other than merge conflict should return failure and do
+    nothing else."""
+    monkeypatch.setenv("TASKCLUSTER_ROOT_URL", "https://tc")
+    monkeypatch.setenv("TASK_ID", "task_id")
+    monkeypatch.setenv("RUN_ID", "1")
+    tag_info = {
+        "revision": "abcdef123456",
+        "hg_repo_url": "https://hg.testing/repo",
+        "tags": ["BUILD1", "RELEASE"],
+    }
+    payload = {
+        "actions": ["tag"],
+        "lando_repo": "repo_name",
+        "tag_info": tag_info,
+    }
+    submit_uri, status_uri, job_id, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["tag"], "repo_name")
+    context.task = {"payload": payload, "scopes": scopes}
+
+    # previous run status
+    task_status_url = "https://tc/api/queue/v1/task/task_id/status"
+    task_status_resp = responses.get(
+        task_status_url,
+        status=200,
+        json={
+            "status": {
+                "runs": [
+                    {
+                        "runId": 0,
+                        "state": "exception",
+                    },
+                ]
+            },
+        },
+    )
+
+    # previous run's status artifact
+    artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/0/artifacts/public%2Fbuild%2Flando-status.json"
+    artifact_info_resp = responses.get(artifact_url, status=303, json={"storageType": "s3", "url": "https://s3.fake/artifact"})
+
+    # the actual artifact
+    aioresponses.get(
+        "https://s3.fake/artifact",
+        status=200,
+        payload={
+            "url": str(status_uri),
+            "failure_reason": "lando_status_failed",
+        },
+        body=str(status_uri),
+    )
+
+    # response from lando when this run checks on the job
+    aioresponses.get(
+        status_uri,
+        status=200,
+        payload={
+            "commits": ["abcdef123"],
+            "push_id": job_id,
+            "status": "FAILED",
+        },
+    )
+
+    try:
+        await async_main(context)
+        assert False, f"should've raised LandoScriptError"
+    except LandoscriptError as e:
+        assert_status_response(aioresponses.requests, status_uri)
+
+        assert task_status_resp.call_count == 1
+        # ensure we got the correct error
+        assert "Landing status is FAILED" in e.args[0]
+        # ensure we found the previous run's artifact
+        assert artifact_info_resp.call_count == 1
+        assert ("GET", URL("https://s3.fake/artifact")) in aioresponses.requests
+        # ensure another lando job was _not_ submitted
+        assert ("POST", submit_uri) not in aioresponses.requests
+
+
+@pytest.mark.asyncio
+async def test_rerun_previous_lando_job_failed_merge_conflict(monkeypatch, aioresponses, responses, github_installation_responses, context):
     """A rerun that finds a lando job that failed should return failure
     and do nothing else."""
     monkeypatch.setenv("TASKCLUSTER_ROOT_URL", "https://tc")
@@ -185,41 +268,31 @@ async def test_rerun_previous_lando_job_failed(monkeypatch, aioresponses, respon
     )
 
     # previous run's status artifact
-    artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/0/artifacts/public%2Fbuild%2Flando-status.txt"
+    artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/0/artifacts/public%2Fbuild%2Flando-status.json"
     artifact_info_resp = responses.get(artifact_url, status=303, json={"storageType": "s3", "url": "https://s3.fake/artifact"})
 
     # the actual artifact
     aioresponses.get(
         "https://s3.fake/artifact",
         status=200,
-        body=str(status_uri),
-    )
-
-    # response from lando when this run checks on the job
-    aioresponses.get(
-        status_uri,
-        status=200,
         payload={
-            "commits": ["abcdef123"],
-            "push_id": job_id,
-            "status": "FAILED",
+            "url": str(status_uri),
+            "failure_reason": "merge_conflict",
         },
     )
 
-    try:
-        await async_main(context)
-        assert False, f"should've raised LandoScriptError"
-    except LandoscriptError as e:
-        assert_status_response(aioresponses.requests, status_uri)
+    git_commit = "ghijkl654321"
+    aioresponses.get(
+        f"{tag_info['hg_repo_url']}/json-rev/{tag_info['revision']}",
+        status=200,
+        payload={"git_commit": git_commit},
+    )
 
+    def assert_func(req):
+        assert_tag_response(req, tag_info, git_commit)
         assert task_status_resp.call_count == 1
-        # ensure we got the correct error
-        assert "Landing status is FAILED" in e.args[0]
-        # ensure we found the previous run's artifact
-        assert artifact_info_resp.call_count == 1
-        assert ("GET", URL("https://s3.fake/artifact")) in aioresponses.requests
-        # ensure another lando job was _not_ submitted
-        assert ("POST", submit_uri) not in aioresponses.requests
+
+    await run_test(aioresponses, github_installation_responses, context, payload, ["tag"], True, assert_func)
 
 
 @pytest.mark.asyncio
@@ -260,14 +333,17 @@ async def test_rerun_previous_lando_job_in_progress(monkeypatch, aioresponses, r
     )
 
     # previous run's status artifact
-    artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/0/artifacts/public%2Fbuild%2Flando-status.txt"
+    artifact_url = f"https://tc/api/queue/v1/task/task_id/runs/0/artifacts/public%2Fbuild%2Flando-status.json"
     artifact_info_resp = responses.get(artifact_url, status=303, json={"storageType": "s3", "url": "https://s3.fake/artifact"})
 
     # the actual artifact
     aioresponses.get(
         "https://s3.fake/artifact",
         status=200,
-        body=str(status_uri),
+        payload={
+            "url": str(status_uri),
+            "failure_reason": "",
+        },
     )
 
     # response from lando when this run checks on the job

--- a/landoscript/tests/test_rerun_handling.py
+++ b/landoscript/tests/test_rerun_handling.py
@@ -149,7 +149,7 @@ async def test_rerun_previous_lando_job_succeeded(monkeypatch, aioresponses, res
 
 @pytest.mark.asyncio
 async def test_rerun_previous_lando_job_failed(monkeypatch, aioresponses, responses, github_installation_responses, context):
-    """A rerun that finds a lando job that succeeded should return failure
+    """A rerun that finds a lando job that failed should return failure
     and do nothing else."""
     monkeypatch.setenv("TASKCLUSTER_ROOT_URL", "https://tc")
     monkeypatch.setenv("TASK_ID", "task_id")

--- a/landoscript/tests/test_script.py
+++ b/landoscript/tests/test_script.py
@@ -1,3 +1,4 @@
+import json
 from aiohttp import ClientResponseError
 import pytest
 from scriptworker.client import STATUSES, TaskVerificationError
@@ -19,7 +20,13 @@ from .test_tag import assert_tag_response
 def assert_success(artifact_dir, req, commit_msg_strings, initial_values, expected_bumps, has_actions=True):
     if has_actions:
         assert (artifact_dir / "public/build/lando-actions.json").exists()
-        assert (artifact_dir / "public/build/lando-status.txt").exists()
+        lando_status = artifact_dir / "public/build/lando-status.json"
+        assert lando_status.exists()
+        with open(lando_status) as ls:
+            status = json.loads(ls.read())
+            assert "url" in status
+            # for successes, this will be present but empty
+            assert "failure_reason" in status
 
     assert "json" in req.kwargs
     assert "actions" in req.kwargs["json"]


### PR DESCRIPTION
Merge conflicts end up resolving a run with the `intermittent-task` exception. We want to keep using this exception, because automatic retries are a feature here. However, we need to make sure that when we resume from this run that we start fresh and ignore the earlier lando attempt. To do this, we need to enrich the status artifact we add with a distinct failure reason.
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1978590