### PR TITLE
feat: push docker images to GAR repository

### DIFF
--- a/taskcluster/docker/skopeo/push_image_gar.sh
+++ b/taskcluster/docker/skopeo/push_image_gar.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -e
+# Set pipefail so curl failures are caught before the pipe to jq
+set -o pipefail  # This will fail on sh / only works on bash
+
+test $APP
+test $DOCKER_TAG
+test $DOCKER_REPO
+test $MOZ_FETCHES_DIR
+test $TASKCLUSTER_ROOT_URL
+test $TASK_ID
+test $VCS_HEAD_REPOSITORY
+test $VCS_HEAD_REV
+
+echo "=== Generating dockercfg ==="
+PASSWORD_URL=http://taskcluster/secrets/v1/secret/project/releng/scriptworker-scripts/deploy
+mkdir -m 700 $HOME/.docker
+# curl --fail forces curl to return a non-zero exit code if the response isn't HTTP 200 (i.e.: HTTP 403 Unauthorized)
+curl --fail -v $PASSWORD_URL | jq '.secret.gar.dockercfg' > $HOME/.docker/config.json
+chmod 600 $HOME/.docker/config.json
+
+cd $MOZ_FETCHES_DIR
+unzstd image.tar.zst
+
+echo "=== Inserting version.json into image ==="
+# Create an OCI copy of image in order umoci can patch it
+skopeo copy docker-archive:image.tar oci:${APP}:final
+
+cat > version.json <<EOF
+{
+    "commit": "${VCS_HEAD_REV}",
+    "source": "${VCS_HEAD_REPOSITORY}",
+    "build": "${TASKCLUSTER_ROOT_URL}/tasks/${TASK_ID}"
+}
+EOF
+
+umoci insert --image ${APP}:final version.json /app/version.json
+
+echo "=== Pushing to docker hub ==="
+skopeo copy oci:${APP}:final docker://$DOCKER_REPO:$DOCKER_TAG
+skopeo inspect docker://$DOCKER_REPO:$DOCKER_TAG
+
+echo "=== Clean up ==="
+rm -rf $HOME/.docker

--- a/taskcluster/kinds/push-image-gar/kind.yml
+++ b/taskcluster/kinds/push-image-gar/kind.yml
@@ -1,0 +1,73 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: taskgraph.loader.transform:loader
+
+kind-dependencies:
+    - docker-image
+
+transforms:
+    - taskgraph.transforms.task_context
+    - taskgraph.transforms.run
+    - taskgraph.transforms.task
+
+task-defaults:
+    description: Push {name} {docker_tag} docker image to GAR
+    worker-type: images
+    task-context:
+        from-parameters:
+            head_rev: head_rev
+            head_repo: head_repository
+            docker_tag: docker_tag
+            moz_build_date: moz_build_date
+        substitution-fields:
+            - description
+            - dependencies.image
+            - worker.env
+            - run-on-git-branches
+    dependencies:
+        image: docker-image-{name}
+    worker:
+        taskcluster-proxy: true
+        docker-image: {in-tree: skopeo}
+        max-run-time: 1800
+        env:
+            VCS_HEAD_REPOSITORY: "{head_repo}"
+            APP: "{name}"
+            DOCKER_REPO: "{name}"
+            VCS_HEAD_REV: "{head_rev}"
+            DOCKER_TAG: "{docker_tag}"
+    run-on-tasks-for: [github-push]
+    run-on-git-branches:
+        - ^dev$
+        - ^production$
+        - ^dev-{name}$
+        - ^production-{name}$
+    run:
+        using: run-task
+        checkout: false
+        command:
+            - /usr/local/bin/push_image_gar.sh
+    fetches:
+        image:
+            - artifact: image.tar.zst
+              extract: false
+    scopes:
+        - secrets:get:project/releng/scriptworker-scripts/deploy
+
+tasks:
+    addonscript: {}
+    balrogscript: {}
+    bitrisescript: {}
+    beetmoverscript: {}
+    bouncerscript: {}
+    githubscript: {}
+    landoscript: {}
+    pushapkscript: {}
+    pushflatpakscript: {}
+    pushmsixscript: {}
+    shipitscript: {}
+    signingscript: {}
+    treescript: {}


### PR DESCRIPTION
This is to support the migration to Mozcloud. We'll do this in parallel with pushes to dockerhub to avoid one pipeline busting the other.

I've dropped support for the archive tags here, because as far as I know we've never made use of them.