### PR TITLE
chore: switch remaining trust domains to new GPG key

### DIFF
--- a/signingscript/docker.d/passwords.yml
+++ b/signingscript/docker.d/passwords.yml
@@ -389,7 +389,7 @@ in:
                {"$eval": "AUTOGRAPH_GPG_USERNAME"},
                {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
                ["gcp_prod_autograph_gpg"],
-               "release_at_mozilla_rel_pgp_202503"
+               "release_at_mozilla_rel_pgp_202608"
             ]
             - ["https://prod.autograph.prod.webservices.mozgcp.net",
                {"$eval": "AUTOGRAPH_WIDEVINE_USERNAME"},
@@ -413,7 +413,7 @@ in:
                {"$eval": "AUTOGRAPH_RPMSIGN_USERNAME"},
                {"$eval": "AUTOGRAPH_RPMSIGN_PASSWORD"},
                ["autograph_rpmsign"],
-               "release_at_mozilla_rel_rpmsign_202602",
+               "release_at_mozilla_rel_rpmsign_202608",
             ]
           firefox_and_thunderbird_prod_nightly_autograph:
             # GCP Autograph prod
@@ -436,7 +436,7 @@ in:
                {"$eval": "AUTOGRAPH_GPG_USERNAME"},
                {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
                ["gcp_prod_autograph_gpg"],
-               "release_at_mozilla_rel_pgp_202503"
+               "release_at_mozilla_rel_pgp_202608"
             ]
             - ["https://prod.autograph.prod.webservices.mozgcp.net",
                {"$eval": "AUTOGRAPH_WIDEVINE_USERNAME"},
@@ -460,7 +460,7 @@ in:
                {"$eval": "AUTOGRAPH_RPMSIGN_USERNAME"},
                {"$eval": "AUTOGRAPH_RPMSIGN_PASSWORD"},
                ["autograph_rpmsign"],
-               "release_at_mozilla_rel_rpmsign_202602",
+               "release_at_mozilla_rel_rpmsign_202608",
             ]
         in:
           '${scope_prefix[0]}cert:nightly-signing':
@@ -528,7 +528,7 @@ in:
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["gcp_prod_autograph_gpg"],
-             "release_at_mozilla_rel_pgp_202503"
+             "release_at_mozilla_rel_pgp_202608"
           ]
 
       'ENV == "prod" && COT_PRODUCT == "glean"':
@@ -538,7 +538,7 @@ in:
              {"$eval": "AUTOGRAPH_GPG_USERNAME"},
              {"$eval": "AUTOGRAPH_GPG_PASSWORD"},
              ["gcp_prod_autograph_gpg"],
-             "release_at_mozilla_rel_pgp_202503"
+             "release_at_mozilla_rel_pgp_202608"
           ]
 
       # passwords-xpi.json


### PR DESCRIPTION
Testing on adhoc went well; we're ready to switch the remaining trust domains to the new gpg subkey.

Related to https://bugzilla.mozilla.org/show_bug.cgi?id=2061475