### PR TITLE
signingscript: fix logging deprecation warning

### DIFF
--- a/signingscript/src/signingscript/rcodesign.py
+++ b/signingscript/src/signingscript/rcodesign.py
@@ -43,7 +43,7 @@ async def _execute_command(command):
         stderr = (await proc.stderr.readline()).decode("utf-8").rstrip()
         if stderr:
             # Unfortunately a lot of outputs from rcodesign come out to stderr
-            log.warn(stderr)
+            log.warning(stderr)
             output_lines.append(stderr)
 
     exitcode = await proc.wait()


### PR DESCRIPTION
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead