### PR TITLE
fix: add regex_replacements to landoscript payload schema

### DIFF
--- a/landoscript/src/landoscript/data/landoscript_task_schema.json
+++ b/landoscript/src/landoscript/data/landoscript_task_schema.json
@@ -63,6 +63,26 @@
                         ]
                     }
                 },
+                "regex_replacements": {
+                    "type": "array",
+                    "minItems": 0,
+                    "default": [],
+                    "items": {
+                        "type": "array",
+                        "minItems": 3,
+                        "maxItems": 3,
+                        "items": {
+                            "type": "string"
+                        },
+                        "examples": [
+                            [
+                                "browser/extensions/webcompat/manifest.json",
+                                "'version': '[0-9]+.[0-9]+.0'",
+                                "'version': '{next_major_version}.0.0'"
+                            ]
+                        ]
+                    }
+                },
                 "from_branch": {
                     "type": "string",
                     "examples": [


### PR DESCRIPTION
Seeing as these are actually used for the `bump-main` action I guess we're not (fully) validating them, but that's a separate problem...and this ought to be in there regardless.