### PR TITLE
Slim down docker images

### DIFF
--- a/pushflatpakscript/docker.d/image_setup.sh
+++ b/pushflatpakscript/docker.d/image_setup.sh
@@ -2,5 +2,5 @@
 set -o errexit -o pipefail
 
 apt-get update
-apt-get install -y gir1.2-ostree-1.0 libgirepository-2.0-dev ostree
+apt-get install --no-install-recommends -y curl gir1.2-ostree-1.0 libgirepository-2.0-dev ostree gcc libcairo2-dev
 apt-get clean

--- a/signingscript/docker.d/build_msix_packaging.sh
+++ b/signingscript/docker.d/build_msix_packaging.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set +e
+set -e
 
 git clone --depth=1 https://github.com/mozilla/msix-packaging --branch johnmcpms/signing --single-branch msix-packaging
 

--- a/taskcluster/docker/base-test/Dockerfile
+++ b/taskcluster/docker/base-test/Dockerfile
@@ -22,7 +22,9 @@ RUN ln -s /app/docker.d/healthcheck /bin/healthcheck
 
 ARG APT_PACKAGES
 # Install extra requirements
-RUN /bin/sh -c "if [ \"${APT_PACKAGES}\" != \"\" ]; then apt-get update && apt-get install -y ${APT_PACKAGES} && apt-get clean; fi"
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y git ${APT_PACKAGES} && \
+    apt-get clean
 
 # %include-run-task
 ENV SHELL=/bin/bash \

--- a/taskcluster/docker/githubscript/Dockerfile
+++ b/taskcluster/docker/githubscript/Dockerfile
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+FROM $DOCKER_IMAGE_PARENT
+
+USER root
+
+# We use mimetypes.guess_type which depends on /etc/mime.types
+RUN apt-get update && apt-get install -y --no-install-recommends media-types && apt-get clean
+
+USER app
+
+# %include githubscript
+ADD --chown=app:app topsrcdir/githubscript /app/githubscript
+
+RUN cp -R /app/githubscript/docker.d/* /app/docker.d/ \
+ && . /app/.venv/bin/activate \
+ &&  uv sync --no-dev --active --frozen --package githubscript

--- a/taskcluster/docker/pushapkscript/Dockerfile
+++ b/taskcluster/docker/pushapkscript/Dockerfile
@@ -9,7 +9,7 @@ ADD --chown=app:app topsrcdir/pushapkscript /app/pushapkscript
 
 USER root
 RUN apt-get update \
- && apt-get install -y default-jre-headless \
+ && apt-get install --no-install-recommends -y curl default-jre-headless \
  && apt-get clean
 
 USER app

--- a/taskcluster/docker/signingscript/Dockerfile
+++ b/taskcluster/docker/signingscript/Dockerfile
@@ -16,7 +16,7 @@ USER root
 # Install msix
 # Install rcodesign
 RUN apt-get update \
- && apt-get install -y osslsigncode cmake clang gpg gpgv \
+ && apt-get install --no-install-recommends -y osslsigncode cmake make clang gpg gpgv git libicu-dev wget \
  && apt-get clean \
  && chown -R app:app /app \
  && cd /app/signingscript/docker.d \

--- a/taskcluster/docker/skopeo/Dockerfile
+++ b/taskcluster/docker/skopeo/Dockerfile
@@ -34,7 +34,7 @@ FROM debian:trixie@sha256:55a15a112b42be10bfc8092fcc40b6748dc236f7ef46a358d9392b
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq \
     && apt-get dist-upgrade -y \
-    && apt-get install -y jq zstd python3-minimal curl \
+    && apt-get install --no-install-recommends -y jq zstd python3-minimal curl \
     && apt-get clean
 
 COPY push_image.sh /usr/local/bin/

--- a/taskcluster/docker/treescript/Dockerfile
+++ b/taskcluster/docker/treescript/Dockerfile
@@ -9,7 +9,7 @@ ADD --chown=app:app topsrcdir/treescript /app/treescript
 
 USER root
 RUN apt-get update \
- && apt-get install -y mercurial \
+ && apt-get install --no-install-recommends -y mercurial \
  && apt-get clean \
  && cp /app/treescript/src/treescript/data/hgrc /etc/mercurial/hgrc.d/treescript.rc \
  && cp /app/treescript/docker.d/extensions.rc /etc/mercurial/hgrc.d/extensions.rc

--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -11,8 +11,8 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 meta:
-    - &py311 "3.11.15-trixie"
-    - &py314 "3.14.3-trixie"
+    - &py311 "3.11.15-slim-trixie"
+    - &py314 "3.14.3-slim-trixie"
     - &uv_version "0.7.15"
 
 tasks:
@@ -60,10 +60,7 @@ tasks:
         args:
             SCRIPT_NAME: bouncerscript
     githubscript:
-        definition: script
         parent: base
-        args:
-            SCRIPT_NAME: githubscript
     landoscript:
         definition: script
         parent: base
@@ -91,6 +88,13 @@ tasks:
         parent: base
 
     # Testing images
+    githubscript-test-py311:
+        definition: base-test
+        args:
+            PYTHON_VERSION: *py311
+            # tests expect mimetypes.guess_type to map *.apk to application/vnd.android.package-archive
+            APT_PACKAGES: media-types
+
     pushapkscript-test-py311:
         definition: base-test
         args:
@@ -108,7 +112,14 @@ tasks:
         definition: base-test
         args:
             PYTHON_VERSION: *py311
-            APT_PACKAGES: osslsigncode cmake clang gpg gpgv
+            APT_PACKAGES: osslsigncode cmake make clang gpg gpgv
+
+    githubscript-test-py314:
+        definition: base-test
+        args:
+            PYTHON_VERSION: *py314
+            # tests expect mimetypes.guess_type to map *.apk to application/vnd.android.package-archive
+            APT_PACKAGES: media-types
 
     pushapkscript-test-py314:
         definition: base-test
@@ -127,4 +138,4 @@ tasks:
         definition: base-test
         args:
             PYTHON_VERSION: *py314
-            APT_PACKAGES: osslsigncode cmake clang gpg gpgv
+            APT_PACKAGES: osslsigncode cmake make clang gpg gpgv

--- a/taskcluster/kinds/tox/kind.yml
+++ b/taskcluster/kinds/tox/kind.yml
@@ -69,6 +69,8 @@ tasks:
         resources:
             - githubscript
             - scriptworker_client
+        worker:
+            docker-image: {in-tree: 'githubscript-test-py{matrix[python]}'}
     init:
         resources:
             - docker.d


### PR DESCRIPTION
Switch to the "slim" images variants, and use `--no-install-recommends`
when installing packages.

Install extra packages we need:
- the test images all need git, to clone scriptworker-scripts itself
- the pushflatpakscript and pushapkscript Dockerfiles call curl
- the githubscript tests expect the mimetypes module to map apk to
  application/vnd.android.package-archive, which requires
  the media-types package to populate /etc/mime.types
- pushflatpakscript needs a compiler and a couple of libraries to install
  flat-manager-client's dependencies
- signingscript uses wget to download rcodesign, and needs git, make and
  libicu-dev for the msix-packaging build

Also make build_msix_packaging.sh not ignore errors.