### PR TITLE
pushflatpakscript: make scopes include app id in addition to channel

### DIFF
--- a/pushflatpakscript/SCOPES.md
+++ b/pushflatpakscript/SCOPES.md
@@ -1,1 +1,10 @@
-TODO
+# Prefixes
+Supported scope prefixes:
+* `project:releng:flathub:firefox`
+* `project:comm:thunderbird:releng:flathub`
+
+Scopes:
+* `{scope_prefix}:stable:{app_id}`: push `app_id` to flathub
+* `{scope_prefix}:beta:{app_id}`: push `app_id` to flathub-beta
+* `{scope_prefix}:mock:{app_id}`: don't push to flathub
+* `{scope_prefix}:stable`, `{scope_prefix}:beta`, `{scope_prefix}:mock`: push the default/fallback app id

--- a/pushflatpakscript/docker.d/worker.yml
+++ b/pushflatpakscript/docker.d/worker.yml
@@ -10,6 +10,14 @@ taskcluster_root_url: { "$eval": "TASKCLUSTER_ROOT_URL" }
 token_locations:
   $if: 'ENV == "prod"'
   then:
-    beta: { "$eval": "REPO_TOKEN_BETA_PATH" }
-    stable: { "$eval": "REPO_TOKEN_STABLE_PATH" }
+    $merge:
+      $match:
+        'COT_PRODUCT == "firefox"':
+          'org.mozilla.firefox':
+            beta: { "$eval": "REPO_TOKEN_BETA_PATH" }
+            stable: { "$eval": "REPO_TOKEN_STABLE_PATH" }
+        'COT_PRODUCT == "thunderbird"':
+          'org.mozilla.Thunderbird':
+            beta: { "$eval": "REPO_TOKEN_BETA_PATH" }
+            stable: { "$eval": "REPO_TOKEN_STABLE_PATH" }
   else: {}

--- a/pushflatpakscript/src/pushflatpakscript/data/config_schema.json
+++ b/pushflatpakscript/src/pushflatpakscript/data/config_schema.json
@@ -29,7 +29,15 @@
         "token_locations": {
             "type": "object",
             "additionalProperties": {
-                "type": "string"
+                "type": "object",
+                "properties": {
+                    "beta": {
+                        "type": "string"
+                    },
+                    "stable": {
+                        "type": "string"
+                    }
+                }
             }
         },
         "taskcluster_root_url": {

--- a/pushflatpakscript/src/pushflatpakscript/flathub.py
+++ b/pushflatpakscript/src/pushflatpakscript/flathub.py
@@ -150,10 +150,11 @@ def check_app_id_matches_flatpak(context, flatpak_path):
     flatpak_refs = [ref.split("/")[1] for ref in flatpak_refs if ref.startswith("app/")]
 
     # Create a list, if any, of all unexpected Flatpak IDs present in repo
-    invalid_refs = set(flatpak_refs) - {context.config["app_id"]}
+    app_id = task.get_flatpak_app(context.config, context.task)
+    invalid_refs = set(flatpak_refs) - {app_id}
 
-    if context.config["app_id"] not in flatpak_refs:
-        raise TaskVerificationError(f"Supplied app ID ({context.config['app_id']}) is not present in Flatpak!")
+    if app_id not in flatpak_refs:
+        raise TaskVerificationError(f"Supplied app ID ({app_id}) is not present in Flatpak!")
 
     if len(invalid_refs) > 0:
         raise TaskVerificationError("One or more invalid app IDs are present in Flatpak!")
@@ -174,7 +175,11 @@ def push(context, flatpak_file_path, channel):
         # We don't raise an error because we still want green tasks on dev instances
         return
 
-    token_args = ["--token-file", context.config["token_locations"][channel]]
+    app_id = task.get_flatpak_app(context.config, context.task)
+    if app_id not in context.config["token_locations"] or channel not in context.config["token_locations"][app_id]:
+        raise TaskVerificationError(f"Cannot push {app_id} to flathub channel {channel}")
+
+    token_args = ["--token-file", context.config["token_locations"][app_id][channel]]
     log.info("Grab a flatpak buildid from Flathub ...")
     publish_build_output = run_flat_manager_client_process(
         context, token_args + ["create", context.config["flathub_url"], channel, "--build-log-url", build_log]

--- a/pushflatpakscript/src/pushflatpakscript/task.py
+++ b/pushflatpakscript/src/pushflatpakscript/task.py
@@ -10,14 +10,27 @@ def get_flatpak_channel(config, task):
         raise TaskVerificationError(f"Channel must be defined in the task payload. Given payload: {payload}")
 
     channel = payload["channel"]
-    scope = config["taskcluster_scope_prefix"] + channel
-    if config["push_to_flathub"] and scope not in task["scopes"]:
-        raise TaskVerificationError(f"Channel {channel} not allowed, missing scope {scope}")
+    legacy_scope = f"{config['taskcluster_scope_prefix']}{channel}"
+    scope_prefix = f"{config['taskcluster_scope_prefix']}{channel}:"
+    if config["push_to_flathub"]:
+        if legacy_scope not in task["scopes"] and not any(scope.startswith(scope_prefix) for scope in task["scopes"]):
+            raise TaskVerificationError(f"Channel {channel} not allowed, missing scope {scope_prefix}*")
 
     if channel not in ALLOWED_CHANNELS:
         raise TaskVerificationError('Channel "{}" is not allowed. Allowed ones are: {}'.format(channel, ALLOWED_CHANNELS))
 
     return channel
+
+
+def get_flatpak_app(config, task):
+    channel = task["payload"]["channel"]
+    scope_prefix = f"{config['taskcluster_scope_prefix']}{channel}:"
+    apps = [scope.removeprefix(scope_prefix) for scope in task["scopes"] if scope.startswith(scope_prefix)]
+    if len(apps) > 1:
+        raise TaskVerificationError(f"Multiple app ids in task scopes, expected just one: {apps}")
+    if not apps:
+        return config["app_id"]
+    return apps[0]
 
 
 def is_allowed_to_push_to_flathub(config, channel):

--- a/pushflatpakscript/tests/test_config.py
+++ b/pushflatpakscript/tests/test_config.py
@@ -14,6 +14,7 @@ COMMON_CONTEXT = {
     "FLATHUB_URL": "https://flat.example",
     "FLAT_MANAGER_CLIENT": "/app/bin/flat-manager-client",
     "TASKCLUSTER_ROOT_URL": "http://taskcluster",
+    "COT_PRODUCT": "firefox",
 }
 
 

--- a/pushflatpakscript/tests/test_task.py
+++ b/pushflatpakscript/tests/test_task.py
@@ -1,7 +1,7 @@
 import pytest
 from scriptworker.exceptions import TaskVerificationError
 
-from pushflatpakscript.task import get_flatpak_channel, is_allowed_to_push_to_flathub
+from pushflatpakscript.task import get_flatpak_app, get_flatpak_channel, is_allowed_to_push_to_flathub
 
 
 def test_get_flatpak_channel_without_payload_raises():
@@ -31,6 +31,13 @@ def test_get_flatpak_channel_dep(raises, channel):
         (False, ["project:releng:flathub:firefox:beta", "some:other:scope"], "beta"),
         (False, ["project:releng:flathub:firefox:beta", "project:releng:flathub:firefox:stable"], "beta"),
         (True, ["project:releng:flathub:firefox:stable"], "beta"),
+        (False, ["project:releng:flathub:firefox:stable:org.mozilla.firefox"], "stable"),
+        (False, ["project:releng:flathub:firefox:beta:org.mozilla.firefox"], "beta"),
+        (False, ["project:releng:flathub:firefox:mock:org.mozilla.firefox"], "mock"),
+        (False, ["project:releng:flathub:firefox:beta:org.mozilla.firefox", "some:other:scope"], "beta"),
+        (False, ["project:releng:flathub:firefox:beta:org.mozilla.firefox", "project:releng:flathub:firefox:stable:org.mozilla.firefox"], "beta"),
+        (True, ["project:releng:flathub:firefox:stable:org.mozilla.firefox"], "beta"),
+        (False, ["project:releng:flathub:firefox:beta:org.mozilla.firefox", "project:releng:flathub:firefox:beta:org.mozilla.thunderbird"], "beta"),
     ),
 )
 def test_get_flatpak_channel_prod(raises, scopes, channel):
@@ -57,3 +64,22 @@ def test_get_flatpak_channel_prod(raises, scopes, channel):
 def test_is_allowed_to_push_to_flathub(channel, push_to_flathub, expected):
     config = {"app_id": "org.mozilla.firefox", "taskcluster_scope_prefix": "project:releng:flathub:firefox:", "push_to_flathub": push_to_flathub}
     assert is_allowed_to_push_to_flathub(config, channel) == expected
+
+
+@pytest.mark.parametrize(
+    "raises, scopes, channel, expected",
+    (
+        (False, ["project:releng:flathub:firefox:stable"], "stable", "org.mozilla.firefox"),
+        (False, ["project:releng:flathub:firefox:stable:org.mozilla.firefox_nightly"], "stable", "org.mozilla.firefox_nightly"),
+        (False, ["project:releng:flathub:firefox:beta:org.mozilla.firefox_nightly"], "stable", "org.mozilla.firefox"),
+        (True, ["project:releng:flathub:firefox:stable:org.mozilla.firefox", "project:releng:flathub:firefox:stable:org.mozilla.firefox_nightly"], "stable", None),
+    ),
+)
+def test_get_flatpak_app(raises, scopes, channel, expected):
+    config = {"app_id": "org.mozilla.firefox", "taskcluster_scope_prefix": "project:releng:flathub:firefox:", "push_to_flathub": True}
+    task = {"scopes": scopes, "payload": {"channel": channel}}
+    if raises:
+        with pytest.raises(TaskVerificationError):
+            get_flatpak_app(config, task)
+    else:
+        assert get_flatpak_app(config, task) == expected


### PR DESCRIPTION
- refactor token_locations config to map channel+app_id to a token
- expect `{scope_prefix}:{channel}:{app_id}` instead of `{scope_prefix}:{channel}`, but fall back to the pre-existing/default app id for backwards compat