### PR TITLE
bug 2061475: switch adhoc to new gpg signing key; add rpm signing to adhoc-signing

### DIFF
--- a/signingscript/docker.d/init_worker.sh
+++ b/signingscript/docker.d/init_worker.sh
@@ -172,6 +172,8 @@ case $ENV in
         test_var_set 'AUTOGRAPH_MAR_USERNAME'
         test_var_set 'AUTOGRAPH_GPG_PASSWORD'
         test_var_set 'AUTOGRAPH_GPG_USERNAME'
+        test_var_set 'AUTOGRAPH_RPMSIGN_USERNAME'
+        test_var_set 'AUTOGRAPH_RPMSIGN_PASSWORD'
         test_var_set 'AUTOGRAPH_XPI_PASSWORD'
         test_var_set 'AUTOGRAPH_XPI_USERNAME'
         test_var_set 'AUTOGRAPH_FENIX_PASSWORD'
@@ -270,6 +272,8 @@ case $ENV in
         test_var_set 'AUTOGRAPH_MAR_RELEASE_USERNAME'
         test_var_set 'AUTOGRAPH_FENNEC_RELEASE_PASSWORD'
         test_var_set 'AUTOGRAPH_FENNEC_RELEASE_USERNAME'
+        test_var_set 'AUTOGRAPH_RPMSIGN_USERNAME'
+        test_var_set 'AUTOGRAPH_RPMSIGN_PASSWORD'
         ;;
     esac
     ;;

--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -358,6 +358,12 @@ in:
              ["gcp_prod_autograph_apk"],
              "fenix_dep_apk"
           ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_RPMSIGN_USERNAME"},
+             {"$eval": "AUTOGRAPH_RPMSIGN_PASSWORD"},
+             ["autograph_rpmsign"],
+             "release_at_mozilla_rpmsign_dep",
+          ]
 
       # passwords.json
       'ENV == "prod" && (COT_PRODUCT in ["firefox", "thunderbird", "enterprise"])':
@@ -610,7 +616,13 @@ in:
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["gcp_prod_autograph_gpg"],
-             "release_at_mozilla_rel_pgp_202503"
+             "release_at_mozilla_rel_pgp_202608"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_RPMSIGN_USERNAME"},
+             {"$eval": "AUTOGRAPH_RPMSIGN_PASSWORD"},
+             ["autograph_rpmsign"],
+             "release_at_mozilla_rel_rpmsign_202608"
           ]
           - ["https://prod.autograph.prod.webservices.mozgcp.net",
              {"$eval": "AUTOGRAPH_FENNEC_RELEASE_USERNAME"},
@@ -640,5 +652,11 @@ in:
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["gcp_prod_autograph_gpg"],
-             "release_at_mozilla_rel_pgp_202503"
+             "release_at_mozilla_rel_pgp_202608"
+          ]
+          - ["https://prod.autograph.prod.webservices.mozgcp.net",
+             {"$eval": "AUTOGRAPH_RPMSIGN_USERNAME"},
+             {"$eval": "AUTOGRAPH_RPMSIGN_PASSWORD"},
+             ["autograph_rpmsign"],
+             "release_at_mozilla_rel_rpmsign_202608"
           ]


### PR DESCRIPTION
I am _explicitly_ not adding a new format here, as we sometimes do in the past. Because we're planning to revoke the previous key it's better to stop signing with it ASAP.

Note that RPM signing on adhoc is new; I'll be adding secrets for these to sops.