### PR TITLE
fix: lower `paths_per_query` to 1 in github client

### DIFF
--- a/landoscript/src/landoscript/actions/android_l10n_import.py
+++ b/landoscript/src/landoscript/actions/android_l10n_import.py
@@ -64,7 +64,7 @@ async def run(
             if "**" in contents["paths"][0]["reference"]:
                 # localized file paths contain globs; we need that directory
                 # structure to determine the files we need to fetch
-                force_paths = await l10n_github_client.get_file_listing(str(src_file_prefix), depth_per_query=4, paths_per_query=100)
+                force_paths = await l10n_github_client.get_file_listing(str(src_file_prefix), depth_per_query=4)
             else:
                 force_paths = []
 

--- a/scriptworker_client/src/scriptworker_client/github_client.py
+++ b/scriptworker_client/src/scriptworker_client/github_client.py
@@ -196,7 +196,7 @@ class GithubClient:
 
         return repo["object"]["oid"]
 
-    async def get_file_listing(self, paths: Union[str, List[str]] = "", branch: Optional[str] = None, depth_per_query=5, paths_per_query=100) -> List[str]:
+    async def get_file_listing(self, paths: Union[str, List[str]] = "", branch: Optional[str] = None, depth_per_query=5, paths_per_query=1) -> List[str]:
         """Get the recursive file and directory listings of the given path on
         the given branch, `depth_per_query` levels deep at a time.
 
@@ -302,7 +302,7 @@ class GithubClient:
             files.extend(files_)
 
         if refetches:
-            refetch_files = await self.get_file_listing(refetches, branch, depth_per_query)
+            refetch_files = await self.get_file_listing(refetches, branch, depth_per_query, paths_per_query)
             files.extend(refetch_files)
 
         return files

--- a/scriptworker_client/tests/test_github_client.py
+++ b/scriptworker_client/tests/test_github_client.py
@@ -464,6 +464,101 @@ async def test_get_repository_files(aioresponses, github_client):
 
 
 @pytest.mark.asyncio
+async def test_get_file_listing_paths_per_query_inheritance(aioresponses, github_client):
+    """Test that paths_per_query parameter is properly inherited in recursive calls."""
+    branch = "main"
+    paths = ["dir1", "dir2", "dir3", "dir4", "dir5"]  # More than paths_per_query=2, so we need to split
+
+    # First call: processes first 2 paths (dir1, dir2)
+    aioresponses.post(
+        GITHUB_GRAPHQL_ENDPOINT,
+        status=200,
+        payload={
+            "data": {
+                "repository": {
+                    "path0": {
+                        "entries": [
+                            {
+                                "name": "file1.txt",
+                                "type": "blob",
+                            }
+                        ]
+                    },
+                    "path1": {
+                        "entries": [
+                            {
+                                "name": "file2.txt",
+                                "type": "blob",
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+    )
+    # Second call: processes excess paths with paths_per_query=2 (dir3, dir4)
+    aioresponses.post(
+        GITHUB_GRAPHQL_ENDPOINT,
+        status=200,
+        payload={
+            "data": {
+                "repository": {
+                    "path0": {
+                        "entries": [
+                            {
+                                "name": "file3.txt",
+                                "type": "blob",
+                            }
+                        ]
+                    },
+                    "path1": {
+                        "entries": [
+                            {
+                                "name": "file4.txt",
+                                "type": "blob",
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+    )
+    # Third call: processes remaining excess path (dir5) with paths_per_query=2
+    aioresponses.post(
+        GITHUB_GRAPHQL_ENDPOINT,
+        status=200,
+        payload={
+            "data": {
+                "repository": {
+                    "path0": {
+                        "entries": [
+                            {
+                                "name": "file5.txt",
+                                "type": "blob",
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+    )
+
+    result = await github_client.get_file_listing(paths=paths, branch=branch, paths_per_query=2)
+
+    expected = [
+        "dir1/file1.txt",
+        "dir2/file2.txt",
+        "dir3/file3.txt",
+        "dir4/file4.txt",
+        "dir5/file5.txt"
+    ]
+    assert sorted(result) == sorted(expected)
+
+    # Verify all 3 requests were made (this demonstrates paths_per_query is inherited)
+    assert len(aioresponses.requests[("POST", URL(GITHUB_GRAPHQL_ENDPOINT))]) == 3
+
+
+@pytest.mark.asyncio
 async def test_get_repository_files_with_initial_subtree(aioresponses, github_client):
     branch = "main"
     expected = [

--- a/scriptworker_client/tests/test_github_client.py
+++ b/scriptworker_client/tests/test_github_client.py
@@ -491,7 +491,7 @@ async def test_get_file_listing_paths_per_query_inheritance(aioresponses, github
                                 "type": "blob",
                             }
                         ]
-                    }
+                    },
                 }
             }
         },
@@ -518,7 +518,7 @@ async def test_get_file_listing_paths_per_query_inheritance(aioresponses, github
                                 "type": "blob",
                             }
                         ]
-                    }
+                    },
                 }
             }
         },
@@ -545,13 +545,7 @@ async def test_get_file_listing_paths_per_query_inheritance(aioresponses, github
 
     result = await github_client.get_file_listing(paths=paths, branch=branch, paths_per_query=2)
 
-    expected = [
-        "dir1/file1.txt",
-        "dir2/file2.txt",
-        "dir3/file3.txt",
-        "dir4/file4.txt",
-        "dir5/file5.txt"
-    ]
+    expected = ["dir1/file1.txt", "dir2/file2.txt", "dir3/file3.txt", "dir4/file4.txt", "dir5/file5.txt"]
     assert sorted(result) == sorted(expected)
 
     # Verify all 3 requests were made (this demonstrates paths_per_query is inherited)


### PR DESCRIPTION
We're seeing timeouts in android-l10n jobs due to the increased query size caused by https://github.com/mozilla-releng/scriptworker-scripts/pull/1283; this restores the queries to their original size without backing out the feature.

It also fixes a bug where `paths_per_query` was not being forwarded in recursive calls.