### PR TITLE
signingscript: remove dependency on distutils from tests

### DIFF
--- a/signingscript/tests/conftest.py
+++ b/signingscript/tests/conftest.py
@@ -1,7 +1,6 @@
 import os
 import tempfile
 from contextlib import contextmanager
-from distutils.util import strtobool
 
 import pytest
 from scriptworker.context import Context
@@ -66,6 +65,22 @@ def context(tmpdir):
 @contextmanager
 def does_not_raise():
     yield
+
+
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value {!r}".format(val))
 
 
 def skip_when_no_autograph_server(function):

--- a/signingscript/tests/conftest.py
+++ b/signingscript/tests/conftest.py
@@ -75,9 +75,9 @@ def strtobool(val):
     'val' is anything else.
     """
     val = val.lower()
-    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+    if val in ("y", "yes", "t", "true", "on", "1"):
         return 1
-    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+    elif val in ("n", "no", "f", "false", "off", "0"):
         return 0
     else:
         raise ValueError("invalid truth value {!r}".format(val))


### PR DESCRIPTION
The distutils package was removed in python 3.12.  Just vendor in the one function we use.