### PR TITLE
Revert "Bug 2058413 - update k8s scriptworkers to python 3.14"

### DIFF
--- a/addonscript/tox.ini
+++ b/addonscript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 depends = clean
@@ -19,7 +19,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [coverage:run]

--- a/balrogscript/tox.ini
+++ b/balrogscript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 depends = clean
@@ -19,7 +19,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [pytest]

--- a/beetmoverscript/tox.ini
+++ b/beetmoverscript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 depends = clean
@@ -19,7 +19,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [pytest]

--- a/bitrisescript/tox.ini
+++ b/bitrisescript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 depends = clean
@@ -19,7 +19,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [pytest]

--- a/bouncerscript/tox.ini
+++ b/bouncerscript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 depends = clean
@@ -19,7 +19,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [pytest]

--- a/configloader/tox.ini
+++ b/configloader/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 depends = clean
@@ -19,7 +19,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [coverage:run]

--- a/githubscript/tox.ini
+++ b/githubscript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 depends = clean
@@ -19,7 +19,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [pytest]

--- a/landoscript/tox.ini
+++ b/landoscript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 depends = clean
@@ -19,7 +19,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [coverage:run]

--- a/pushapkscript/tox.ini
+++ b/pushapkscript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 setenv =
@@ -18,7 +18,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [pytest]

--- a/pushflatpakscript/tox.ini
+++ b/pushflatpakscript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 depends = clean
@@ -20,7 +20,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [pytest]

--- a/pushmsixscript/tox.ini
+++ b/pushmsixscript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 setenv =
@@ -18,7 +18,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [pytest]

--- a/scriptworker_client/tox.ini
+++ b/scriptworker_client/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314,mypy
+envlist = py311,mypy
 
 [testenv]
 setenv =

--- a/shipitscript/tox.ini
+++ b/shipitscript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 setenv =
@@ -18,7 +18,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [pytest]

--- a/signingscript/tox.ini
+++ b/signingscript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 depends = clean
@@ -20,7 +20,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [pytest]

--- a/taskcluster/kinds/check/kind.yml
+++ b/taskcluster/kinds/check/kind.yml
@@ -19,7 +19,7 @@ task-defaults:
         code-review: true
     worker-type: b-linux
     worker:
-        docker-image: {in-tree: 'python314'}
+        docker-image: {in-tree: 'python311'}
         max-run-time: 1800
 
 tasks:

--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -32,7 +32,7 @@ tasks:
 
     base:
         args:
-            PYTHON_VERSION: *py314
+            PYTHON_VERSION: *py311
             UV_VERSION: *uv_version
     addonscript:
         definition: script
@@ -84,13 +84,35 @@ tasks:
         args:
             SCRIPT_NAME: pushmsixscript
     signingscript:
-        # python:3.14.3-slim-trixie docker image contains osslsigncode 2.9.
+        # python:3.11.15-trixie docker image contains osslsigncode 2.9.
         # if the image changes, verify version of osslsigncode and make sure winsign works as well
         parent: base
     treescript:
         parent: base
 
     # Testing images
+    pushapkscript-test-py311:
+        definition: base-test
+        args:
+            PYTHON_VERSION: *py311
+            UV_VERSION: *uv_version
+            APT_PACKAGES: default-jre-headless
+
+    pushflatpakscript-test-py311:
+        definition: base-test
+        args:
+            PYTHON_VERSION: *py311
+            UV_VERSION: *uv_version
+            # Copied from pushflatpakscript/docker.d/image_setup.sh
+            APT_PACKAGES: gir1.2-ostree-1.0 libgirepository-2.0-dev ostree
+
+    signingscript-test-py311:
+        definition: base-test
+        args:
+            PYTHON_VERSION: *py311
+            UV_VERSION: *uv_version
+            APT_PACKAGES: osslsigncode cmake make clang gpg gpgv
+
     pushapkscript-test-py314:
         definition: base-test
         args:

--- a/taskcluster/kinds/tox/kind.yml
+++ b/taskcluster/kinds/tox/kind.yml
@@ -43,7 +43,7 @@ task-defaults:
         - tox.ini
         - uv.lock
     matrix:
-        python: ["314"]
+        python: ["311", "314"]
 
 tasks:
     addonscript:
@@ -65,8 +65,6 @@ tasks:
     configloader:
         resources:
             - configloader
-        matrix:
-            python: ["311"]
     githubscript:
         resources:
             - githubscript
@@ -92,8 +90,6 @@ tasks:
             - iscript
             - scriptworker_client
             - vendored/mozbuild
-        matrix:
-            python: ["311"]
     landoscript:
         resources:
             - landoscript
@@ -114,8 +110,6 @@ tasks:
     scriptworker_client:
         resources:
             - scriptworker_client
-        matrix:
-            python: ["311"]
     shipitscript:
         resources:
             - shipitscript

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,53 @@
 [tox]
 envlist =
-    addonscript-py314
-    balrogscript-py314
-    beetmoverscript-py314
-    bitrisescript-py314
-    bouncerscript-py314
-    configloader-py314
+    addonscript-py311
+    balrogscript-py311
+    beetmoverscript-py311
+    bitrisescript-py311
+    bouncerscript-py311
+    configloader-py311
     iscript-py311
-    githubscript-py314
-    init-py314
-    landoscript-py314
-    pushapkscript-py314
-    pushflatpakscript-py314
-    pushmsixscript-py314
-    scriptworker_client-py314
-    shipitscript-py314
-    signingscript-py314
-    treescript-py314
+    githubscript-py311
+    init-py311
+    landoscript-py311
+    pushapkscript-py311
+    pushflatpakscript-py311
+    pushmsixscript-py311
+    scriptworker_client-py311
+    shipitscript-py311
+    signingscript-py311
+    treescript-py311
     ruff
 
 skipsdist = true
 
 [testenv]
 runner = uv-venv-lock-runner
+
+[testenv:addonscript-py311]
+changedir = {toxinidir}/addonscript
+commands =
+    tox -e py311
+
+[testenv:balrogscript-py311]
+changedir = {toxinidir}/balrogscript
+commands =
+    tox -e py311
+
+[testenv:beetmoverscript-py311]
+changedir = {toxinidir}/beetmoverscript
+commands =
+    tox -e py311
+
+[testenv:bitrisescript-py311]
+changedir = {toxinidir}/bitrisescript
+commands =
+    tox -e py311
+
+[testenv:bouncerscript-py311]
+changedir = {toxinidir}/bouncerscript
+commands =
+    tox -e py311
 
 [testenv:configloader-py311]
 changedir = {toxinidir}/configloader
@@ -38,10 +63,50 @@ changedir = {toxinidir}/iscript
 commands =
     tox -e py311
 
+[testenv:githubscript-py311]
+changedir = {toxinidir}/githubscript
+commands =
+    tox -e py311
+
+[testenv:landoscript-py311]
+changedir = {toxinidir}/landoscript
+commands =
+    tox -e py311
+
+[testenv:pushapkscript-py311]
+changedir = {toxinidir}/pushapkscript
+commands =
+    tox -e py311
+
+[testenv:pushflatpakscript-py311]
+changedir = {toxinidir}/pushflatpakscript
+commands =
+    tox -e py311
+
+[testenv:pushmsixscript-py311]
+changedir = {toxinidir}/pushmsixscript
+commands =
+    tox -e py311
+
 [testenv:scriptworker_client-py311]
 changedir = {toxinidir}/scriptworker_client
 commands =
     tox -e py311,mypy
+
+[testenv:shipitscript-py311]
+changedir = {toxinidir}/shipitscript
+commands =
+    tox -e py311
+
+[testenv:signingscript-py311]
+changedir = {toxinidir}/signingscript
+commands =
+    tox -e py311
+
+[testenv:treescript-py311]
+changedir = {toxinidir}/treescript
+commands =
+    tox -e py311
 
 [testenv:addonscript-py314]
 changedir = {toxinidir}/addonscript

--- a/treescript/tox.ini
+++ b/treescript/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py314
+envlist = py311
 
 [testenv]
 setenv =
@@ -19,7 +19,7 @@ depends =
 [testenv:report]
 skip_install = true
 commands = coverage report -m
-depends = py314
+depends = py311
 parallel_show_output = true
 
 [pytest]


### PR DESCRIPTION
Reverts mozilla-releng/scriptworker-scripts#1496


Upstream scriptworker needs a fix before they can run on 3.14

When released, all workers were failing with the error:
```
Traceback (most recent call last):
  File "/app/.venv/bin/scriptworker", line 10, in <module>
    sys.exit(main())
  File "/app/.venv/lib/python3.14/site-packages/scriptworker/worker.py", line 246, in main
    context.event_loop = event_loop or asyncio.get_event_loop()
  File "/usr/local/lib/python3.14/asyncio/events.py", line 715, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'MainThread'.
```