### PR TITLE
fix: make 'mozcloud-prod' an accepted environment

### DIFF
--- a/docker.d/init.sh
+++ b/docker.d/init.sh
@@ -36,6 +36,12 @@ esac
 # Validate content of certain variables
 #
 case $ENV in
+  # temporary environment to allow validation of new production environment
+  # when `aus4-admin.mozilla.org` is pointed at mozcloud prod this can go away
+  mozcloud-prod)
+    export TRUST_LEVEL=3
+    export WORKER_SUFFIX=
+    ;;
   prod)
     export TRUST_LEVEL=3
     export WORKER_SUFFIX=


### PR DESCRIPTION
Follow-up from #1438. These are currently failing to deploy due to hitting the "Unknown ENV" block in this script.