### PR TITLE
signingscript: unpin winsign

### DIFF
--- a/signingscript/pyproject.toml
+++ b/signingscript/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "scriptworker",
     "taskcluster",
     "mohawk>=1.0.0",
-    "winsign==2.2.4",
+    "winsign",
     "macholib>=1.11",
     "mozbuild",
     "jsonschema>=4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3980,7 +3980,7 @@ requires-dist = [
     { name = "scriptworker" },
     { name = "six" },
     { name = "taskcluster" },
-    { name = "winsign", specifier = "==2.2.4" },
+    { name = "winsign" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
I don't think we need to pin a particular version in pyproject.toml, we can let the regular uv.lock updates handle it along with other dependencies.