### PR TITLE
fix: use full python install on skopeo image

### DIFF
--- a/taskcluster/docker/skopeo/Dockerfile
+++ b/taskcluster/docker/skopeo/Dockerfile
@@ -34,7 +34,7 @@ FROM debian:trixie@sha256:55a15a112b42be10bfc8092fcc40b6748dc236f7ef46a358d9392b
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq \
     && apt-get dist-upgrade -y \
-    && apt-get install --no-install-recommends -y jq zstd python3-minimal curl \
+    && apt-get install --no-install-recommends -y jq zstd python3 curl ca-certificates \
     && apt-get clean
 
 COPY push_image.sh /usr/local/bin/


### PR DESCRIPTION
This is needed to run `run-task`. Presumably regressed by https://github.com/mozilla-releng/scriptworker-scripts/pull/1395.

See https://firefox-ci-tc.services.mozilla.com/tasks/WszCJA9bSQSt46xX7PtBkQ/runs/0 and https://firefox-ci-tc.services.mozilla.com/tasks/RQDNW2TUT221noIPdXKC_A for push tasks with and without these change.