### PR TITLE
complete hack: add support for a signingscript docker-compose.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,7 +30,7 @@ coverage.xml
 docs/
 
 # Human readable content
-**/*.rst
+# **/*.rst
 # githubscript and pushapkscript need README.md files
 # **/*.md
 

--- a/signingscript/docker-compose.yml
+++ b/signingscript/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  base:
+    build:
+      args:
+        UV_VERSION: 0.7.15
+        PYTHON_VERSION: 3.11.9
+      context: ../taskcluster/docker/base
+      additional_contexts:
+        scratch: ../
+  signingscript:
+    build:
+      args:
+        DOCKER_IMAGE_PARENT: base
+      context: ../taskcluster/docker/signingscript
+      additional_contexts:
+        base: service:base
+        signingscript/scratch: ../
+  autograph:
+    image: mozilla/autograph:latest
+    expose:
+      - "8000"
+    # volumes:
+    #   - autographtmp:/tmp/
+    logging:
+      driver: none
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/__heartbeat__"]
+      interval: 2s
+      timeout: 5s
+      retries: 3

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -14,18 +14,22 @@ RUN ln -s /app/docker.d/healthcheck /bin/healthcheck \
  && groupadd --gid 10001 app \
  && useradd -g app --uid 10001 --shell /usr/sbin/nologin --create-home --home-dir /app app
 
+COPY --from=scratch . /topsrcdir/
+
 # %include scriptworker_client
-ADD --chown=app:app topsrcdir/scriptworker_client /app/scriptworker_client
+# ADD --chown=app:app topsrcdir/scriptworker_client /app/scriptworker_client
 # %include configloader
-ADD --chown=app:app topsrcdir/configloader /app/configloader
+# ADD --chown=app:app topsrcdir/configloader /app/configloader
 # %include docker.d
-ADD --chown=app:app topsrcdir/docker.d /app/docker.d
+# ADD --chown=app:app topsrcdir/docker.d /app/docker.d
 # %include .dockerignore
-ADD --chown=app:app topsrcdir/.dockerignore /app/.dockerignore
+# ADD --chown=app:app topsrcdir/.dockerignore /app/.dockerignore
 # %include uv.lock
-ADD --chown=app:app topsrcdir/uv.lock /app/uv.lock
+# ADD --chown=app:app topsrcdir/uv.lock /app/uv.lock
 # %include pyproject.toml
-ADD --chown=app:app topsrcdir/pyproject.toml /app/pyproject.toml
+# ADD --chown=app:app topsrcdir/pyproject.toml /app/pyproject.toml
+
+RUN cp -R /topsrcdir/* /app/ && chown -R app:app /app
 
 USER app
 WORKDIR /app

--- a/taskcluster/docker/signingscript/Dockerfile
+++ b/taskcluster/docker/signingscript/Dockerfile
@@ -2,13 +2,20 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+ARG DOCKER_IMAGE_PARENT
+
 FROM $DOCKER_IMAGE_PARENT
 
+COPY --from=signingscript/scratch . /topsrcdir/
+
 # %include signingscript
-ADD --chown=app:app topsrcdir/signingscript /app/signingscript
+# ADD --chown=app:app topsrcdir/signingscript /app/signingscript
 
 # %include vendored
-ADD --chown=app:app topsrcdir/vendored /app/vendored
+# ADD --chown=app:app topsrcdir/vendored /app/vendored
+
+RUN cp -R /topsrcdir/signingscript/ /app/signingscript/
+RUN cp -R /topsrcdir/vendored/ /app/vendored/
 
 # Root for installs
 USER root


### PR DESCRIPTION
this is 100% not intended for review or landing at this time...i'm just experimenting with a docker compose for signingscript, and want to see if the changes i've made even build in taskcluster