### PR TITLE
Use ruff format on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,7 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.12.0
-    hooks:
-      - id: black
+      - id: ruff-format
 exclude: |
   (?x)^(
     vendored |

--- a/landoscript/src/landoscript/actions/android_l10n_import.py
+++ b/landoscript/src/landoscript/actions/android_l10n_import.py
@@ -1,11 +1,11 @@
 import logging
 import os.path
+import tomllib
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Self
 
-import tomllib
 from scriptworker_client.github import extract_github_repo_owner_and_name
 from scriptworker_client.github_client import GithubClient
 

--- a/landoscript/src/landoscript/actions/android_l10n_sync.py
+++ b/landoscript/src/landoscript/actions/android_l10n_sync.py
@@ -1,11 +1,11 @@
 import logging
 import os.path
+import tomllib
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Self
 
-import tomllib
 from scriptworker_client.github_client import GithubClient
 
 from landoscript.errors import LandoscriptError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,29 +46,6 @@ docs = [
     "sphinx-rtd-theme",
 ]
 
-[tool.black]
-line-length = 160
-target-version = ["py311"]
-include = '\.(wsgi|pyi?)$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | \.cache
-  | \.cache_py3
-  | _build
-  | buck-out
-  | build
-  | dist
-  | ui
-  | vendored
-)/
-'''
-
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -98,11 +75,8 @@ exclude = [
     "createprecomplete.py",
 ]
 
-# Same as Black.
 line-length = 160
-
-# Assume Python 3.9.
-target-version = "py39"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
Right now we're using black on pre-commit, ruff on CI, and they seem to disagree after a ruff update... Instead of figuring out why, just use ruff for everything, there's no point in running black when ruff does the same thing.