### PR TITLE
Update docker images from debian 12 to debian 13

### DIFF
--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -11,8 +11,8 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 meta:
-    - &py311 "3.11.9"
-    - &py314 "3.14.3"
+    - &py311 "3.11.15-trixie"
+    - &py314 "3.14.3-trixie"
     - &uv_version "0.7.15"
 
 tasks:
@@ -84,7 +84,7 @@ tasks:
         args:
             SCRIPT_NAME: pushmsixscript
     signingscript:
-        # python:3.11.9 docker image contains osslsigncode 2.5.
+        # python:3.11.15-trixie docker image contains osslsigncode 2.9.
         # if the image changes, verify version of osslsigncode and make sure winsign works as well
         parent: base
     treescript:


### PR DESCRIPTION
Bump python 3.11-based docker images from 3.11.9 to 3.11.15, which also updates the underlying OS.

This required some fixes to msix-packaging (for compatibility with the newer glibc/libstdc++/ICU) and winsign (for compatibility with the newer osslsigncode).