### PR TITLE
fix(signingscript): Bug 2033267 - clear stale authenticode outfile before retrying winsign

### DIFF
--- a/signingscript/src/signingscript/sign.py
+++ b/signingscript/src/signingscript/sign.py
@@ -11,6 +11,7 @@ import json
 import logging
 import lzma
 import os
+import pathlib
 import re
 import resource
 import shutil
@@ -1387,6 +1388,12 @@ async def merge_omnija_files(orig, signed, to):
 # sign_authenticode_file {{{1
 async def _winsign_helper(error_message, *args, **kwargs):
     """Raise an exception if winsign.sign.sign_file returns False to enable retries."""
+    # winsign.sign.sign_file signature is (infile, outfile, ...), so outfile is args[1].
+    # On a prior failed attempt, osslsigncode may have already written outfile to disk;
+    # leaving it there makes the next attempt fail with "Overwriting an existing file
+    # is not supported." — masking the original transient error.
+    outfile = args[1]
+    pathlib.Path(outfile).unlink(missing_ok=True)
     if not await winsign.sign.sign_file(*args, **kwargs):
         raise SigningScriptError(error_message)
 

--- a/signingscript/tests/test_sign.py
+++ b/signingscript/tests/test_sign.py
@@ -1217,6 +1217,45 @@ async def test_authenticode_sign_authenticode_permanent_error(tmpdir, mocker, co
 
 
 @pytest.mark.asyncio
+async def test_winsign_helper_clears_stale_outfile_between_retries(tmpdir, mocker):
+    """_winsign_helper must remove the stale -new outfile before each retry, so
+    osslsigncode doesn't bail with "Overwriting an existing file is not supported."
+    after a transient first-attempt failure.
+    """
+    infile = os.path.join(tmpdir, "helper.exe")
+    outfile = infile + "-new"
+    with open(infile, "wb") as f:
+        f.write(b"unsigned")
+
+    calls = {"n": 0}
+
+    async def mocked_winsign(_infile, _outfile, *args, **kwargs):
+        calls["n"] += 1
+        # Real osslsigncode bails out if -out already exists, so mirror that here:
+        # if the helper didn't clear the stale outfile, surface it as a test failure.
+        if os.path.exists(_outfile):
+            raise AssertionError("Overwriting an existing file is not supported.")
+        # Simulate osslsigncode writing the -new file on every invocation — including
+        # the failing one (winsign returns False for transient post-sign hiccups).
+        with open(_outfile, "wb") as f:
+            f.write(b"signed")
+        if calls["n"] == 1:
+            return False
+        return True
+
+    mocker.patch.object(winsign.sign, "sign_file", mocked_winsign)
+
+    # First attempt: winsign returns False -> helper raises. outfile is left behind.
+    with pytest.raises(SigningScriptError):
+        await sign._winsign_helper("boom", infile, outfile, "sha256", [], None)
+    assert os.path.exists(outfile)
+
+    # Second attempt: helper must unlink the stale outfile before calling sign_file.
+    await sign._winsign_helper("boom", infile, outfile, "sha256", [], None)
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
 async def test_sign_gpg_temporary_error(tmpdir, mocker, context, caplog):
     context.autograph_configs = {
         TEST_CERT_TYPE: [


### PR DESCRIPTION
When winsign.sign.sign_file fails transiently (e.g. DigiCert CRL hiccup during post-sign verification), osslsigncode has already written <orig_path>-new to disk. Subsequent retries then fail with "Overwriting an existing file is not supported.", masking the original error and turning transient failures into permanent task failures. _winsign_helper now unlinks the outfile before each sign_file invocation so retries start clean.