### PR TITLE
chore(iscript): Fix python dependency list

### DIFF
--- a/iscript/pyproject.toml
+++ b/iscript/pyproject.toml
@@ -13,16 +13,16 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "aiohttp",
-    "arrow>=1.0",
     "attrs",
-    "macholib",
     "mozbuild",
     "pexpect",
+    "requests",
     "requests-hawk",
     "scriptworker-client",
-    "taskcluster",
-    # for mozbuild - remove after the following bug is fixed: https://bugzilla.mozilla.org/show_bug.cgi?id=1831648
+    # mozbuild imports these but doesn't declare them; upstream removed its
+    # setup.py entirely (https://bugzilla.mozilla.org/show_bug.cgi?id=1831648)
+    # rather than fix the metadata, so these must stay declared here for as
+    # long as we vendor mozbuild.
     "packaging",
     "six",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1900,17 +1900,14 @@ name = "iscript"
 version = "1.0.1"
 source = { editable = "iscript" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "arrow" },
     { name = "attrs" },
-    { name = "macholib" },
     { name = "mozbuild" },
     { name = "packaging" },
     { name = "pexpect" },
+    { name = "requests" },
     { name = "requests-hawk" },
     { name = "scriptworker-client" },
     { name = "six" },
-    { name = "taskcluster" },
 ]
 
 [package.optional-dependencies]
@@ -1934,18 +1931,15 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp" },
-    { name = "arrow", specifier = ">=1.0" },
     { name = "attrs" },
-    { name = "macholib" },
     { name = "mozbuild", directory = "vendored/mozbuild" },
     { name = "packaging" },
     { name = "pexpect" },
+    { name = "requests" },
     { name = "requests-hawk" },
     { name = "scriptworker", marker = "extra == 'scriptworker'" },
     { name = "scriptworker-client", editable = "scriptworker_client" },
     { name = "six" },
-    { name = "taskcluster" },
 ]
 provides-extras = ["scriptworker"]
 


### PR DESCRIPTION
- Add requests (was being imported by another package, but used explicitly)
- Removes aiohttp, arrow, macholib, taskcluster (unused)