### PR TITLE
feat: support providing to_revision and from_revision in merge day payloads

### DIFF
--- a/landoscript/src/landoscript/actions/merge_day.py
+++ b/landoscript/src/landoscript/actions/merge_day.py
@@ -35,7 +35,10 @@ class VersionFile:
 class MergeInfo:
     to_branch: str
     fetch_version_from: str
+    # TODO: to_revision should be required after all callers are updated to use it
+    to_revision: str = ""
     from_branch: str = ""
+    from_revision: str = ""
     base_tag: str = ""
     end_tag: str = ""
     merge_old_head: bool = False
@@ -44,6 +47,9 @@ class MergeInfo:
     version_files: list[VersionFile] = field(default_factory=list)
     replacements: list[list[str]] = field(default_factory=list)
     regex_replacements: list[list[str]] = field(default_factory=list)
+
+    # TODO: add __post_init__ to require `from_revision` when `from_branch` is
+    # present after all callers are already doing so
 
     @classmethod
     def from_payload_data(cls, payload_data) -> Self:
@@ -59,6 +65,8 @@ async def run(
 ) -> list[LandoAction]:
     to_branch = merge_info.to_branch
     from_branch = merge_info.from_branch
+    to_revision = merge_info.to_revision
+    from_revision = merge_info.from_revision
     end_tag = merge_info.end_tag
     base_tag = merge_info.base_tag
     merge_old_head = merge_info.merge_old_head
@@ -67,9 +75,23 @@ async def run(
     actions = []
 
     log.info("Starting merge day operations!")
-    to_version = await get_version(github_client, version_file, to_branch)
+    if not to_revision:
+        # TODO: remove this fallback once `to_revision` is required
+        to_revision = await github_client.get_branch_head_oid(to_branch)
+
+    to_version = await get_version(github_client, version_file, to_revision)
+
     log.info(f"to_version is: {to_version}")
     if end_tag:
+        # `end_revision` is purposely made to be whatever the current tip of `to_branch`
+        # is when a landoscript task runs (as opposed to, eg: using the `to_revision`).
+        # This guards against a task being created, something being pushed to the
+        # `to_branch`, and then the `END` tag ending up on an outdated revision.
+        # Even in a case where multiple versions of the same task are scheduled
+        # and race against one another the tag cannot end up in the wrong place so
+        # long as the `version` in it was fetched from a concrete revision. (If a race
+        # does take place, the second task will attempt to move a tag, which will
+        # fail the task.)
         end_revision = await github_client.get_branch_head_oid(to_branch)
         # End tag specifically uses the `to_version` _before_ we bump it
         # (because we're declaring its current version as "done")
@@ -84,10 +106,21 @@ async def run(
     # at that point. If there's no `from_branch`, whatever is currently on `to_branch`
     # is correct.
     if from_branch:
-        bump_version = await get_version(github_client, version_file, from_branch)
-        bump_branch = from_branch
+        if from_revision:
+            bump_version = await get_version(github_client, version_file, from_revision)
+            # Unlike tagging the `to_branch`, tagging the `from_branch` must be done
+            # against a concrete revision known at task scheduling time. This is because
+            # that revision is used as the merge target, and the tag must go on that
+            # specific revision.
+            end_revision = from_revision
+        else:
+            # TODO: remove this fallback once `from_revision` is being passed whenever
+            # `from_branch is
+            bump_version = await get_version(github_client, version_file, from_branch)
+            end_revision = await github_client.get_branch_head_oid(from_branch)
+
+        bump_revision = end_revision
         log.info(f"from_branch is present, got bump_version from it: {bump_version}")
-        end_revision = await github_client.get_branch_head_oid(from_branch)
 
         # base tagging _only_ happens when we have a `from_branch` -- these are
         # scenarios where we're uplifting one branch to another, and beginning a new
@@ -108,11 +141,11 @@ async def run(
             raise TaskVerificationError("'from_branch' is required when merge_old_head is True or version_files are present")
 
         bump_version = to_version
-        bump_branch = to_branch
+        bump_revision = to_revision
         log.info(f"from_branch is not present, using to_version as bump_version: {bump_version}")
 
     if merge_info.l10n_bump_info:
-        actions.extend(await l10n_bump.run(github_client, github_config, public_artifact_dir, bump_branch, merge_info.l10n_bump_info, False, True))
+        actions.extend(await l10n_bump.run(github_client, github_config, public_artifact_dir, bump_revision, merge_info.l10n_bump_info, False, True))
 
     if merge_info.version_files:
         log.info("Performing version bumps")
@@ -142,7 +175,7 @@ async def run(
             await version_bump.run(
                 github_client,
                 public_artifact_dir,
-                bump_branch,
+                bump_revision,
                 version_bump_infos,
                 dontbuild=False,
                 munge_next_version=False,
@@ -163,7 +196,7 @@ async def run(
         for r in regex_replacements:
             needed_files.append(r[0])
 
-        orig_contents = await github_client.get_files(needed_files, bump_branch)
+        orig_contents = await github_client.get_files(needed_files, bump_revision)
         # At the moment, there are no known cases of needing to replace with
         # a suffix...so we simply don't handle that here!
         new_contents = process_replacements(bump_version, replacements, regex_replacements, orig_contents)
@@ -174,7 +207,7 @@ async def run(
 
     if update_clobber_file:
         log.info("Touching clobber file")
-        orig_clobber_file = (await github_client.get_files("CLOBBER", bump_branch))["CLOBBER"]
+        orig_clobber_file = (await github_client.get_files("CLOBBER", bump_revision))["CLOBBER"]
         if orig_clobber_file is None:
             raise LandoscriptError("Couldn't find CLOBBER file in repository!")
 

--- a/landoscript/src/landoscript/data/landoscript_task_schema.json
+++ b/landoscript/src/landoscript/data/landoscript_task_schema.json
@@ -97,6 +97,14 @@
                         "beta"
                     ]
                 },
+                "from_revision": {
+                    "type": "string",
+                    "description": "The revision on the from_branch to fetch its current version from, tag with `_BASE` tags, and use as the target revision for merge actions."
+                },
+                "to_revision": {
+                    "type": "string",
+                    "description": "The revision on the to_branch to fetch its current version from and use to base l10n bumps, version bumps, and replacements on."
+                },
                 "merge_old_head": {
                     "type": "boolean",
                     "default": false

--- a/landoscript/tests/test_merge_day_legacy.py
+++ b/landoscript/tests/test_merge_day_legacy.py
@@ -1,3 +1,16 @@
+# LEGACY merge_day tests -- DO NOT ADD NEW TESTS HERE.
+#
+# These tests cover the *old* merge_day payload format, where version
+# information is fetched at runtime from the file named by `fetch_version_from`
+# and tag names contain a `{major_version}` placeholder. They are kept
+# verbatim from before the migration to explicit `to_branch_version`/
+# `from_branch_version` payloads so that we retain coverage of the old format
+# while callers are migrated.
+#
+# Once every caller passes versions explicitly, delete this entire file along
+# with the code blocks marked "legacy merge_day support" in
+# src/landoscript/actions/merge_day.py.
+
 from collections import defaultdict
 import pytest
 from pytest_scriptworker_client import get_files_payload
@@ -26,7 +39,6 @@ from .conftest import (
             {
                 "end_tag": "FIREFOX_NIGHTLY_{major_version}_END",
                 "to_branch": "main",
-                "to_revision": "abcdef",
                 "replacements": [
                     [
                         "services/sync/modules/constants.sys.mjs",
@@ -71,7 +83,6 @@ from .conftest import (
             {
                 "end_tag": "FIREFOX_NIGHTLY_{major_version}_END",
                 "to_branch": "main",
-                "to_revision": "abcdef",
                 "replacements": [
                     [
                         "services/sync/modules/constants.sys.mjs",
@@ -116,7 +127,6 @@ from .conftest import (
             {
                 "end_tag": "FIREFOX_NIGHTLY_{major_version}_END",
                 "to_branch": "main",
-                "to_revision": "abcdef",
                 "regex_replacements": [
                     [
                         "browser/extensions/webcompat/manifest.json",
@@ -166,11 +176,13 @@ async def test_success_bump_main(
         "dry_run": dry_run,
     }
 
-    end_tag_target_ref = merge_info["to_revision"]
+    end_tag_target_ref = "ghijkl654321"
 
     setup_github_graphql_responses(
         aioresponses,
-        # existing version at `to_revision`
+        # look-up of current tip of `to_branch`
+        {"data": {"repository": {"object": {"oid": end_tag_target_ref}}}},
+        # existing version in `to_branch`
         get_files_payload({merge_info["fetch_version_from"]: "137.0a1"}),
         # branch ref for `end` tag
         {"data": {"repository": {"object": {"oid": end_tag_target_ref}}}},
@@ -206,7 +218,6 @@ async def test_success_bump_main(
 async def test_success_bump_esr(patch_date, aioresponses, github_installation_responses, context):
     merge_info = {
         "to_branch": "esr128",
-        "to_revision": "abcdef",
         "version_files": [
             {"filename": "config/milestone.txt", "version_bump": "minor"},
             {"filename": "browser/config/version.txt", "version_bump": "minor"},
@@ -240,7 +251,9 @@ async def test_success_bump_esr(patch_date, aioresponses, github_installation_re
 
     setup_github_graphql_responses(
         aioresponses,
-        # existing version at `to_revision`
+        # look-up of current tip of `to_branch`
+        {"data": {"repository": {"object": {"oid": "abcdef123456"}}}},
+        # existing version in `to_branch`
         get_files_payload({merge_info["fetch_version_from"]: "128.9.0"}),
         # fetch of original contents of files to bump
         *[get_files_payload(iv) for iv in initial_values_by_expected_version.values()],
@@ -268,7 +281,6 @@ async def test_success_bump_esr(patch_date, aioresponses, github_installation_re
 async def test_success_early_to_late_beta(patch_date, aioresponses, github_installation_responses, context):
     merge_info = {
         "to_branch": "beta",
-        "to_revision": "abcdef",
         "replacements": [
             [
                 "build/defines.sh",
@@ -291,6 +303,8 @@ async def test_success_early_to_late_beta(patch_date, aioresponses, github_insta
 
     setup_github_graphql_responses(
         aioresponses,
+        # look-up of current tip of `to_branch`
+        {"data": {"repository": {"object": {"oid": "abcdef123456"}}}},
         # initial version fetch; technically not needed for this use case
         # but it keeps the merge day code cleaner to keep it
         get_files_payload({merge_info["fetch_version_from"]: "139.0"}),
@@ -380,9 +394,7 @@ async def test_success_main_to_beta_merge_day(patch_date, aioresponses, github_i
         "end_tag": "FIREFOX_BETA_{major_version}_END",
         "base_tag": "FIREFOX_BETA_{major_version}_BASE",
         "to_branch": "beta",
-        "to_revision": "abcdef",
         "from_branch": "main",
-        "from_revision": "ghijkl",
         "replacements": [
             [
                 "browser/config/mozconfigs/linux64/l10n-mozconfig",
@@ -450,8 +462,8 @@ async def test_success_main_to_beta_merge_day(patch_date, aioresponses, github_i
         "lando_repo": "repo_name",
         "merge_info": merge_info,
     }
-    end_tag_target_ref = "abcdef"
-    base_tag_target_ref = "ghijkl"
+    end_tag_target_ref = "ghijkl654321"
+    base_tag_target_ref = "mnopqr987654"
 
     submit_uri, status_uri, job_id, scopes = setup_test(aioresponses, github_installation_responses, context, payload, ["merge_day"])
 
@@ -462,12 +474,16 @@ async def test_success_main_to_beta_merge_day(patch_date, aioresponses, github_i
 
     setup_github_graphql_responses(
         aioresponses,
-        # existing version at `to_revision`
+        # look-up of current tip of `to_branch`
+        {"data": {"repository": {"object": {"oid": "abcdef123456"}}}},
+        # existing version in `to_branch`
         get_files_payload({merge_info["fetch_version_from"]: "139.0b11"}),
         # branch ref for `end` tag
         {"data": {"repository": {"object": {"oid": end_tag_target_ref}}}},
-        # existing version at `from_revision`
+        # existing version in `from_branch`
         get_files_payload({merge_info["fetch_version_from"]: "140.0a1"}),
+        # branch ref for `base` tag
+        {"data": {"repository": {"object": {"oid": base_tag_target_ref}}}},
     )
 
     # because the github graphql endpoint is generic we need to make sure we create
@@ -542,9 +558,7 @@ async def test_success_beta_to_release(patch_date, aioresponses, github_installa
         "end_tag": "FIREFOX_RELEASE_{major_version}_END",
         "base_tag": "FIREFOX_RELEASE_{major_version}_BASE",
         "to_branch": "release",
-        "to_revision": "abcdef",
         "from_branch": "beta",
-        "from_revision": "ghijkl",
         "replacements": [[".arcconfig", "BETA", "RELEASE"]],
         "version_files": [
             {"filename": "browser/config/version_display.txt", "new_suffix": ""},
@@ -578,17 +592,21 @@ async def test_success_beta_to_release(patch_date, aioresponses, github_installa
         "lando_repo": "repo_name",
         "merge_info": merge_info,
     }
-    end_tag_target_ref = "abcdef"
-    base_tag_target_ref = "ghijkl"
+    end_tag_target_ref = "ghijkl654321"
+    base_tag_target_ref = "mnopqr987654"
 
     setup_github_graphql_responses(
         aioresponses,
-        # existing version at `to_revision`
+        # look-up of current tip of `to_branch`
+        {"data": {"repository": {"object": {"oid": "abcdef123456"}}}},
+        # existing version in `to_branch`
         get_files_payload({merge_info["fetch_version_from"]: "135.0"}),
         # branch ref for `end` tag
         {"data": {"repository": {"object": {"oid": end_tag_target_ref}}}},
-        # existing version at `from_revision`
+        # existing version in `from_branch`
         get_files_payload({merge_info["fetch_version_from"]: "136.0"}),
+        # branch ref for `base` tag
+        {"data": {"repository": {"object": {"oid": base_tag_target_ref}}}},
         # fetch of original contents of files to bump, if we expect any replacements
         get_files_payload(initial_values),
         # fetch of original contents of `replacements` and `regex_replacements` files
@@ -626,7 +644,6 @@ async def test_success_release_to_esr(patch_date, aioresponses, github_installat
         # yep...we use `BASE` on the `end_tag` for release-to-esr merges
         "end_tag": "FIREFOX_ESR_{major_version}_BASE",
         "to_branch": "esr128",
-        "to_revision": "abcdef",
         "replacements": [[".arcconfig", "RELEASE", "ESRONETWOEIGHT"]],
         "version_files": [
             {"filename": "browser/config/version_display.txt", "new_suffix": "esr"},
@@ -654,11 +671,13 @@ async def test_success_release_to_esr(patch_date, aioresponses, github_installat
         "lando_repo": "repo_name",
         "merge_info": merge_info,
     }
-    end_tag_target_ref = "abcdef"
+    end_tag_target_ref = "ghijkl654321"
 
     setup_github_graphql_responses(
         aioresponses,
-        # existing version at `to_revision`
+        # look-up of current tip of `to_branch`
+        {"data": {"repository": {"object": {"oid": end_tag_target_ref}}}},
+        # existing version in `to_branch`
         get_files_payload({merge_info["fetch_version_from"]: "128.0"}),
         # branch ref for `end` tag
         {"data": {"repository": {"object": {"oid": end_tag_target_ref}}}},


### PR DESCRIPTION
This will allow us to make these tasks more idempotent, and avoid the issue described in https://bugzilla.mozilla.org/show_bug.cgi?id=2047586.

In the short term, we need to fall back to using branch refs. Once I update all of the callers/task creators, we can drop these fallbacks and make `to_revision` required (and `from_revision` when appropriate) to help keep things safer in the future.

Once this is in production I'll need to make some changes to `mozilla-taskgraph`, Gecko, and xpi-manifest to get everything using the new payload format, then I can follow-up here to make the new `revision` parameters required and ensure we always operate safely.