### PR TITLE
pushapkscript: install default-jre-headless instead of default-jdk

### DIFF
--- a/taskcluster/docker/pushapkscript/Dockerfile
+++ b/taskcluster/docker/pushapkscript/Dockerfile
@@ -9,7 +9,7 @@ ADD --chown=app:app topsrcdir/pushapkscript /app/pushapkscript
 
 USER root
 RUN apt-get update \
- && apt-get install -y default-jdk \
+ && apt-get install -y default-jre-headless \
  && apt-get clean
 
 USER app

--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -95,7 +95,7 @@ tasks:
         definition: base-test
         args:
             PYTHON_VERSION: *py311
-            APT_PACKAGES: default-jdk
+            APT_PACKAGES: default-jre-headless
 
     pushflatpakscript-test-py311:
         definition: base-test
@@ -114,7 +114,7 @@ tasks:
         definition: base-test
         args:
             PYTHON_VERSION: *py314
-            APT_PACKAGES: default-jdk
+            APT_PACKAGES: default-jre-headless
 
     pushflatpakscript-test-py314:
         definition: base-test


### PR DESCRIPTION
AIUI we need to run keytool and bundletool, neither of which requires the full jdk.