### PR TITLE
Handle more ok and failure states in pushmsix submissions

### DIFF
--- a/pushmsixscript/tests/test_microsoft_store.py
+++ b/pushmsixscript/tests/test_microsoft_store.py
@@ -556,11 +556,21 @@ def test_get_submission_status(status_code, raises, mocked_response, exc):
     "submission_response, raises, exc",
     (
         ({"status": "PreProcessing"}, False, None),
+        ({"status": "Certification"}, False, None),
+        ({"status": "Release"}, False, None),
+        ({"status": "PendingPublication"}, False, None),
+        ({"status": "Publishing"}, False, None),
+        ({"status": "Published"}, False, None),
         # Max polling attempts
         ({"status": "CommitStarted"}, True, TimeoutError),
         ({"status": "PendingCommit"}, True, TimeoutError),
         # Failed
         ({"status": "CommitFailed"}, True, TaskError),
+        ({"status": "PreProcessingFailed"}, True, TaskError),
+        ({"status": "CertificationFailed"}, True, TaskError),
+        ({"status": "ReleaseFailed"}, True, TaskError),
+        ({"status": "PublishFailed"}, True, TaskError),
+        ({"status": "Canceled"}, True, TaskError),
     ),
 )
 def test_wait_for_commit_completion(monkeypatch, submission_response, raises, exc):


### PR DESCRIPTION
According to microsoft's [StoreBroker] (which matches microsoft's [documentation] on the existing status lists), a happy path looks like this for an application:

`PendingCommit` -> `CommitStarted` -> `PreProcessing` -> `Certification` -> `Release` -> `PendingPublication` -> `Publishing` -> `Published`.

`Commit`, `PreProcessing`, `Publish`, `Certification` and `Release` all have a corresponding `Failed` state.

This handles every state after `PreProcessing` as being terminal and OK, and every failure state as being terminal and obviously NOK.

Hopefully this reduces the amount of silent failed uploads we're seeing to the MSIX store as well as the amount of false failure.

Data shows that half the failures since the start of the year were because the submission ended up in `Certification` without passing by `PreProcessing` (well, it passed by it between poll attempts). And a third of the remaining ones was because of lack of state cleanup between runs, where the state got messed up because of the previous errors. The remaining errors are actual timeouts and we should maybe consider increasing the timeout if it happens again (at least now we should be able to detect other failures and rule them out).

[StoreBroker]: https://github.com/microsoft/StoreBroker/blob/47d06c77d80b6a47d1b66a78d63d1609934d7104/Documentation/USAGE.md#status-progression
[documentation]: https://learn.microsoft.com/en-us/windows/uwp/monetize/get-status-for-an-app-submission