### PR TITLE
tests(beetmoverscript): add flush in test_get_hash to get correct output

### DIFF
--- a/beetmoverscript/tests/test_utils.py
+++ b/beetmoverscript/tests/test_utils.py
@@ -36,7 +36,7 @@ from . import get_fake_checksums_manifest, get_fake_valid_task, get_test_jinja_e
 
 # get_hash {{{1
 def test_get_hash():
-    correct_sha1s = ("cb8aa4802996ac8de0436160e7bc0c79b600c222", "da39a3ee5e6b4b0d3255bfef95601890afd80709")
+    correct_sha1 = "69d0c3a5ff8d7374964cc8202fd713ad0ae9504a"
     text = b"Hello world from beetmoverscript!"
 
     with tempfile.NamedTemporaryFile(delete=True) as fp:
@@ -45,9 +45,10 @@ def test_get_hash():
         count = int(HASH_BLOCK_SIZE / len(text)) * 2
         for i in range(count):
             fp.write(text)
+        fp.flush()
         sha1digest = get_hash(fp.name, hash_type="sha1")
 
-    assert sha1digest in correct_sha1s
+    assert sha1digest == correct_sha1
 
 
 # write_json {{{1


### PR DESCRIPTION
We were hashing only part of the written data and relying on python's buffering behavior to compare against "correct" checksums.  That buffering apparently changed in 3.14, revealing the issue.