### PR TITLE
pushflatpak: REPO_TOKEN_TB_* variables are optional

### DIFF
--- a/pushflatpakscript/docker.d/worker.yml
+++ b/pushflatpakscript/docker.d/worker.yml
@@ -21,8 +21,16 @@ token_locations:
             beta: { "$eval": "REPO_TOKEN_BETA_PATH" }
             stable: { "$eval": "REPO_TOKEN_STABLE_PATH" }
           'org.mozilla.thunderbird':
-            beta: { "$eval": "REPO_TOKEN_TB_BETA_PATH" }
-            stable: { "$eval": "REPO_TOKEN_TB_STABLE_PATH" }
+            $merge:
+              - $if: "defined('REPO_TOKEN_TB_BETA_PATH')"
+                then:
+                  beta: { "$eval": "REPO_TOKEN_TB_BETA_PATH" }
+              - $if: "defined('REPO_TOKEN_TB_STABLE_PATH')"
+                then:
+                  stable: { "$eval": "REPO_TOKEN_TB_STABLE_PATH" }
           'org.mozilla.thunderbird_esr':
-            stable: { "$eval": "REPO_TOKEN_TB_ESR_PATH" }
+            $merge:
+              - $if: "defined('REPO_TOKEN_TB_ESR_PATH')"
+                then:
+                  stable: { "$eval": "REPO_TOKEN_TB_ESR_PATH" }
   else: {}


### PR DESCRIPTION
We don't have tokens for the new apps yet, don't crash on startup.