### PR TITLE
feat: support optional overwrites in translations uploads

### DIFF
--- a/beetmoverscript/src/beetmoverscript/data/upload_translations_artifacts_task_schema.json
+++ b/beetmoverscript/src/beetmoverscript/data/upload_translations_artifacts_task_schema.json
@@ -25,6 +25,10 @@
             ],
             "additionalProperties": false
         },
+        "allow_overwrites": {
+            "type": "boolean",
+            "description": "Whether to allow overwriting existing files in cloud storage"
+        },
         "upstreamArtifacts": {
             "type": "array",
             "items": {

--- a/beetmoverscript/src/beetmoverscript/script.py
+++ b/beetmoverscript/src/beetmoverscript/script.py
@@ -494,6 +494,7 @@ def ensure_no_overwrites_in_artifact_map(artifactMap):
 
 async def upload_translations_artifacts(context):
     artifactMap = context.task["payload"]["artifactMap"]
+    allow_overwrites = context.task["payload"].get("allow_overwrites", False)
 
     # Ignore any failed artifacts; we'll take whatever we can get. All artifacts are considered optional.
     upstreamArtifactPaths = scriptworker_artifacts.get_upstream_artifacts_full_paths_per_task_id(context)[0]
@@ -504,7 +505,7 @@ async def upload_translations_artifacts(context):
     for map_ in concreteArtifactMap:
         for input_path, outputs in map_["paths"].items():
             log.info(f"Uploading {input_path} to {outputs['destinations']}")
-            await retry_upload(context, outputs["destinations"], input_path, fail_on_unknown_mimetype=False, allow_overwrites=False)
+            await retry_upload(context, outputs["destinations"], input_path, fail_on_unknown_mimetype=False, allow_overwrites=allow_overwrites)
 
 
 # copy_beets {{{1


### PR DESCRIPTION
This was requested because we have [a new upload task in translations](https://github.com/mozilla/translations/pull/1285) whose entire purpose is uploading some data to a consistent path, and a similar use case coming soon.