### PR TITLE
Explicitely declare workspace dependencies in workspace members

### DIFF
--- a/balrogscript/pyproject.toml
+++ b/balrogscript/pyproject.toml
@@ -41,6 +41,9 @@ dev = [
     "pytest-mock",
 ]
 
+[tool.uv.sources]
+scriptworker-client = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/bitrisescript/pyproject.toml
+++ b/bitrisescript/pyproject.toml
@@ -31,6 +31,9 @@ dev = [
     "pytest-mock",
 ]
 
+[tool.uv.sources]
+scriptworker-client = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/githubscript/pyproject.toml
+++ b/githubscript/pyproject.toml
@@ -30,6 +30,9 @@ dev = [
     "pytest-cov",
 ]
 
+[tool.uv.sources]
+scriptworker-client = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/iscript/pyproject.toml
+++ b/iscript/pyproject.toml
@@ -46,6 +46,9 @@ scriptworker = [
     "scriptworker",
 ]
 
+[tool.uv.sources]
+scriptworker-client = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/landoscript/pyproject.toml
+++ b/landoscript/pyproject.toml
@@ -36,6 +36,10 @@ dev = [
     "pytest-scriptworker-client",
 ]
 
+[tool.uv.sources]
+scriptworker-client = { workspace = true }
+pytest-scriptworker-client = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pushmsixscript/pyproject.toml
+++ b/pushmsixscript/pyproject.toml
@@ -31,6 +31,9 @@ dev = [
     "requests-mock",
 ]
 
+[tool.uv.sources]
+scriptworker-client = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/treescript/pyproject.toml
+++ b/treescript/pyproject.toml
@@ -39,6 +39,10 @@ dev = [
     "virtualenv",
 ]
 
+[tool.uv.sources]
+scriptworker-client = { workspace = true }
+pytest-scriptworker-client = { workspace = true }
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
This doesn't fix anything since we build our images with the workspace present. This just prevents someone from copying one of those project outside of the workspace and then run `uv sync`, expecting it to work and getting some confusing errors about scriptworker-client not being installable from pypi.