### PR TITLE
iscript: Allow signing with an explicit codesign identifier

### DIFF
--- a/iscript/src/iscript/data/i_task_schema.json
+++ b/iscript/src/iscript/data/i_task_schema.json
@@ -131,6 +131,9 @@
                   "libconstraints": {
                     "type": "string"
                   },
+                  "identifier": {
+                    "type": "string"
+                  },
                   "globs": {
                     "type": "array",
                     "minItems": 1,

--- a/iscript/src/iscript/hardened_sign.py
+++ b/iscript/src/iscript/hardened_sign.py
@@ -129,6 +129,10 @@ def build_sign_command(app_path, identity, keychain, config, file_map):
     if config.get("requirements"):
         cmd.append("--requirements")
         cmd.append(config["requirements"])
+    # Explicit codesign identifier
+    if config.get("identifier"):
+        cmd.append("--identifier")
+        cmd.append(config["identifier"])
     # --options
     if config.get("runtime"):
         cmd.append("--options")

--- a/iscript/tests/test_hardened_sign.py
+++ b/iscript/tests/test_hardened_sign.py
@@ -41,6 +41,7 @@ hs_config = [
 hs_config_no_libconstraints = [{"deep": True, "runtime": True, "force": True, "entitlements": "https://foo.bar", "globs": ["/"]}]
 hs_config_with_identifier = [hs_config[0] | {"identifier": "foo.bar.baz"}]
 
+
 @pytest.mark.asyncio
 async def test_download_signing_resources(mocker):
     mocker.patch.object(hs, "retry_async", new=noop_async)


### PR DESCRIPTION
## Description

We have a bug in the VPN project that we introduced when attempting to split the client binary and the daemon. The problem occurs because macOS's service database relies on the designated requirement of the daemon binary to prevent tampering or replacement of the daemon.

By splitting the daemon into its own binary, we changed its codesign identifier and hence it no longer matches the designated requirements of the old daemon and operating system refuses to launch it. One suggestion from the apple developer forums is to explicitly set the signing identifier to match the main application during signing. I have tested this out with some local builds and it seems to work just fine, so this PR attempts to make this option available using the `iscript` hardened signer behaviour.

## How this change works
The `mac_sign_hardened` can accept a new optional value in the `config` dictionary named `identifier`. When present, the arguments `--identifier <value>` are added to the `codesign` command invocation, otherwise the `codesign` arguments should be unaffected when this value is missing.

## References
Apple developer forums: [Upgrading an SMAppService daemon and changing the plist ](https://developer.apple.com/forums/thread/795022)
JIRA Issue: [VPN-7191](https://mozilla-hub.atlassian.net/browse/VPN-7191)