### PR TITLE
fix: change lockFileMaintenance schedule to match main schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "extends": [
     "github>mozilla-releng/reps:renovate-preset.json5"
   ],
-  "schedule": ["* * 1,15 * *"]
+  "schedule": ["* * 1,15 * *"],
+  "lockFileMaintenance": {
+    "schedule": ["* * 1,15 * *"]
+  }
 }


### PR DESCRIPTION
Per [the source code](https://github.com/renovatebot/renovate/blob/a5679746d7a6ecdaa87f8023088ce6df974c622d/lib/config/options/index.ts#L2565), lock file maintenance follows its own schedule.