### PR TITLE
Add missing `MARK_AS_MERGED_SCHEMA_FILE` env variable to init_worker.sh

### DIFF
--- a/shipitscript/docker.d/init_worker.sh
+++ b/shipitscript/docker.d/init_worker.sh
@@ -54,5 +54,6 @@ esac
 
 
 export MARK_AS_SHIPPED_SCHEMA_FILE="/app/shipitscript/src/shipitscript/data/mark_as_shipped_task_schema.json"
+export MARK_AS_MERGED_SCHEMA_FILE="/app/shipitscript/src/shipitscript/data/mark_as_merged_task_schema.json"
 export CREATE_NEW_RELEASE_SCHEMA_FILE="/app/shipitscript/src/shipitscript/data/create_new_release_task_schema.json"
 export UPDATE_PRODUCT_CHANNEL_VERSION_SCHEMA_FILE="/app/shipitscript/src/shipitscript/data/update_product_channel_version_schema.json"


### PR DESCRIPTION
I fixed this on the dev branch when I tested this but forgot to get the fix into the PR branch. This is currently preventing shipitscript from starting at all since it key errors on boot.