### PR TITLE
Retry 5xx statuses from the ms store

### DIFF
--- a/pushmsixscript/pyproject.toml
+++ b/pushmsixscript/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "pytest-asyncio",
     "pytest-cov",
     "requests-mock",
+    "responses",
 ]
 
 [tool.uv.sources]

--- a/pushmsixscript/src/pushmsixscript/microsoft_store.py
+++ b/pushmsixscript/src/pushmsixscript/microsoft_store.py
@@ -10,6 +10,7 @@ from copy import copy
 import requests
 from azure.storage.blob import BlobClient
 from scriptworker_client.exceptions import TaskError, TimeoutError
+from urllib3.util.retry import Retry
 
 from pushmsixscript import task
 
@@ -40,6 +41,19 @@ DEFAULT_LISTINGS = {
     }
 }
 DEFAULT_ALLOW_TARGET = {"Desktop": True, "Mobile": False, "Holographic": False, "Xbox": False}
+
+
+def _build_session():
+    retry = Retry(
+        total=MAX_RETRIES,
+        status_forcelist=[500, 502, 503, 504],
+        # All methods, including PUT/POST, we rely on `_check_for_pending_submission` to avoid duplicates
+        allowed_methods=None,
+        backoff_factor=1,
+    )
+    session = requests.Session()
+    session.mount("https://", requests.adapters.HTTPAdapter(max_retries=retry))
+    return session
 
 
 def push(config, msix_file_paths, channel, publish_mode=None):
@@ -93,8 +107,7 @@ def _store_session(config):
     url = f"{login_url}/{tenant_id}/oauth2/token"
     body = f"grant_type=client_credentials&client_id={client_id}&client_secret={client_secret}&resource={token_resource}"
     headers = {"Content-Type": "application/x-www-form-urlencoded; charset=utf-8"}
-    with requests.Session() as session:
-        session.mount("https://", requests.adapters.HTTPAdapter(max_retries=MAX_RETRIES))
+    with _build_session() as session:
         response = session.post(url, body, headers=headers, timeout=int(config["request_timeout_seconds"]))
         response.raise_for_status()
         return response.json().get("access_token")
@@ -102,8 +115,7 @@ def _store_session(config):
 
 def _push_to_store(config, channel, msix_file_paths, publish_mode, access_token):
     headers = {"Authorization": f"Bearer {access_token}", "Content-type": "application/json", "User-Agent": "Python"}
-    with requests.Session() as session:
-        session.mount("https://", requests.adapters.HTTPAdapter(max_retries=MAX_RETRIES))
+    with _build_session() as session:
         log.info(">> checking for pending submissions...")
         _check_for_pending_submission(config, channel, session, headers)
         log.info(">> creating a new submission...")

--- a/pushmsixscript/tests/test_microsoft_store.py
+++ b/pushmsixscript/tests/test_microsoft_store.py
@@ -1,9 +1,11 @@
 import tempfile
 from unittest.mock import patch
+from urllib3.util.retry import Retry
 
 import pytest
 import requests
 import requests_mock
+import responses
 
 from pushmsixscript import microsoft_store
 from scriptworker_client.exceptions import TaskError, TimeoutError
@@ -77,6 +79,22 @@ def test_check_for_pending_submission(status_code, pending, raises, exc):
                     microsoft_store._check_for_pending_submission(CONFIG, channel, session, headers)
             else:
                 microsoft_store._check_for_pending_submission(CONFIG, channel, session, headers)
+
+
+@pytest.mark.parametrize("method,verb", [("POST", responses.POST), ("PUT", responses.PUT)])
+@pytest.mark.parametrize("status", (500, 502, 503, 504))
+def test_build_session_retries_transient_5xx(monkeypatch, method, verb, status):
+    monkeypatch.setattr(Retry, "sleep", lambda *a, **kw: None)
+    url = "https://fake-store.example.com/resource"
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(verb, url, body="err", status=status)
+        rsps.add(verb, url, body="err", status=status)
+        rsps.add(verb, url, json={"ok": True}, status=200)
+        with microsoft_store._build_session() as session:
+            resp = session.request(method, url)
+        assert resp.status_code == 200
+        rsps.assert_call_count(url, 3)
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -3069,6 +3069,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "requests-mock" },
+    { name = "responses" },
     { name = "tox" },
     { name = "tox-uv" },
 ]
@@ -3089,6 +3090,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "requests-mock" },
+    { name = "responses" },
     { name = "tox" },
     { name = "tox-uv" },
 ]


### PR DESCRIPTION
Before this, the retry was pretty much dead code as we wouldn't retry any 5xx (the default status list is empty). This marks those statuses as retryable.

We rely on `_check_for_pending_submission` to avoid duplicates so we can mark POST/PATCH as retryable as well which makes this whole retry code actually useful.

Note that this is adding `responses` as a dev dependency on top of `requests-mock` because the latter bypasses the adapter completely, preventing the test from exercising the retry code. Not the end of the world since it's a dev dependency only and was already in the lockfile but might be worth considering removing requests-mock in the future and replace it with responses completely.

Fixes #1422