### PR TITLE
tests(bouncerscript): remove useless mark from pytest fixtures

### DIFF
--- a/bouncerscript/tests/conftest.py
+++ b/bouncerscript/tests/conftest.py
@@ -59,7 +59,6 @@ async def _fake_request(resp_status, method, url, *args, **kwargs):
     return resp
 
 
-@pytest.mark.asyncio
 @pytest_asyncio.fixture(scope="function")
 async def fake_session():
     session = aiohttp.ClientSession()
@@ -68,7 +67,6 @@ async def fake_session():
     await session.close()
 
 
-@pytest.mark.asyncio
 @pytest_asyncio.fixture(scope="function")
 async def fake_session_500():
     session = aiohttp.ClientSession()


### PR DESCRIPTION
```
tests/conftest.py:62
  /builds/worker/checkouts/vcs/bouncerscript/tests/conftest.py:62: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    @pytest.mark.asyncio

tests/conftest.py:71
  /builds/worker/checkouts/vcs/bouncerscript/tests/conftest.py:71: PytestRemovedIn9Warning: Marks applied to fixtures have no effect
  See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
    @pytest.mark.asyncio
```