### PR TITLE
chore: add support for temporary mozcloud production environment

### DIFF
--- a/balrogscript/docker.d/init_worker.sh
+++ b/balrogscript/docker.d/init_worker.sh
@@ -38,6 +38,12 @@ case $COT_PRODUCT in
       prod)
         export AUTH0_AUDIENCE="balrog-production"
         ;;
+      # temporary environment to allow validation of new production environment
+      # when `aus4-admin.mozilla.org` is pointed at mozcloud prod this can go away
+      mozcloud-prod)
+        export API_ROOT="https://admin.prod.balrog.prod.webservices.mozgcp.net/api"
+        export AUTH0_AUDIENCE="balrog-production"
+        ;;
       *)
         exit 1
         ;;


### PR DESCRIPTION
These workers will be used to verify that balrogscript is working correctly with the new MozCloud production environment on a project branch; it will never be used by Nightly et. al. This configuration will be removed once testing is complete.