### PR TITLE
fix(ci): hash tests/ directory into the init task's cache digest

### DIFF
--- a/taskcluster/kinds/tox/kind.yml
+++ b/taskcluster/kinds/tox/kind.yml
@@ -74,6 +74,7 @@ tasks:
             - scriptworker_client
     init:
         resources:
+            - tests
             - docker.d
             - addonscript/docker.d
             - balrogscript/docker.d


### PR DESCRIPTION
Every task in the tox kind is a cached task. `transforms/cached.py` hashes the contents of each path listed under the task's `resources` key and passes the resulting digests to taskgraph's `cached_tasks` transform, which attaches an index-search optimization. If a previous run's digest matches, the new task is dropped from the graph and that run's result is reused.

The init task's effective list is the three entries it inherits from task-defaults (pyproject.toml, tox.ini, uv.lock) plus the fourteen `docker.d` directories it declares - taskgraph concatenates the inherited list rather than replacing it. What the task actually runs is `pytest -n auto tests`, and `tests` was in neither list: of the 41 files feeding the digest, not one was under tests/.

The consequence is that a commit touching only tests/test_init.py hashes identically to its parent, so the task is optimized away and CI reports green without ever running the test that changed. Confirmed by editing tests/test_init.py and recomputing the digest in a fresh interpreter, since hash_path is memoized within a process:

    resources without `tests`:  digest unchanged -> cached task reused
    resources with    `tests`:  digest changes   -> task reruns

That gap matters because test_init.py is the only executable coverage of every init_worker.sh in the repo. It renders each one and asserts its exit code, which is how an unset `test_var_set` variable gets caught, so a fix to it silently not running is the case most likely to be missed.
