### PR TITLE
Bug 1950203 - fix(signingscript): correct openh264 plugin format name in notarization setup check

### DIFF
--- a/signingscript/src/signingscript/script.py
+++ b/signingscript/src/signingscript/script.py
@@ -40,7 +40,7 @@ async def async_main(context):
             if not context.config.get("widevine_cert"):
                 raise Exception("Widevine format is enabled, but widevine_cert is not defined")
 
-        if {"apple_notarization", "apple_notarization_geckodriver", "apple_notarization_stacked", "apple_notarize_openh264_plugin"}.intersection(
+        if {"apple_notarization", "apple_notarization_geckodriver", "apple_notarization_stacked", "apple_notarization_openh264_plugin"}.intersection(
             all_signing_formats
         ):
             if not context.config.get("apple_notarization_configs", False):


### PR DESCRIPTION
The format name `apple_notarize_openh264_plugin` didn't match the actual format key `apple_notarization_openh264_plugin` in the signing format map, causing `setup_apple_notarization_credentials` to never run for openh264 tasks and resulting in an AttributeError on `context.apple_credentials_path`.