### PR TITLE
Bug 2062342 - signingscript: expose RPM-KEY artifact

### DIFF
--- a/signingscript/src/signingscript/script.py
+++ b/signingscript/src/signingscript/script.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import logging
 import os
+import tempfile
 from dataclasses import asdict
 
 import aiohttp
@@ -15,6 +16,9 @@ from signingscript.task import apple_notarize_stacked, build_filelist_dict, sign
 from signingscript.utils import copy_to_dir, load_apple_notarization_configs, load_autograph_configs, load_json
 
 log = logging.getLogger(__name__)
+
+GPG_FORMATS = {"autograph_gpg", "gcp_prod_autograph_gpg", "stage_autograph_gpg"}
+RPM_FORMATS = {"autograph_rpmsign", "gcp_prod_autograph_rpmsign", "stage_autograph_rpmsign"}
 
 
 # async_main {{{1
@@ -28,13 +32,16 @@ async def async_main(context):
     work_dir = context.config["work_dir"]
     async with aiohttp.ClientSession() as session:
         all_signing_formats = task_signing_formats(context)
-        if {"autograph_gpg", "gcp_prod_autograph_gpg", "stage_autograph_gpg"}.intersection(all_signing_formats):
-            if not context.config.get("gpg_pubkey"):
-                raise Exception("GPG format is enabled but gpg_pubkey is not defined")
-            if not os.path.exists(context.config["gpg_pubkey"]):
-                raise Exception("gpg_pubkey ({}) doesn't exist!".format(context.config["gpg_pubkey"]))
+        if GPG_FORMATS.intersection(all_signing_formats):
+            check_gpg_pubkey(context, "GPG")
             await set_up_gpg_keyring(context)
             copy_to_dir(context.config["gpg_pubkey"], context.config["artifact_dir"], target="public/build/KEY")
+
+        if RPM_FORMATS.intersection(all_signing_formats):
+            check_gpg_pubkey(context, "RPM")
+            rpm_pubkey = os.path.join(work_dir, "RPM-KEY")
+            await export_pubkey_without_revoked_subkeys(context, rpm_pubkey)
+            copy_to_dir(rpm_pubkey, context.config["artifact_dir"], target="public/build/RPM-KEY")
 
         if {"autograph_widevine", "gcp_prod_autograph_widevine", "stage_autograph_widevine"}.intersection(all_signing_formats):
             if not context.config.get("widevine_cert"):
@@ -81,6 +88,51 @@ async def async_main(context):
                 copy_to_dir(os.path.join(work_dir, source), context.config["artifact_dir"], target=source)
 
     log.info("Done!")
+
+
+def check_gpg_pubkey(context, format_name):
+    """Make sure the configured gpg pubkey exists.
+
+    Args:
+        context (Context): the signing context.
+        format_name (str): the name of the signing format needing the pubkey,
+            used in the error messages.
+
+    """
+    if not context.config.get("gpg_pubkey"):
+        raise Exception("{} format is enabled but gpg_pubkey is not defined".format(format_name))
+    if not os.path.exists(context.config["gpg_pubkey"]):
+        raise Exception("gpg_pubkey ({}) doesn't exist!".format(context.config["gpg_pubkey"]))
+
+
+async def _run_gpg(gnupghome, args, stdout=None):
+    """Run gpg in `gnupghome`, raising SigningScriptError on failure."""
+    command = ["gpg", "--homedir", gnupghome, "--batch", "--no-tty", "--no-autostart", "--quiet"] + args
+    p = await asyncio.create_subprocess_exec(*command, stdout=stdout)
+    try:
+        ret = await asyncio.wait_for(p.wait(), timeout=30)
+    except TimeoutError:
+        p.kill()
+        ret = await p.wait()
+    if ret != 0:
+        raise SigningScriptError("gpg failed ({}): {}".format(ret, " ".join(command)))
+
+
+async def export_pubkey_without_revoked_subkeys(context, dest):
+    """Write an armored copy of the gpg pubkey with revoked subkeys stripped out.
+
+    rpm chokes on keys containing revoked subkeys, so the key we publish
+    alongside signed rpms must not have any.
+
+    Args:
+        context (Context): the signing context.
+        dest (str): the path to write the filtered pubkey to.
+
+    """
+    with tempfile.TemporaryDirectory(dir=context.config["work_dir"]) as gnupghome:
+        await _run_gpg(gnupghome, ["--import", context.config["gpg_pubkey"]])
+        with open(dest, "wb") as pubkey:
+            await _run_gpg(gnupghome, ["--armor", "--export-filter", "drop-subkey=revoked -t", "--export"], stdout=pubkey)
 
 
 async def set_up_gpg_keyring(context):

--- a/signingscript/tests/test_script.py
+++ b/signingscript/tests/test_script.py
@@ -1,5 +1,6 @@
 import builtins
 import os
+import subprocess
 from unittest.mock import MagicMock, mock_open
 
 import mock
@@ -83,6 +84,79 @@ async def test_async_main_gpg_pubkey_doesnt_exist(tmpdir, mocker):
         await async_main_helper(tmpdir, mocker, formats, {"gpg_pubkey": "faaaaaaake"})
     except Exception as e:
         assert e.args[0] == "gpg_pubkey (faaaaaaake) doesn't exist!"
+
+
+@pytest.mark.asyncio
+async def test_async_main_rpm(tmpdir, tmpfile, mocker):
+    formats = ["autograph_rpmsign"]
+    mocked_copy_to_dir = mocker.Mock()
+    mocker.patch.object(script, "copy_to_dir", new=mocked_copy_to_dir)
+    mocker.patch.object(script, "export_pubkey_without_revoked_subkeys")
+
+    await async_main_helper(tmpdir, mocker, formats, {"gpg_pubkey": tmpfile})
+    for call in mocked_copy_to_dir.call_args_list:
+        if call[1].get("target") == "public/build/RPM-KEY":
+            break
+    else:
+        assert False, "couldn't find copy_to_dir call that created RPM-KEY"
+
+    script.export_pubkey_without_revoked_subkeys.assert_called_once_with(mock.ANY, os.path.join(tmpdir, "RPM-KEY"))
+
+
+@pytest.mark.asyncio
+async def test_async_main_rpm_no_pubkey_defined(tmpdir, mocker):
+    formats = ["autograph_rpmsign"]
+
+    with pytest.raises(Exception) as exc:
+        await async_main_helper(tmpdir, mocker, formats)
+    assert exc.value.args[0] == "RPM format is enabled but gpg_pubkey is not defined"
+
+
+@pytest.mark.asyncio
+async def test_async_main_rpm_pubkey_doesnt_exist(tmpdir, mocker):
+    formats = ["autograph_rpmsign"]
+
+    with pytest.raises(Exception) as exc:
+        await async_main_helper(tmpdir, mocker, formats, {"gpg_pubkey": "faaaaaaake"})
+    assert exc.value.args[0] == "gpg_pubkey (faaaaaaake) doesn't exist!"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pubkey", ("gpg_pubkey_dep.asc", "gpg_pubkey_prod.asc"))
+async def test_export_pubkey_without_revoked_subkeys(tmpdir, mocker, pubkey):
+    context = mock.MagicMock()
+    context.config = {"work_dir": str(tmpdir), "gpg_pubkey": os.path.join(BASE_DIR, "src/signingscript/data", pubkey)}
+    dest = os.path.join(str(tmpdir), "RPM-KEY")
+
+    await script.export_pubkey_without_revoked_subkeys(context, dest)
+
+    exported = _key_validities(dest, str(tmpdir))
+    original = _key_validities(context.config["gpg_pubkey"], str(tmpdir))
+    assert exported == [validity for validity in original if validity != ("sub", "r")]
+    # the primary key and at least one usable subkey survived the filtering
+    assert ("pub", "-") in exported
+    assert ("sub", "-") in exported
+
+
+def _key_validities(path, homedir):
+    """List the (record type, validity) of each key/subkey in an exported pubkey."""
+    output = subprocess.run(
+        ["gpg", "--homedir", homedir, "--batch", "--no-tty", "--no-autostart", "--with-colons", "--show-keys", path],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    records = (line.split(":") for line in output.splitlines())
+    return [(record[0], record[1]) for record in records if record[0] in ("pub", "sub")]
+
+
+@pytest.mark.asyncio
+async def test_export_pubkey_without_revoked_subkeys_failure(tmpdir, mocker):
+    context = mock.MagicMock()
+    context.config = {"work_dir": str(tmpdir), "gpg_pubkey": os.path.join(BASE_DIR, "tests", "data", "SHA256SUMS")}
+
+    with pytest.raises(SigningScriptError):
+        await script.export_pubkey_without_revoked_subkeys(context, os.path.join(str(tmpdir), "RPM-KEY"))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
RPM package managers don't all deal well with revoked subkeys, so filter them out of the public key artifact.

Per @eijebong:

> Old version of dnf won't even import a key that contains a hard
> revoked key (expired keys are fine). We'll have to publish the key
> with the compromised one omitted from it instead. On top of that old
> versions of dnf don't cleanly reimport keys when the main one is the
> same. They say they do, return 0, and then don't do it... dnf5 which
> is what recent-ish fedora runs self-heals but that's a fraction of
> users.