### PR TITLE
Bug 2025695 - landoscript: extend version_bump to handle JSON manifests

### DIFF
--- a/landoscript/src/landoscript/actions/version_bump.py
+++ b/landoscript/src/landoscript/actions/version_bump.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os.path
 import typing
@@ -17,10 +18,11 @@ from landoscript.util.version import find_what_version_parser_to_use
 
 log = logging.getLogger(__name__)
 
-# A list of files that this action is allowed to operate on.
 ALLOWED_BUMP_FILES = (
     "browser/config/version.txt",
     "browser/config/version_display.txt",
+    "browser/extensions/newtab/manifest.json",
+    "browser/extensions/webcompat/manifest.json",
     "config/milestone.txt",
     "mobile/android/version.txt",
     "mail/config/version.txt",
@@ -32,6 +34,12 @@ ALLOWED_BUMP_FILES = (
 class VersionBumpInfo:
     next_version: str
     files: list[str]
+
+
+def parse_manifest_version(orig_contents: str) -> BaseVersion:
+    """Extract and parse the version field from a JSON manifest."""
+    manifest = json.loads(orig_contents)
+    return BaseVersion.parse(manifest["version"])
 
 
 async def run(
@@ -119,6 +127,11 @@ async def run(
 
 
 def get_cur_and_next_version(filename, orig_contents, next_version, munge_next_version):
+    if filename.endswith(".json"):
+        cur = parse_manifest_version(orig_contents)
+        next_ = BaseVersion.parse(next_version)
+        return cur, next_
+
     VersionClass: BaseVersion = find_what_version_parser_to_use(filename)
     lines = [line for line in orig_contents.splitlines() if line and not line.startswith("#")]
     cur = VersionClass.parse(lines[-1])

--- a/landoscript/src/landoscript/actions/version_bump.py
+++ b/landoscript/src/landoscript/actions/version_bump.py
@@ -95,7 +95,8 @@ async def run(
 
             modified = orig.replace(str(cur), str(next_))
             if orig == modified:
-                raise LandoscriptError("file not modified, this should be impossible")
+                log.warning(f"{file}: version replacement produced no change, skipping")
+                continue
 
             log.info(f"{file}: successfully bumped! new contents are:")
             log_file_contents(modified)

--- a/landoscript/src/landoscript/actions/version_bump.py
+++ b/landoscript/src/landoscript/actions/version_bump.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os.path
 import typing
@@ -17,10 +18,11 @@ from landoscript.util.version import find_what_version_parser_to_use
 
 log = logging.getLogger(__name__)
 
-# A list of files that this action is allowed to operate on.
 ALLOWED_BUMP_FILES = (
     "browser/config/version.txt",
     "browser/config/version_display.txt",
+    "browser/extensions/newtab/manifest.json",
+    "browser/extensions/webcompat/manifest.json",
     "config/milestone.txt",
     "mobile/android/version.txt",
     "mail/config/version.txt",
@@ -32,6 +34,12 @@ ALLOWED_BUMP_FILES = (
 class VersionBumpInfo:
     next_version: str
     files: list[str]
+
+
+def parse_manifest_version(orig_contents: str) -> BaseVersion:
+    """Extract and parse the version field from a JSON manifest."""
+    manifest = json.loads(orig_contents)
+    return BaseVersion.parse(manifest["version"])
 
 
 async def run(
@@ -119,6 +127,11 @@ async def run(
 
 
 def get_cur_and_next_version(filename, orig_contents, next_version, munge_next_version):
+    if filename.endswith("/manifest.json"):
+        cur = parse_manifest_version(orig_contents)
+        next_ = BaseVersion.parse(next_version)
+        return cur, next_
+
     VersionClass: BaseVersion = find_what_version_parser_to_use(filename)
     lines = [line for line in orig_contents.splitlines() if line and not line.startswith("#")]
     cur = VersionClass.parse(lines[-1])

--- a/landoscript/tests/test_version_bump.py
+++ b/landoscript/tests/test_version_bump.py
@@ -6,6 +6,7 @@ from pytest_scriptworker_client import get_files_payload
 from landoscript.errors import LandoscriptError
 from landoscript.script import async_main
 from landoscript.actions.version_bump import ALLOWED_BUMP_FILES
+import json as _json
 from landoscript.util.version import _VERSION_CLASS_PER_BEGINNING_OF_PATH
 
 from .conftest import (
@@ -394,4 +395,97 @@ def test_no_overlaps_in_version_classes():
 
 def test_all_bump_files_have_version_class():
     for bump_file in ALLOWED_BUMP_FILES:
+        # JSON manifests use BaseVersion directly and bypass the version class lookup
+        if bump_file.endswith(".json"):
+            continue
         assert any([bump_file.startswith(path) for path in _VERSION_CLASS_PER_BEGINNING_OF_PATH])
+
+
+NEWTAB_MANIFEST = "browser/extensions/newtab/manifest.json"
+WEBCOMPAT_MANIFEST = "browser/extensions/webcompat/manifest.json"
+MANIFEST_FILE = NEWTAB_MANIFEST
+
+
+def _manifest(version):
+    return _json.dumps({"manifest_version": 2, "name": "New Tab", "version": version}, indent=2)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "initial_version,expected_version",
+    [
+        pytest.param("151.0.0", "151.1.0", id="initial_after_merge_day"),
+        pytest.param("151.1.0", "151.2.0", id="normal_minor_bump"),
+    ],
+)
+async def test_json_manifest_bump(aioresponses, github_installation_responses, context, initial_version, expected_version):
+    payload = {
+        "actions": ["version_bump"],
+        "lando_repo": "repo_name",
+        "version_bump_info": {
+            "files": [MANIFEST_FILE],
+            "next_version": expected_version,
+        },
+    }
+    setup_github_graphql_responses(aioresponses, get_files_payload({MANIFEST_FILE: _manifest(initial_version)}))
+    await run_test(
+        aioresponses,
+        github_installation_responses,
+        context,
+        payload,
+        ["version_bump"],
+        assert_func=lambda req: assert_success(
+            req,
+            ["Automatic version bump", "NO BUG", "a=release", "CLOSED TREE"],
+            {MANIFEST_FILE: f'  "version": "{initial_version}"'},
+            {MANIFEST_FILE: f'  "version": "{expected_version}"'},
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_json_manifest_file_not_found(aioresponses, github_installation_responses, context):
+    payload = {
+        "actions": ["version_bump"],
+        "lando_repo": "repo_name",
+        "version_bump_info": {
+            "files": [MANIFEST_FILE],
+            "next_version": "151.1.0",
+        },
+    }
+    setup_github_graphql_responses(aioresponses, get_files_payload({MANIFEST_FILE: None}))
+    await run_test(
+        aioresponses,
+        github_installation_responses,
+        context,
+        payload,
+        ["version_bump"],
+        err=LandoscriptError,
+        errmsg="does not exist",
+    )
+
+
+@pytest.mark.asyncio
+async def test_webcompat_manifest_bump(aioresponses, github_installation_responses, context):
+    payload = {
+        "actions": ["version_bump"],
+        "lando_repo": "repo_name",
+        "version_bump_info": {
+            "files": [WEBCOMPAT_MANIFEST],
+            "next_version": "151.1.0",
+        },
+    }
+    setup_github_graphql_responses(aioresponses, get_files_payload({WEBCOMPAT_MANIFEST: _manifest("151.0.0")}))
+    await run_test(
+        aioresponses,
+        github_installation_responses,
+        context,
+        payload,
+        ["version_bump"],
+        assert_func=lambda req: assert_success(
+            req,
+            ["Automatic version bump", "NO BUG", "a=release", "CLOSED TREE"],
+            {WEBCOMPAT_MANIFEST: '  "version": "151.0.0"'},
+            {WEBCOMPAT_MANIFEST: '  "version": "151.1.0"'},
+        ),
+    )

--- a/landoscript/tests/test_version_bump.py
+++ b/landoscript/tests/test_version_bump.py
@@ -6,6 +6,7 @@ from pytest_scriptworker_client import get_files_payload
 from landoscript.errors import LandoscriptError
 from landoscript.script import async_main
 from landoscript.actions.version_bump import ALLOWED_BUMP_FILES
+import json as _json
 from landoscript.util.version import _VERSION_CLASS_PER_BEGINNING_OF_PATH
 
 from .conftest import (
@@ -394,4 +395,97 @@ def test_no_overlaps_in_version_classes():
 
 def test_all_bump_files_have_version_class():
     for bump_file in ALLOWED_BUMP_FILES:
+        # JSON manifests use BaseVersion directly and bypass the version class lookup
+        if bump_file.endswith("/manifest.json"):
+            continue
         assert any([bump_file.startswith(path) for path in _VERSION_CLASS_PER_BEGINNING_OF_PATH])
+
+
+NEWTAB_MANIFEST = "browser/extensions/newtab/manifest.json"
+WEBCOMPAT_MANIFEST = "browser/extensions/webcompat/manifest.json"
+MANIFEST_FILE = NEWTAB_MANIFEST
+
+
+def _manifest(version):
+    return _json.dumps({"manifest_version": 2, "name": "New Tab", "version": version}, indent=2)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "initial_version,expected_version",
+    [
+        pytest.param("151.0.0", "151.1.0", id="initial_after_merge_day"),
+        pytest.param("151.1.0", "151.2.0", id="normal_minor_bump"),
+    ],
+)
+async def test_json_manifest_bump(aioresponses, github_installation_responses, context, initial_version, expected_version):
+    payload = {
+        "actions": ["version_bump"],
+        "lando_repo": "repo_name",
+        "version_bump_info": {
+            "files": [MANIFEST_FILE],
+            "next_version": expected_version,
+        },
+    }
+    setup_github_graphql_responses(aioresponses, get_files_payload({MANIFEST_FILE: _manifest(initial_version)}))
+    await run_test(
+        aioresponses,
+        github_installation_responses,
+        context,
+        payload,
+        ["version_bump"],
+        assert_func=lambda req: assert_success(
+            req,
+            ["Automatic version bump", "NO BUG", "a=release", "CLOSED TREE"],
+            {MANIFEST_FILE: f'  "version": "{initial_version}"'},
+            {MANIFEST_FILE: f'  "version": "{expected_version}"'},
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_json_manifest_file_not_found(aioresponses, github_installation_responses, context):
+    payload = {
+        "actions": ["version_bump"],
+        "lando_repo": "repo_name",
+        "version_bump_info": {
+            "files": [MANIFEST_FILE],
+            "next_version": "151.1.0",
+        },
+    }
+    setup_github_graphql_responses(aioresponses, get_files_payload({MANIFEST_FILE: None}))
+    await run_test(
+        aioresponses,
+        github_installation_responses,
+        context,
+        payload,
+        ["version_bump"],
+        err=LandoscriptError,
+        errmsg="does not exist",
+    )
+
+
+@pytest.mark.asyncio
+async def test_webcompat_manifest_bump(aioresponses, github_installation_responses, context):
+    payload = {
+        "actions": ["version_bump"],
+        "lando_repo": "repo_name",
+        "version_bump_info": {
+            "files": [WEBCOMPAT_MANIFEST],
+            "next_version": "151.1.0",
+        },
+    }
+    setup_github_graphql_responses(aioresponses, get_files_payload({WEBCOMPAT_MANIFEST: _manifest("151.0.0")}))
+    await run_test(
+        aioresponses,
+        github_installation_responses,
+        context,
+        payload,
+        ["version_bump"],
+        assert_func=lambda req: assert_success(
+            req,
+            ["Automatic version bump", "NO BUG", "a=release", "CLOSED TREE"],
+            {WEBCOMPAT_MANIFEST: '  "version": "151.0.0"'},
+            {WEBCOMPAT_MANIFEST: '  "version": "151.1.0"'},
+        ),
+    )

--- a/landoscript/tests/test_version_bump_json_manifest.py
+++ b/landoscript/tests/test_version_bump_json_manifest.py
@@ -1,0 +1,33 @@
+import json
+
+import pytest
+
+from landoscript.actions.version_bump import parse_manifest_version
+
+
+def _manifest(version, name="New Tab"):
+    return json.dumps({"manifest_version": 2, "name": name, "version": version}, indent=2)
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["151.0.0", "151.1.0", "151.2.0"],
+)
+def test_parse_manifest_version(version):
+    result = parse_manifest_version(_manifest(version))
+    assert str(result) == version
+
+
+def test_parse_manifest_version_ignores_other_fields():
+    contents = '{"manifest_version": 2, "version": "151.0.0", "strict_min_version": "140.0"}'
+    result = parse_manifest_version(contents)
+    assert str(result) == "151.0.0"
+
+
+@pytest.mark.parametrize(
+    "manifest_name",
+    ["New Tab", "Web Compat"],
+)
+def test_parse_manifest_version_works_for_newtab_and_webcompat(manifest_name):
+    result = parse_manifest_version(_manifest("151.0.0", name=manifest_name))
+    assert str(result) == "151.0.0"


### PR DESCRIPTION
[Bug 2025695](https://bugzilla.mozilla.org/show_bug.cgi?id=2025695)

## Summary

- Extends `version_bump` to handle JSON manifests: adds `browser/extensions/newtab/manifest.json` and `browser/extensions/webcompat/manifest.json` to `ALLOWED_BUMP_FILES`, uses `endswith("/manifest.json")` to select the JSON-specific version reader, and uses `str.replace` for the actual replacement (same as all other files)
- Adds `parse_manifest_version()` as an independently unit-testable pure function
- Makes the action idempotent: warns and skips (instead of raising) when the replacement produces no change

## Merge order

1. mozilla-releng/fxci-config [#912](https://github.com/mozilla-releng/fxci-config/pull/912) — merged ✓
2. mozilla-releng/fxci-config [#933](https://github.com/mozilla-releng/fxci-config/pull/933) — merged ✓ (scope name update)
3. mozilla-services/cloudops-infra [#6835](https://github.com/mozilla-services/cloudops-infra/pull/6835) (dev) — merged ✓
4. mozilla-services/cloudops-infra [#6848](https://github.com/mozilla-services/cloudops-infra/pull/6848) (chart secret) — merged ✓
5. k8s-sops: dev worker secrets — done ✓
6. mozilla-releng/k8s-autoscale [#264](https://github.com/mozilla-releng/k8s-autoscale/pull/264) (dev) — merged ✓
7. **This PR** — merged ✓
8. mozilla-services/cloudops-infra [#6838](https://github.com/mozilla-services/cloudops-infra/pull/6838) (prod) — merged ✓
9. k8s-sops: prod worker secrets — manual step
10. mozilla-releng/k8s-autoscale [#266](https://github.com/mozilla-releng/k8s-autoscale/pull/266) (prod) — merged ✓
11. mozilla-releng/fxci-config [#979](https://github.com/mozilla-releng/fxci-config/pull/979) — fix production lando action scope — merged ✓
12. mozilla-extensions/xpi-manifest [#271](https://github.com/mozilla-extensions/xpi-manifest/pull/271) — merged ✓

## Verification

- Unit tests: 104 pass (`uv run pytest` in `landoscript/`)
- Staging end-to-end test via local landoscript (CoT disabled): fetched `manifest.json` from `staging-firefox`, bumped `150.1.0 → 150.2.0`, submitted to staging Lando, got `LANDED` status
- Staging XPI release via Ship-It staging: version-bump task [BRV3TeLXT8S1wONrxgN7_g](https://firefox-ci-tc.services.mozilla.com/tasks/BRV3TeLXT8S1wONrxgN7_g) completed successfully on `xpi-1-lando-dev` worker, landing [this commit](https://github.com/mozilla-releng/staging-firefox/commit/cf5f4fda76c7a226dda97f61bd973d42ba63cfff) on staging-firefox:
  ```
  fetching bump files from github
  browser/extensions/newtab/manifest.json: successfully bumped!
  -  "version": "151.3.0",
  +  "version": "151.4.0",
  Not a dry run...submitting lando actions
  submitting POST request to https://stage.lando.nonprod.webservices.mozgcp.net/api/repo/staging-firefox-main
  success! got 200 response with 'LANDED' status
  ```