### PR TITLE
signingscript: check mar channel id against allowlist (bug 2017860)

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -25,6 +25,7 @@ export HFSPLUS_PATH=$APP_DIR/signingscript/files/hfsplus
 
 export PASSWORDS_PATH=$CONFIG_DIR/passwords.json
 export APPLE_NOTARIZATION_CREDS_PATH=$CONFIG_DIR/apple_notarization_creds.json
+export MAR_CHANNELS_PATH=$CONFIG_DIR/mar-channels.json
 export GPG_PUBKEY_PATH=$APP_DIR/signingscript/src/signingscript/data/gpg_pubkey_dep.asc
 export WIDEVINE_CERT_PATH=$CONFIG_DIR/widevine.crt
 export AUTHENTICODE_TIMESTAMP_STYLE=old
@@ -280,3 +281,4 @@ esac
 
 $CONFIG_LOADER $TEMPLATE_DIR/passwords.yml $PASSWORDS_PATH
 $CONFIG_LOADER $TEMPLATE_DIR/apple_notarization_creds.yml $APPLE_NOTARIZATION_CREDS_PATH
+$CONFIG_LOADER $TEMPLATE_DIR/mar-channels.yml $MAR_CHANNELS_PATH

--- a/signingscript/docker.d/mar-channels.yml
+++ b/signingscript/docker.d/mar-channels.yml
@@ -1,0 +1,27 @@
+$let:
+  scope_prefix:
+    $match:
+      'COT_PRODUCT == "adhoc"': 'project:adhoc:releng:signing:'
+      'COT_PRODUCT == "enterprise"': 'project:enterprise:releng:signing:'
+      'COT_PRODUCT == "firefox"': 'project:releng:signing:'
+      'COT_PRODUCT == "thunderbird"': 'project:comm:thunderbird:releng:signing:'
+in:
+  $switch:
+    'COT_PRODUCT == "adhoc"':
+      # adhoc can sign anything, for custom updates
+      '${scope_prefix[0]}cert:nightly-signing': ["*"]
+      '${scope_prefix[0]}cert:release-signing': ["*"]
+      '${scope_prefix[0]}cert:dep-signing': ["*"]
+    'COT_PRODUCT == "enterprise"':
+      '${scope_prefix[0]}cert:nightly-signing': ["firefox-enterprise-nightly"]
+      '${scope_prefix[0]}cert:release-signing': ["firefox-enterprise-release"]
+      '${scope_prefix[0]}cert:dep-signing': ["*"]
+    'COT_PRODUCT == "firefox"':
+      '${scope_prefix[0]}cert:nightly-signing': ["firefox-nightly-*", "firefox-mozilla-central", "firefox-mozilla-aurora"]
+      '${scope_prefix[0]}cert:release-signing': ["firefox-mozilla-beta", "firefox-mozilla-release", "firefox-mozilla-esr"]
+      '${scope_prefix[0]}cert:dep-signing': ["*"]
+    'COT_PRODUCT == "thunderbird"':
+      '${scope_prefix[0]}cert:nightly-signing': ["thunderbird-comm-central"]
+      '${scope_prefix[0]}cert:release-signing': ["thunderbird-comm-beta", "thunderbird-comm-release", "thunderbird-comm-esr"]
+      '${scope_prefix[0]}cert:dep-signing': ["*"]
+    $default: {}

--- a/signingscript/docker.d/worker.yml
+++ b/signingscript/docker.d/worker.yml
@@ -3,6 +3,7 @@ artifact_dir: { "$eval": "ARTIFACTS_DIR" }
 verbose: { "$eval": "VERBOSE == 'true'" }
 autograph_configs: { "$eval": "PASSWORDS_PATH" }
 apple_notarization_configs: { "$eval": "APPLE_NOTARIZATION_CREDS_PATH" }
+mar_channels: { "$eval": "MAR_CHANNELS_PATH" }
 taskcluster_scope_prefixes:
   $flatten:
     $match:

--- a/signingscript/src/signingscript/data/config_schema.json
+++ b/signingscript/src/signingscript/data/config_schema.json
@@ -49,6 +49,9 @@
         },
         "authenticode_url": {
             "type": "string"
+        },
+        "mar_channels": {
+            "type": "string"
         }
     }
 }

--- a/signingscript/src/signingscript/data/mar_config_schema.json
+++ b/signingscript/src/signingscript/data/mar_config_schema.json
@@ -1,0 +1,13 @@
+{
+    "title": "signingscript mar-channels config schema",
+    "type": "object",
+    "patternProperties": {
+        "cert:(nightly|release|dep)-signing$": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    },
+    "additionalProperties": false
+}

--- a/signingscript/src/signingscript/script.py
+++ b/signingscript/src/signingscript/script.py
@@ -11,7 +11,7 @@ import scriptworker.client
 
 from signingscript.exceptions import SigningScriptError
 from signingscript.task import apple_notarize_stacked, build_filelist_dict, sign, task_cert_type, task_signing_formats
-from signingscript.utils import copy_to_dir, load_apple_notarization_configs, load_autograph_configs
+from signingscript.utils import copy_to_dir, load_apple_notarization_configs, load_autograph_configs, load_json
 
 log = logging.getLogger(__name__)
 
@@ -46,6 +46,10 @@ async def async_main(context):
 
         context.session = session
         context.autograph_configs = load_autograph_configs(context.config["autograph_configs"])
+        if "mar_channels" in context.config:
+            context.mar_channels = load_json(context.config["mar_channels"])
+        else:
+            context.mar_channels = {}
 
         # TODO: Make task.sign take in the whole filelist_dict and return a dict of output files.
         #       That would likely mean changing all behaviors to accept and deal with multiple files at once.

--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -1197,6 +1197,19 @@ def verify_mar_signature(cert_type, fmt, mar, keyid=None):
         raise SigningScriptError(e)
 
 
+def validate_mar_channel(context, mar):
+    """Verify the mar channel matches an authorized pattern"""
+    cert_type = task.task_cert_type(context)
+    try:
+        channel_id = mar.productinfo[1]
+    except TypeError:
+        raise SigningScriptError("Can't find mar channel id")
+    allowed_channels = context.mar_channels.get(cert_type, [])
+    if any(fnmatch.fnmatch(channel_id, pattern) for pattern in allowed_channels):
+        return
+    raise SigningScriptError(f"Cannot use mar channel id {channel_id}, expected one of {allowed_channels}")
+
+
 @time_async_function
 async def sign_mar384_with_autograph_hash(context, from_, fmt, to=None, **kwargs):
     """Signs a hash with autograph, injects it into the file, and writes the result to arg `to` or `from_` if `to` is None.
@@ -1232,6 +1245,8 @@ async def sign_mar384_with_autograph_hash(context, from_, fmt, to=None, **kwargs
         tmp.seek(0)
 
         with MarReader(tmp) as m:
+            validate_mar_channel(context, m)
+
             hashes = m.calculate_hashes()
         h = hashes[0][1]
 

--- a/signingscript/tests/conftest.py
+++ b/signingscript/tests/conftest.py
@@ -56,6 +56,7 @@ def context(tmpdir):
     context.config["apple_notarization_configs"] = APPLE_CONFIG_PATH
     context.autograph_configs = load_autograph_configs(SERVER_CONFIG_PATH)
     context.apple_credentials_path = "fakepath"
+    context.mar_channels = {TEST_CERT_TYPE: ["*"]}
     mkdir(context.config["work_dir"])
     mkdir(context.config["artifact_dir"])
     context.task = {"scopes": [TEST_CERT_TYPE]}

--- a/signingscript/tests/test_config.py
+++ b/signingscript/tests/test_config.py
@@ -11,6 +11,7 @@ COMMON_CONTEXT = {
     "VERBOSE": "true",
     "PASSWORDS_PATH": "",
     "APPLE_NOTARIZATION_CREDS_PATH": "",
+    "MAR_CHANNELS_PATH": "",
     "SSL_CERT_PATH": "",
     "SIGNTOOL_PATH": "",
     "DMG_PATH": "",
@@ -45,16 +46,63 @@ def _validate_config(context):
     context.update(COMMON_CONTEXT)
     config = load_config(os.path.join(os.path.dirname(__file__), "..", "docker.d", "worker.yml"), context)
     passwords_config = load_config(os.path.join(os.path.dirname(__file__), "..", "docker.d", "passwords.yml"), context)
+    mar_channels_config = load_config(os.path.join(os.path.dirname(__file__), "..", "docker.d", "mar-channels.yml"), context)
     config_schema = load_schema(os.path.join(os.path.dirname(__file__), "..", "src", "signingscript", "data", "config_schema.json"))
     passwords_schema = load_schema(os.path.join(os.path.dirname(__file__), "..", "src", "signingscript", "data", "passwords_config_schema.json"))
+    mar_config_schema = load_schema(os.path.join(os.path.dirname(__file__), "..", "src", "signingscript", "data", "mar_config_schema.json"))
 
     jsonschema.validate(config, config_schema)
     jsonschema.validate(passwords_config, passwords_schema)
+    jsonschema.validate(mar_channels_config, mar_config_schema)
 
 
 def test_firefox_dev():
     context = {
         "COT_PRODUCT": "firefox",
+        "ENV": "dev",
+        "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME": "",
+        "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD": "",
+        "AUTOGRAPH_MAR_USERNAME": "",
+        "AUTOGRAPH_MAR_PASSWORD": "",
+        "AUTOGRAPH_GPG_USERNAME": "",
+        "AUTOGRAPH_GPG_PASSWORD": "",
+        "AUTOGRAPH_WIDEVINE_USERNAME": "",
+        "AUTOGRAPH_WIDEVINE_PASSWORD": "",
+        "AUTOGRAPH_OMNIJA_USERNAME": "",
+        "AUTOGRAPH_OMNIJA_PASSWORD": "",
+        "AUTOGRAPH_LANGPACK_USERNAME": "",
+        "AUTOGRAPH_LANGPACK_PASSWORD": "",
+        "AUTOGRAPH_FOCUS_USERNAME": "",
+        "AUTOGRAPH_FOCUS_PASSWORD": "",
+        "AUTOGRAPH_FENIX_USERNAME": "",
+        "AUTOGRAPH_FENIX_PASSWORD": "",
+        "AUTOGRAPH_RPMSIGN_USERNAME": "",
+        "AUTOGRAPH_RPMSIGN_PASSWORD": "",
+        "AUTOGRAPH_STAGE_AUTHENTICODE_SHA2_USERNAME": "",
+        "AUTOGRAPH_STAGE_AUTHENTICODE_SHA2_PASSWORD": "",
+        "AUTOGRAPH_STAGE_MAR_USERNAME": "",
+        "AUTOGRAPH_STAGE_MAR_PASSWORD": "",
+        "AUTOGRAPH_STAGE_GPG_USERNAME": "",
+        "AUTOGRAPH_STAGE_GPG_PASSWORD": "",
+        "AUTOGRAPH_STAGE_OMNIJA_USERNAME": "",
+        "AUTOGRAPH_STAGE_OMNIJA_PASSWORD": "",
+        "AUTOGRAPH_STAGE_WIDEVINE_USERNAME": "",
+        "AUTOGRAPH_STAGE_WIDEVINE_PASSWORD": "",
+        "AUTOGRAPH_STAGE_LANGPACK_USERNAME": "",
+        "AUTOGRAPH_STAGE_LANGPACK_PASSWORD": "",
+        "AUTOGRAPH_STAGE_FOCUS_USERNAME": "",
+        "AUTOGRAPH_STAGE_FOCUS_PASSWORD": "",
+        "AUTOGRAPH_STAGE_FENIX_USERNAME": "",
+        "AUTOGRAPH_STAGE_FENIX_PASSWORD": "",
+        "AUTOGRAPH_STAGE_RPMSIGN_USERNAME": "",
+        "AUTOGRAPH_STAGE_RPMSIGN_PASSWORD": "",
+    }
+    _validate_config(context)
+
+
+def test_enterprise_dev():
+    context = {
+        "COT_PRODUCT": "enterprise",
         "ENV": "dev",
         "AUTOGRAPH_AUTHENTICODE_SHA2_USERNAME": "",
         "AUTOGRAPH_AUTHENTICODE_SHA2_PASSWORD": "",


### PR DESCRIPTION
Avoid signing mar files that are targeted to a different application.