### PR TITLE
bug 2055645: support direct git tags in landoscript

### DIFF
--- a/landoscript/src/landoscript/script.py
+++ b/landoscript/src/landoscript/script.py
@@ -88,9 +88,11 @@ async def process_actions(session, context, owner, repo, public_artifact_dir, br
                 if version_bump_actions:
                     lando_actions.extend(version_bump_actions)
             elif action == "tag":
-                if "hg_repo_url" not in payload["tag_info"]:
-                    raise TaskVerificationError("must provide hg_repo_url!")
-                tag_actions = await tag.run(session, tag.HgTagInfo(**payload["tag_info"]))
+                if "hg_repo_url" in payload["tag_info"]:
+                    tag_info = tag.HgTagInfo(**payload["tag_info"])
+                else:
+                    tag_info = tag.GitTagInfo(**payload["tag_info"])
+                tag_actions = await tag.run(session, tag_info)
                 lando_actions.extend(tag_actions)
             elif action == "merge_day":
                 merge_day_actions = await merge_day.run(

--- a/landoscript/tests/test_tag.py
+++ b/landoscript/tests/test_tag.py
@@ -59,30 +59,47 @@ async def test_success(aioresponses, github_installation_responses, context, tag
 
 
 @pytest.mark.asyncio
-async def test_no_tags(aioresponses, github_installation_responses, context):
+@pytest.mark.parametrize(
+    "tag_info,dry_run",
+    (
+        pytest.param(
+            {
+                "revision": "ghijkl654321",
+                "tags": ["BUILD1"],
+            },
+            True,
+            id="dry_run",
+        ),
+        pytest.param(
+            {
+                "revision": "ghijkl654321",
+                "tags": ["BUILD1"],
+            },
+            False,
+            id="one_tag",
+        ),
+        pytest.param(
+            {
+                "revision": "ghijkl654321",
+                "tags": ["BUILD1", "RELEASE"],
+            },
+            False,
+            id="multiple_tags",
+        ),
+    ),
+)
+async def test_success_git(aioresponses, github_installation_responses, context, tag_info, dry_run):
     payload = {
         "actions": ["tag"],
         "lando_repo": "repo_name",
-        "tag_info": {
-            "revision": "abcdef123456",
-            "hg_repo_url": "https://hg.testing/repo",
-            "tags": [],
-        },
+        "tag_info": tag_info,
+        "dry_run": dry_run,
     }
-    await run_test(aioresponses, github_installation_responses, context, payload, ["tag"], err=TaskVerificationError, errmsg="must provide at least one tag!")
 
+    def assert_func(req):
+        assert_tag_response(req, tag_info, tag_info["revision"])
 
-@pytest.mark.asyncio
-async def test_hg_repo_url(aioresponses, github_installation_responses, context):
-    payload = {
-        "actions": ["tag"],
-        "lando_repo": "repo_name",
-        "tag_info": {
-            "revision": "abcdef123456",
-            "tags": ["FOO"],
-        },
-    }
-    await run_test(aioresponses, github_installation_responses, context, payload, ["tag"], err=TaskVerificationError, errmsg="must provide hg_repo_url!")
+    await run_test(aioresponses, github_installation_responses, context, payload, ["tag"], not dry_run, assert_func)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Landoscript supports requesting tags to be added to repositories. The [underlying tag action](https://github.com/mozilla-releng/scriptworker-scripts/blob/1cb7c72fcc9e5523c9c917fc8fa3a0ca620d4b2d/landoscript/src/landoscript/actions/tag.py) supports hg and git repositories, but git support is [only wired in when used by the merge day action](https://github.com/mozilla-releng/scriptworker-scripts/blob/1cb7c72fcc9e5523c9c917fc8fa3a0ca620d4b2d/landoscript/src/landoscript/actions/merge_day.py#L100)). The toplevel tag action support [hardcodes hg](https://github.com/mozilla-releng/scriptworker-scripts/blob/1cb7c72fcc9e5523c9c917fc8fa3a0ca620d4b2d/landoscript/src/landoscript/script.py#L93).

In the immediate term, this means we can't make early-tagging and version-bump tasks work on Try (because there's no hg-to-git mapping we can look up there). In the medium term, this will be needed when we start firing release promotion from git events, and won't have an hg revision to feed to these tasks.

I'm not _super_ happy with controlling hg vs. git based on the presence of hg_repo_url...but seeing as hg support as a finite lifespan, it's probably fine.