### PR TITLE
tests(treescript): fix assertions to actually test something

### DIFF
--- a/treescript/tests/test_script.py
+++ b/treescript/tests/test_script.py
@@ -71,10 +71,10 @@ async def test_async_main(mocker, task, expected):
     else:
         await script.async_main(config, task)
         if expected == "github":
-            assert github_mock.called_with(config, task)
+            github_mock.assert_called_with(config, task)
             assert not gecko_mock.called
         elif expected == "gecko":
-            assert gecko_mock.called_with(config, task)
+            gecko_mock.assert_called_with(config, task)
             assert not github_mock.called
 
 


### PR DESCRIPTION
Caught by python 3.12+ (https://github.com/python/cpython/issues/100690):

> AttributeError: 'called_with' is not a valid assertion. Use a spec for the mock if 'called_with' is meant to be an attribute.